### PR TITLE
Graph node transforms

### DIFF
--- a/ocpmodels/datasets/tests/test_transforms.py
+++ b/ocpmodels/datasets/tests/test_transforms.py
@@ -48,3 +48,14 @@ def test_remove_tag_zero():
     graph = next(iter(loader))["graph"]
     # make sure we've purged all of the tag zero nodes
     assert not torch.any(graph.ndata["tags"] == 0)
+
+
+@pytest.mark.dependency(["test_remove_tag_zero"])
+def test_graph_supernode():
+    trans = [transforms.GraphSupernode(100), transforms.RemoveTagZeroNodes()]
+    dm = S2EFDGLDataModule.from_devset(transforms=trans)
+    dm.setup()
+    loader = dm.train_dataloader()
+    graph = next(iter(loader))["graph"]
+    # should be one super node per graph
+    assert (graph.ndata["tags"] == 3).sum() == graph.batch_size

--- a/ocpmodels/datasets/tests/test_transforms.py
+++ b/ocpmodels/datasets/tests/test_transforms.py
@@ -98,3 +98,14 @@ def test_all_supernodes():
     # make sure the graph super node has an embedding index of 100
     mask = graph.ndata["tags"] == 3
     assert (graph.ndata["atomic_numbers"][mask] - 100).sum() == 0
+
+
+def test_graph_sorting():
+    trans = [
+        transforms.GraphReordering("metis", k=10),
+    ]
+    dm = S2EFDGLDataModule.from_devset(transforms=trans)
+    dm.setup()
+    loader = dm.train_dataloader()
+    graph = next(iter(loader))["graph"]
+    # not really anything to test, but just make sure it runs :D

--- a/ocpmodels/datasets/tests/test_transforms.py
+++ b/ocpmodels/datasets/tests/test_transforms.py
@@ -52,7 +52,7 @@ def test_remove_tag_zero():
 
 @pytest.mark.dependency(["test_remove_tag_zero"])
 def test_graph_supernode():
-    trans = [transforms.GraphSupernode(100), transforms.RemoveTagZeroNodes()]
+    trans = [transforms.GraphSuperNodes(100), transforms.RemoveTagZeroNodes()]
     dm = S2EFDGLDataModule.from_devset(transforms=trans)
     dm.setup()
     loader = dm.train_dataloader()

--- a/ocpmodels/datasets/tests/test_transforms.py
+++ b/ocpmodels/datasets/tests/test_transforms.py
@@ -35,3 +35,16 @@ def test_batched_gv_transform():
     assert gv.ndim == 2
     assert gv.shape == (8, 9)
     assert torch.all(~torch.isnan(gv))
+
+
+@pytest.mark.dependency()
+def test_remove_tag_zero():
+    trans = [
+        transforms.RemoveTagZeroNodes(),
+    ]
+    dm = S2EFDGLDataModule.from_devset(transforms=trans)
+    dm.setup()
+    loader = dm.train_dataloader()
+    graph = next(iter(loader))["graph"]
+    # make sure we've purged all of the tag zero nodes
+    assert not torch.any(graph.ndata["tags"] == 0)

--- a/ocpmodels/datasets/tests/test_transforms.py
+++ b/ocpmodels/datasets/tests/test_transforms.py
@@ -59,3 +59,19 @@ def test_graph_supernode():
     graph = next(iter(loader))["graph"]
     # should be one super node per graph
     assert (graph.ndata["tags"] == 3).sum() == graph.batch_size
+
+
+@pytest.mark.dependency(["test_remove_tag_zero"])
+def test_atom_supernode():
+    trans = [
+        transforms.AtomicSuperNodes(100),
+        transforms.RemoveTagZeroNodes(),
+    ]
+    dm = S2EFDGLDataModule.from_devset(transforms=trans)
+    dm.setup()
+    loader = dm.train_dataloader()
+    graph = next(iter(loader))["graph"]
+    # make sure node numbers don't exceed the expected limit
+    assert torch.all(graph.ndata["atomic_numbers"] <= 199)
+    # make sure we have atomic super nodes after the transform
+    assert torch.any(graph.ndata["tags"] == 4)

--- a/ocpmodels/datasets/transforms.py
+++ b/ocpmodels/datasets/transforms.py
@@ -186,7 +186,7 @@ class GraphSuperNodes(AbstractGraphTransform):
     def supernode_index(self) -> int:
         # mostly for the sake of abstraction; this just makes it easier to
         # understand the embedding lookup index for the graph supernode
-        return self.atom_max_embed_index + 1
+        return self.atom_max_embed_index
 
     def __call__(
         self, data: Dict[str, Union[torch.Tensor, dgl.DGLGraph]]

--- a/ocpmodels/datasets/transforms.py
+++ b/ocpmodels/datasets/transforms.py
@@ -170,7 +170,7 @@ class RemoveTagZeroNodes(AbstractGraphTransform):
         return data
 
 
-class GraphSupernode(AbstractGraphTransform):
+class GraphSuperNodes(AbstractGraphTransform):
     """
     Generates a super node based on tag zero nodes.
 

--- a/ocpmodels/datasets/transforms.py
+++ b/ocpmodels/datasets/transforms.py
@@ -161,7 +161,7 @@ class RemoveTagZeroNodes(AbstractGraphTransform):
         self, data: Dict[str, Union[torch.Tensor, dgl.DGLGraph]]
     ) -> Dict[str, Union[torch.Tensor, dgl.DGLGraph]]:
         graph = data.get("graph")
-        tag_zero_mask = graph.ndata["tag"] != 0
+        tag_zero_mask = graph.ndata["tags"] != 0
         select_node_indices = graph.nodes()[tag_zero_mask]
         # induce subgraph based on atom tags
         subgraph = dgl.node_subgraph(graph, select_node_indices)
@@ -194,11 +194,11 @@ class GraphSupernode(AbstractGraphTransform):
         graph = data.get("graph")
         # check to make sure the nodes
         assert (
-            len(graph.ndata["tag"] == 0) > 0
+            len(graph.ndata["tags"] == 0) > 0
         ), "No nodes with tag == 0 in `graph`! Please apply this transform before removing tag zero nodes."
-        tag_zero_indices = graph.nodes()[graph.ndata["tag"] == 0]
+        tag_zero_indices = graph.nodes()[graph.ndata["tags"] == 0]
         supernode_data = {
-            "tag": torch.as_tensor([3], dtype=graph.ndata["tag"].dtype),
+            "tags": torch.as_tensor([3], dtype=graph.ndata["tags"].dtype),
             "atomic_numbers": torch.as_tensor(
                 [self.supernode_index], dtype=graph.ndata["atomic_numbers"].dtype
             ),

--- a/ocpmodels/datasets/transforms.py
+++ b/ocpmodels/datasets/transforms.py
@@ -143,8 +143,19 @@ class RemoveTagZeroNodes(AbstractGraphTransform):
     Create a subgraph representation where atoms tagged with
     zero are absent.
 
-    TODO make sure the properties of the graph are updated.
+    The `overwrite` kwarg, which is by default `True`, will overwrite
+    the `graph` key in a batch to avoid duplication of data. If set
+    to `False`, the new subgraph can be referenced with the `subgraph`
+    key.
+
+    TODO make sure the properties of the graph are updated, but a glance
+    at the original implementation the `dgl.node_subgraph` should take
+    care of everything.
     """
+
+    def __init__(self, overwrite: bool = True) -> None:
+        super().__init__()
+        self.overwrite = overwrite
 
     def __call__(
         self, data: Dict[str, Union[torch.Tensor, dgl.DGLGraph]]
@@ -154,5 +165,6 @@ class RemoveTagZeroNodes(AbstractGraphTransform):
         select_node_indices = graph.nodes()[tag_zero_mask]
         # induce subgraph based on atom tags
         subgraph = dgl.node_subgraph(graph, select_node_indices)
-        data["subgraph"] = subgraph
+        target_key = "graph" if self.overwrite else "subgraph"
+        data[target_key] = subgraph
         return data

--- a/ocpmodels/datasets/transforms.py
+++ b/ocpmodels/datasets/transforms.py
@@ -136,3 +136,23 @@ class GraphVariablesTransform(AbstractGraphTransform):
         avg_dist, std_dist = graph.edata["r"].mean(), graph.edata["r"].std()
         avg_mu, std_mu = graph.edata["mu"].mean(), graph.edata["mu"].std()
         return [avg_dist, std_dist, avg_mu, std_mu, sub_distance]
+
+
+class RemoveTagZeroNodes(AbstractGraphTransform):
+    """
+    Create a subgraph representation where atoms tagged with
+    zero are absent.
+
+    TODO make sure the properties of the graph are updated.
+    """
+
+    def __call__(
+        self, data: Dict[str, Union[torch.Tensor, dgl.DGLGraph]]
+    ) -> Dict[str, Union[torch.Tensor, dgl.DGLGraph]]:
+        graph = data.get("graph")
+        tag_zero_mask = graph.ndata["tag"] != 0
+        select_node_indices = graph.nodes()[tag_zero_mask]
+        # induce subgraph based on atom tags
+        subgraph = dgl.node_subgraph(graph, select_node_indices)
+        data["subgraph"] = subgraph
+        return data


### PR DESCRIPTION
This PR implements new features along the transform pipeline, with three of the four inspired by the PhAST transforms out of the [Rolnick group](https://github.com/RolnickLab/ocp/tree/main/ocpmodels/preprocessing).

Documentation is also included for how to use these transforms, but likely a follow up example script would be good.