### PR TITLE
EGNN embedding table

### DIFF
--- a/ocpmodels/models/dgl/egnn/egnn.py
+++ b/ocpmodels/models/dgl/egnn/egnn.py
@@ -43,6 +43,7 @@ class PLEGNNBackbone(AbstractEnergyModel):
         prediction_hidden_dim: int,
         prediction_out_dim: int,
         prediction_activation: str,
+        num_atoms_embedding: int = 100,
     ) -> None:
         super().__init__()
         self.embed = EGNN(
@@ -62,6 +63,7 @@ class PLEGNNBackbone(AbstractEnergyModel):
             k_linears=embed_k_linears,
             use_attention=embed_use_attention,
             attention_norm=self._get_attention_norm(embed_attention_norm),
+            num_atoms_embedding=num_atoms_embedding,
         )
 
         node_projection_dims = self._get_node_projection_dims(
@@ -151,7 +153,7 @@ class PLEGNNBackbone(AbstractEnergyModel):
         return prediction_dims
 
     def forward(self, graph: dgl.DGLGraph) -> torch.Tensor:
-        inputs = graph.ndata["atomic_numbers"].unsqueeze(-1)
+        inputs = graph.ndata["atomic_numbers"].long()
         pos = graph.ndata["pos"]
 
         x, _ = self.embed(graph, inputs, pos)

--- a/ocpmodels/models/dgl/egnn/egnn.py
+++ b/ocpmodels/models/dgl/egnn/egnn.py
@@ -153,6 +153,8 @@ class PLEGNNBackbone(AbstractEnergyModel):
         return prediction_dims
 
     def forward(self, graph: dgl.DGLGraph) -> torch.Tensor:
+        # cast atomic numbers to make sure they're floats, then pass
+        # them into the embedding lookup
         inputs = graph.ndata["atomic_numbers"].long()
         pos = graph.ndata["pos"]
 

--- a/ocpmodels/models/dgl/egnn/egnn_model/nets.py
+++ b/ocpmodels/models/dgl/egnn/egnn_model/nets.py
@@ -28,20 +28,22 @@ class MLP(nn.Module):
             self.linear = nn.Linear
         else:
             self.linear = KLinears
-            self._linear_kwargs['k'] = k_linears
+            self._linear_kwargs["k"] = k_linears
 
         self.layers = nn.ModuleList()
 
         for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
             if i < self._depth - 1:
-                self.layers.append(self.linear(in_dim, out_dim, bias=True,
-                                               **self._linear_kwargs))
+                self.layers.append(
+                    self.linear(in_dim, out_dim, bias=True, **self._linear_kwargs)
+                )
 
                 if activation is not None:
                     self.layers.append(activation)
             else:
-                self.layers.append(self.linear(in_dim, out_dim, bias=bias_last,
-                                               **self._linear_kwargs))
+                self.layers.append(
+                    self.linear(in_dim, out_dim, bias=bias_last, **self._linear_kwargs)
+                )
 
                 if activation is not None and activate_last:
                     self.layers.append(activation)
@@ -51,7 +53,7 @@ class MLP(nn.Module):
 
         for layer in self.layers:
             if isinstance(layer, (nn.Linear, KLinears)):
-                dims.append(f'{layer.in_features} \u2192 {layer.out_features}')
+                dims.append(f"{layer.in_features} \u2192 {layer.out_features}")
             else:
                 dims.append(layer.__class__.__name__)
 
@@ -177,15 +179,17 @@ class EGNN(nn.Module):
                     attention_norm,
                 )
 
-            self.layers.append(EquiCoordGraphConv(
-                edge_func,
-                position_func,
-                feat_func,
-                attention_func if use_attention else None,
-                residual=residual,
-                normalize=normalize,
-                tanh=tanh,
-            ))
+            self.layers.append(
+                EquiCoordGraphConv(
+                    edge_func,
+                    position_func,
+                    feat_func,
+                    attention_func if use_attention else None,
+                    residual=residual,
+                    normalize=normalize,
+                    tanh=tanh,
+                )
+            )
 
             if i < depth - 1 or activate_last:
                 self.layers.append(activation)

--- a/ocpmodels/models/dgl/egnn/egnn_model/nets.py
+++ b/ocpmodels/models/dgl/egnn/egnn_model/nets.py
@@ -110,6 +110,7 @@ class EGNN(nn.Module):
         use_attention: bool = False,
         attention_dims: List[int] = None,
         attention_norm: Callable[[torch.Tensor], torch.Tensor] = None,
+        num_atoms_embedding: int = 100,
     ) -> nn.Module:
         super().__init__()
         self._k_linears = k_linears
@@ -122,7 +123,9 @@ class EGNN(nn.Module):
         hidden_sizes = [hidden_dim for _ in range(depth)]
         hidden_sizes.append(out_dim)
 
-        self.in_embed = MLP([in_dim, hidden_dim], k_linears=k_linears)
+        # use an atomic number lookup to grab from the table of embeddings
+        self.atom_embedding = nn.Embedding(num_atoms_embedding, hidden_dim)
+        self.in_embed = MLP([hidden_dim, hidden_dim], k_linears=k_linears)
         self.layers = nn.ModuleList()
 
         for i, (in_dim_, out_dim_) in enumerate(zip(hidden_sizes, hidden_sizes[:-1])):
@@ -142,12 +145,19 @@ class EGNN(nn.Module):
 
                 attention_sizes.append(1)
 
-            edge_func = MLP(edge_sizes, activation=activation,
-                            activate_last=True, k_linears=k_linears)
-            position_func = MLP(position_sizes, activation=activation,
-                                bias_last=False, k_linears=k_linears)
-            feat_func = MLP(feat_sizes, activation=activation,
-                            k_linears=k_linears)
+            edge_func = MLP(
+                edge_sizes,
+                activation=activation,
+                activate_last=True,
+                k_linears=k_linears,
+            )
+            position_func = MLP(
+                position_sizes,
+                activation=activation,
+                bias_last=False,
+                k_linears=k_linears,
+            )
+            feat_func = MLP(feat_sizes, activation=activation, k_linears=k_linears)
 
             if use_attention:
                 if isinstance(attention_norm, nn.Softmax):
@@ -199,9 +209,10 @@ class EGNN(nn.Module):
 
             if edge_attrs is not None:
                 edge_attrs = torch.stack(
-                    [edge_attrs for _ in range(self._k_linears)], dim=1)
-
-        feats = self.in_embed(node_feats)
+                    [edge_attrs for _ in range(self._k_linears)], dim=1
+                )
+        embeddings = self.atom_embedding(node_feats)
+        feats = self.in_embed(embeddings)
 
         for layer in self.layers:
             if isinstance(layer, EquiCoordGraphConv):


### PR DESCRIPTION
This partially addresses #4, where the EGNN embedding layer is now replaced with an `Embedding` table as opposed to straight MLP.