### PR TITLE
MEGNet embedding table

### DIFF
--- a/ocpmodels/models/dgl/__init__.py
+++ b/ocpmodels/models/dgl/__init__.py
@@ -14,3 +14,4 @@ if _has_dgl:
     from ocpmodels.models.dgl.egnn import PLEGNNBackbone
     from ocpmodels.models.dgl.gaanet import GalaPotential
     from ocpmodels.models.dgl.gcn import GraphConvModel
+    from ocpmodels.models.dgl.megnet import MEGNet

--- a/ocpmodels/models/dgl/megnet/__init__.py
+++ b/ocpmodels/models/dgl/megnet/__init__.py
@@ -1,0 +1,2 @@
+from ocpmodels.models.dgl.megnet.helper import MLP, EdgeSet2Set
+from ocpmodels.models.dgl.megnet.layers import MEGNetBlock

--- a/ocpmodels/models/dgl/megnet/__init__.py
+++ b/ocpmodels/models/dgl/megnet/__init__.py
@@ -1,2 +1,3 @@
 from ocpmodels.models.dgl.megnet.helper import MLP, EdgeSet2Set
 from ocpmodels.models.dgl.megnet.layers import MEGNetBlock
+from ocpmodels.models.dgl.megnet.megnet import MEGNet

--- a/ocpmodels/models/dgl/megnet/helper.py
+++ b/ocpmodels/models/dgl/megnet/helper.py
@@ -1,0 +1,177 @@
+"""
+Implementations of multi-layer perceptron (MLP) and other helper classes.
+
+Code attributions to https://github.com/materialsvirtuallab/m3gnet-dgl/tree/main/megnet,
+along with contributions and modifications from Marcel Nassar, Santiago Miret, and Kelvin Lee
+"""
+
+from typing import Callable, Optional
+
+import torch
+from dgl import broadcast_edges, softmax_edges, sum_edges, DGLGraph
+from torch.nn import LSTM, Linear, Module, ModuleList
+
+
+class MLP(Module):
+    """
+    An implementation of a multi-layer perception.
+    """
+
+    def __init__(
+        self,
+        dims: list[int],
+        activation: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+        activate_last: bool = False,
+        bias_last: bool = True,
+    ) -> None:
+        """
+        Bog standard MLP stack with activations in between.
+
+        Parameters
+        ----------
+        dims : list[int]
+            Dimensionality of each MLP layer
+        activation : Optional[Callable[[torch.Tensor], torch.Tensor]], optional
+            Activation functions to apply to each layer, by default None
+        activate_last : bool, optional
+            Whether to apply activations to the output layer, by default False
+        bias_last : bool, optional
+            Whether to include a bias term in the last layer, by default True
+        """
+        super().__init__()
+        self._depth = len(dims) - 1
+        self.layers = ModuleList()
+
+        for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
+            if i < self._depth - 1:
+                self.layers.append(Linear(in_dim, out_dim, bias=True))
+
+                if activation is not None:
+                    self.layers.append(activation)
+            else:
+                self.layers.append(Linear(in_dim, out_dim, bias=bias_last))
+
+                if activation is not None and activate_last:
+                    self.layers.append(activation)
+
+    def __repr__(self):
+        dims = []
+
+        for layer in self.layers:
+            if isinstance(layer, Linear):
+                dims.append(f"{layer.in_features} \u2192 {layer.out_features}")
+            else:
+                dims.append(layer.__class__.__name__)
+
+        return f'MLP({", ".join(dims)})'
+
+    @property
+    def last_linear(self) -> Linear:
+        """
+        :return: The last linear layer.
+        """
+        for layer in reversed(self.layers):
+            if isinstance(layer, Linear):
+                return layer
+
+    @property
+    def depth(self) -> int:
+        """Returns depth of MLP."""
+        return self._depth
+
+    @property
+    def in_features(self) -> int:
+        """Return input features of MLP"""
+        return self.layers[0].in_features
+
+    @property
+    def out_features(self) -> int:
+        """Returns output features of MLP."""
+        for layer in reversed(self.layers):
+            if isinstance(layer, Linear):
+                return layer.out_features
+        raise RuntimeError
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        """
+        Applies all layers in turn.
+        :param inputs: Input tensor
+        :return: Output tensor
+        """
+        x = inputs
+
+        for layer in self.layers:
+            x = layer(x)
+
+        return x
+
+
+class EdgeSet2Set(Module):
+    """
+    Implementation of Set2Set.
+    """
+
+    def __init__(self, input_dim: int, n_iters: int, n_layers: int):
+        """
+        :param input_dim: The size of each input sample.
+        :param n_iters: The number of iterations.
+        :param n_layers: The number of recurrent layers.
+
+        Parameters
+        ----------
+        input_dim : int
+            The size of each input sample
+        n_iters : int
+            Number of iterations to operate on the Set2Set
+        n_layers : int
+            Number of recurrent (LSTM) layers
+        """
+        super().__init__()
+        self.input_dim = input_dim
+        self.output_dim = 2 * input_dim
+        self.n_iters = n_iters
+        self.n_layers = n_layers
+        self.lstm = LSTM(self.output_dim, self.input_dim, n_layers)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Reinitialize learnable parameters."""
+        self.lstm.reset_parameters()
+
+    def forward(self, graph: DGLGraph, feat: torch.Tensor) -> torch.Tensor:
+        """
+        Performs a forward pass of the edge Set2Set.
+
+        Parameters
+        ----------
+        graph : DGLGraph
+            Input DGL graph structure
+        feat : torch.Tensor
+            Edge features to operate on
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed features
+        """
+        with graph.local_scope():
+            batch_size = graph.batch_size
+
+            h = (
+                feat.new_zeros((self.n_layers, batch_size, self.input_dim)),
+                feat.new_zeros((self.n_layers, batch_size, self.input_dim)),
+            )
+
+            q_star = feat.new_zeros(batch_size, self.output_dim)
+
+            for _ in range(self.n_iters):
+                q, h = self.lstm(q_star.unsqueeze(0), h)
+                q = q.view(batch_size, self.input_dim)
+                e = (feat * broadcast_edges(graph, q)).sum(dim=-1, keepdim=True)
+                graph.edata["e"] = e
+                alpha = softmax_edges(graph, "e")
+                graph.edata["r"] = feat * alpha
+                readout = sum_edges(graph, "r")
+                q_star = torch.cat([q, readout], dim=-1)
+
+            return q_star

--- a/ocpmodels/models/dgl/megnet/layers.py
+++ b/ocpmodels/models/dgl/megnet/layers.py
@@ -1,0 +1,287 @@
+"""
+Implement graph convolution layers for MEGNet.
+
+Code attributions to https://github.com/materialsvirtuallab/m3gnet-dgl/tree/main/megnet,
+along with contributions and modifications from Marcel Nassar, Santiago Miret, and Kelvin Lee
+"""
+
+from typing import Dict, Optional
+
+import dgl
+import dgl.function as fn
+import torch
+from torch import nn
+from torch.nn import Dropout, Identity, Module, Softplus
+
+from ocpmodels.models.dgl.megnet import MLP
+
+
+class MEGNetGraphConv(Module):
+    """
+    A MEGNet graph convolution layer in DGL.
+    """
+
+    def __init__(
+        self,
+        edge_func: nn.Module,
+        node_func: nn.Module,
+        attr_func: nn.Module,
+    ) -> None:
+        """
+        Initialization method for the MEGNet graph convolution layer.
+
+        Parameters
+        ----------
+        edge_func : nn.Module
+            `nn.Module` function that operates on edge features.
+        node_func : nn.Module
+            `nn.Module` function that operates on node features.
+        attr_func : nn.Module
+            `nn.Module` function that operates on graph features.
+        """
+        super().__init__()
+        self.edge_func = edge_func
+        self.node_func = node_func
+        self.attr_func = attr_func
+
+    @staticmethod
+    def from_dims(edge_dims: list[int], node_dims: list[int], attr_dims: list[int]):
+        """
+        TODO: Add docs.
+        :param edge_dims:
+        :param node_dims:
+        :param attr_dims:
+        :return:
+        """
+        # TODO(marcel): Softplus doesnt exactly match paper's SoftPlus2
+        # TODO(marcel): Should we activate last?
+        edge_update = MLP(edge_dims, Softplus(), activate_last=True)
+        node_update = MLP(node_dims, Softplus(), activate_last=True)
+        attr_update = MLP(attr_dims, Softplus(), activate_last=True)
+        return MEGNetGraphConv(edge_update, node_update, attr_update)
+
+    def _edge_udf(self, edges: dgl.udf.EdgeBatch) -> Dict[str, torch.Tensor]:
+        """
+        Edge-based user defined function; will apply `edge_func` to edge features.
+
+        Parameters
+        ----------
+        edges : dgl.udf.EdgeBatch
+            Edge abstraction from DGL
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            Dictionary containing the transformed edge features
+        """
+        vi = edges.src["v"]
+        vj = edges.dst["v"]
+        u = edges.src["u"]
+        eij = edges.data.pop("e")
+        inputs = torch.hstack([vi, vj, eij, u])
+        mij = {"mij": self.edge_func(inputs)}
+        return mij
+
+    def edge_update_(self, graph: dgl.DGLGraph) -> torch.Tensor:
+        """
+        Update function for edges: applies the edge-focused MLP to get transformed
+        edge features, and updates the corresponding key in the DGL graph.
+
+        Parameters
+        ----------
+        graph : dgl.DGLGraph
+            Input DGL graph
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed edge features
+        """
+        graph.apply_edges(self._edge_udf)
+        graph.edata["e"] = graph.edata.pop("mij")
+        return graph.edata["e"]
+
+    def node_update_(self, graph: dgl.DGLGraph) -> torch.Tensor:
+        """
+        Update function for nodes: applies the node-focused MLP to get transformed
+        edge features, and updates the corresponding key in the DGL graph.
+
+        Parameters
+        ----------
+        graph : dgl.DGLGraph
+            Input DGL graph
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed node features
+        """
+        graph.update_all(fn.copy_e("e", "e"), fn.mean("e", "ve"))
+        ve = graph.ndata.pop("ve")
+        v = graph.ndata.pop("v")
+        u = graph.ndata.pop("u")
+        inputs = torch.hstack([v, ve, u])
+        graph.ndata["v"] = self.node_func(inputs)
+        return graph.ndata["v"]
+
+    def attr_update_(self, graph: dgl.DGLGraph, attrs: torch.Tensor) -> torch.Tensor:
+        """
+        Update function for graph attributes: applies the graph attribute
+        focused MLP to get transformed graph features and returns them
+
+        Parameters
+        ----------
+        graph : dgl.DGLGraph
+            Input DGL graph
+
+        attrs : torch.Tensor
+            Input graph attributes
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed graph features
+        """
+        u = attrs
+        ue = dgl.readout_edges(graph, feat="e", op="mean")
+        uv = dgl.readout_nodes(graph, feat="v", op="mean")
+        inputs = torch.hstack([u, ue, uv])
+        graph_attr = self.attr_func(inputs)
+        return graph_attr
+
+    def forward(
+        self,
+        graph: dgl.DGLGraph,
+        edge_feat: torch.Tensor,
+        node_feat: torch.Tensor,
+        graph_attr: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Forward pass for the MEGNet convolution operation, composing the
+        order of the edge, node, and graph feature transformations.
+
+        Parameters
+        ----------
+        graph : dgl.DGLGraph
+            _description_
+        edge_feat, node_feat, graph_attr : torch.Tensor
+            Respective input feature tensors for each type
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            Respective output tensors with transformed features.
+        """
+        with graph.local_scope():
+            graph.edata["e"] = edge_feat
+            graph.ndata["v"] = node_feat
+            graph.ndata["u"] = dgl.broadcast_nodes(graph, graph_attr)
+
+            edge_feat = self.edge_update_(graph)
+            node_feat = self.node_update_(graph)
+            graph_attr = self.attr_update_(graph, graph_attr)
+
+        return edge_feat, node_feat, graph_attr
+
+
+class MEGNetBlock(Module):
+    """
+    A MEGNet block comprising a sequence of update operations.
+    """
+
+    def __init__(
+        self,
+        dims: list[int],
+        conv_hiddens: list[int],
+        dropout: Optional[float] = None,
+        skip: bool = True,
+    ) -> None:
+        """
+        MEGNet block init function
+
+        Parameters
+        ----------
+        dims : list[int]
+            List of integer dimensions to create MLP blocks
+        conv_hiddens : list[int]
+            Hidden dimension to use for the convolution layers
+        dropout : Optional[float], optional
+            Dropout proabibility, by default None which does not use
+            dropout.
+        skip : bool, optional
+            Whether to use skip connections, by default True
+        """
+        super().__init__()
+
+        self.has_dense = len(dims) > 1
+        conv_dim = dims[-1]
+        out_dim = conv_hiddens[-1]
+
+        mlp_kwargs = {
+            "dims": dims,
+            "activation": Softplus(),
+            "activate_last": True,
+            "bias_last": True,
+        }
+        self.edge_func = MLP(**mlp_kwargs) if self.has_dense else Identity()
+        self.node_func = MLP(**mlp_kwargs) if self.has_dense else Identity()
+        self.attr_func = MLP(**mlp_kwargs) if self.has_dense else Identity()
+
+        # compute input sizes
+        edge_in = 2 * conv_dim + conv_dim + conv_dim  # 2*NDIM+EDIM+GDIM
+        node_in = out_dim + conv_dim + conv_dim  # EDIM+NDIM+GDIM
+        attr_in = out_dim + out_dim + conv_dim  # EDIM+NDIM+GDIM
+        self.conv = MEGNetGraphConv.from_dims(
+            edge_dims=[edge_in] + conv_hiddens,
+            node_dims=[node_in] + conv_hiddens,
+            attr_dims=[attr_in] + conv_hiddens,
+        )
+
+        self.dropout = Dropout(dropout) if dropout else None
+        # TODO(marcel): should this be an 1D dropout
+        self.skip = skip
+
+    def forward(
+        self,
+        graph: dgl.DGLGraph,
+        edge_feat: torch.Tensor,
+        node_feat: torch.Tensor,
+        graph_attr: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Forward pass of the MEGNet block, which transforms edge, node, and graph
+        features based on the `MEGNetGraphConv` operations.
+
+        Parameters
+        ----------
+        graph : dgl.DGLGraph
+            Input DGL graph structure
+        edge_feat, node_feat, graph_attr : torch.Tensor
+            Respective feature tensors for each type
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            Transformed feature tensors for each respective type of feature
+        """
+
+        inputs = (edge_feat, node_feat, graph_attr)
+        edge_feat = self.edge_func(edge_feat)
+        node_feat = self.node_func(node_feat)
+        graph_attr = self.attr_func(graph_attr)
+
+        edge_feat, node_feat, graph_attr = self.conv(
+            graph, edge_feat, node_feat, graph_attr
+        )
+
+        if self.dropout:
+            edge_feat = self.dropout(edge_feat)
+            node_feat = self.dropout(node_feat)
+            graph_attr = self.dropout(graph_attr)
+
+        if self.skip:
+            edge_feat = edge_feat + inputs[0]
+            node_feat = node_feat + inputs[1]
+            graph_attr = graph_attr + inputs[2]
+
+        return edge_feat, node_feat, graph_attr

--- a/ocpmodels/models/dgl/megnet/layers.py
+++ b/ocpmodels/models/dgl/megnet/layers.py
@@ -44,21 +44,40 @@ class MEGNetGraphConv(Module):
         self.node_func = node_func
         self.attr_func = attr_func
 
-    @staticmethod
-    def from_dims(edge_dims: list[int], node_dims: list[int], attr_dims: list[int]):
+    @classmethod
+    def from_dims(
+        cls, edge_dims: list[int], node_dims: list[int], attr_dims: list[int]
+    ):
         """
-        TODO: Add docs.
-        :param edge_dims:
-        :param node_dims:
-        :param attr_dims:
-        :return:
+        Class method to instantiate a MEGNet graph convolution layer given
+        a list of dimensionalities.
+
+        Parameters
+        ----------
+        edge_dims, node_dims, attr_dims : list[int]
+            Dimensionalities for each MLP function that transforms edge, node, and
+            graph features.
+
+        Parameters
+        ----------
+        edge_dims : list[int]
+            _description_
+        node_dims : list[int]
+            _description_
+        attr_dims : list[int]
+            _description_
+
+        Returns
+        -------
+        _type_
+            _description_
         """
         # TODO(marcel): Softplus doesnt exactly match paper's SoftPlus2
         # TODO(marcel): Should we activate last?
         edge_update = MLP(edge_dims, Softplus(), activate_last=True)
         node_update = MLP(node_dims, Softplus(), activate_last=True)
         attr_update = MLP(attr_dims, Softplus(), activate_last=True)
-        return MEGNetGraphConv(edge_update, node_update, attr_update)
+        return cls(edge_update, node_update, attr_update)
 
     def _edge_udf(self, edges: dgl.udf.EdgeBatch) -> Dict[str, torch.Tensor]:
         """

--- a/ocpmodels/models/dgl/megnet/layers.py
+++ b/ocpmodels/models/dgl/megnet/layers.py
@@ -4,8 +4,8 @@ Implement graph convolution layers for MEGNet.
 Code attributions to https://github.com/materialsvirtuallab/m3gnet-dgl/tree/main/megnet,
 along with contributions and modifications from Marcel Nassar, Santiago Miret, and Kelvin Lee
 """
-
-from typing import Dict, Optional
+from __future__ import annotations
+from typing import Dict, Optional, List
 
 import dgl
 import dgl.function as fn
@@ -46,8 +46,8 @@ class MEGNetGraphConv(Module):
 
     @classmethod
     def from_dims(
-        cls, edge_dims: list[int], node_dims: list[int], attr_dims: list[int]
-    ):
+        cls, edge_dims: List[int], node_dims: List[int], attr_dims: List[int]
+    ) -> MEGNetGraphConv:
         """
         Class method to instantiate a MEGNet graph convolution layer given
         a list of dimensionalities.
@@ -58,19 +58,10 @@ class MEGNetGraphConv(Module):
             Dimensionalities for each MLP function that transforms edge, node, and
             graph features.
 
-        Parameters
-        ----------
-        edge_dims : list[int]
-            _description_
-        node_dims : list[int]
-            _description_
-        attr_dims : list[int]
-            _description_
-
         Returns
         -------
-        _type_
-            _description_
+        MEGNetGraphConv
+            Instance of a MEGNet graph convolution layer
         """
         # TODO(marcel): Softplus doesnt exactly match paper's SoftPlus2
         # TODO(marcel): Should we activate last?

--- a/ocpmodels/models/dgl/megnet/megnet.py
+++ b/ocpmodels/models/dgl/megnet/megnet.py
@@ -1,0 +1,129 @@
+"""
+Implementation of MEGNet model.
+
+Code attributions to https://github.com/materialsvirtuallab/m3gnet-dgl/tree/main/megnet,
+along with contributions and modifications from Marcel Nassar, Santiago Miret, and Kelvin Lee
+"""
+from typing import Optional
+
+import dgl
+import torch
+from torch import nn
+from dgl.nn import Set2Set
+from torch.nn import Dropout, Identity, Module, ModuleList, Softplus
+
+from ocpmodels.models.dgl.megnet import MLP, MEGNetBlock, EdgeSet2Set
+
+
+class MEGNet(Module):
+    """
+    DGL implementation of MEGNet.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        num_blocks: int,
+        hiddens: list[int],
+        conv_hiddens: list[int],
+        s2s_num_layers: int,
+        s2s_num_iters: int,
+        output_hiddens: list[int],
+        is_classification: bool = True,
+        node_embed: Optional[nn.Module] = None,
+        edge_embed: Optional[nn.Module] = None,
+        attr_embed: Optional[nn.Module] = None,
+        dropout: Optional[float] = None,
+    ) -> None:
+        """
+        TODO: Add docs.
+        :param in_dim:
+        :param num_blocks:
+        :param hiddens:
+        :param conv_hiddens:
+        :param s2s_num_layers:
+        :param s2s_num_iters:
+        :param output_hiddens:
+        :param is_classification:
+        :param node_embed:
+        :param edge_embed:
+        :param attr_embed:
+        :param dropout:
+        """
+        super().__init__()
+
+        self.edge_embed = edge_embed if edge_embed else Identity()
+        self.node_embed = node_embed if node_embed else Identity()
+        self.attr_embed = attr_embed if attr_embed else Identity()
+
+        dims = [in_dim] + hiddens
+        self.edge_encoder = MLP(dims, Softplus(), activate_last=True)
+        self.node_encoder = MLP(dims, Softplus(), activate_last=True)
+        self.attr_encoder = MLP(dims, Softplus(), activate_last=True)
+
+        blocks_in_dim = hiddens[-1]
+        block_out_dim = conv_hiddens[-1]
+        block_args = dict(conv_hiddens=conv_hiddens, dropout=dropout, skip=True)
+        blocks = []
+        from .layers import MEGNetBlock
+
+        # first block
+        blocks.append(MEGNetBlock(dims=[blocks_in_dim], **block_args))  # type: ignore
+        # other blocks
+        for _ in range(num_blocks - 1):
+            blocks.append(MEGNetBlock(dims=[block_out_dim] + hiddens, **block_args))  # type: ignore
+        self.blocks = ModuleList(blocks)
+
+        s2s_kwargs = dict(n_iters=s2s_num_iters, n_layers=s2s_num_layers)
+        self.edge_s2s = EdgeSet2Set(block_out_dim, **s2s_kwargs)
+        self.node_s2s = Set2Set(block_out_dim, **s2s_kwargs)
+
+        self.output_proj = MLP(
+            # S2S cats q_star to output producing double the dim
+            dims=[2 * 2 * block_out_dim + block_out_dim] + output_hiddens + [1],
+            activation=Softplus(),
+            activate_last=False,
+        )
+
+        self.dropout = Dropout(dropout) if dropout else None
+        # TODO(marcel): should this be an 1D dropout
+
+        self.is_classification = is_classification
+
+    def forward(
+        self,
+        graph: dgl.DGLGraph,
+        edge_feat: torch.Tensor,
+        node_feat: torch.Tensor,
+        graph_attr: torch.Tensor,
+    ) -> None:
+        """
+        TODO: Add docs.
+        :param graph:
+        :param edge_feat:
+        :param node_feat:
+        :param graph_attr:
+        :return:
+        """
+
+        edge_feat = self.edge_encoder(self.edge_embed(edge_feat))
+        node_feat = self.node_encoder(self.node_embed(node_feat))
+        graph_attr = self.attr_encoder(self.attr_embed(graph_attr))
+
+        for block in self.blocks:
+            output = block(graph, edge_feat, node_feat, graph_attr)
+            edge_feat, node_feat, graph_attr = output
+
+        node_vec = self.node_s2s(graph, node_feat)
+        edge_vec = self.edge_s2s(graph, edge_feat)
+
+        vec = torch.hstack([node_vec, edge_vec, graph_attr])
+
+        if self.dropout:
+            vec = self.dropout(vec)  # pylint: disable=E1102
+
+        output = self.output_proj(vec)
+        if self.is_classification:
+            output = torch.sigmoid(output)
+
+        return output

--- a/ocpmodels/models/dgl/megnet/megnet.py
+++ b/ocpmodels/models/dgl/megnet/megnet.py
@@ -36,19 +36,32 @@ class MEGNet(Module):
         dropout: Optional[float] = None,
     ) -> None:
         """
-        TODO: Add docs.
-        :param in_dim:
-        :param num_blocks:
-        :param hiddens:
-        :param conv_hiddens:
-        :param s2s_num_layers:
-        :param s2s_num_iters:
-        :param output_hiddens:
-        :param is_classification:
-        :param node_embed:
-        :param edge_embed:
-        :param attr_embed:
-        :param dropout:
+        Init method for MEGNet.
+
+        Parameters
+        ----------
+        in_dim : int
+            Input dimensionality, which is used to create the encoder layers.
+        num_blocks : int
+            Number of MEGNet convolution blocks to use
+        hiddens : list[int]
+            Hidden dimensionality of encoding MLP layers, follows `in_dim`
+        conv_hiddens : list[int]
+            Hidden dimensionality of the convolution layers
+        s2s_num_layers : int
+            Number of Set2Set layers
+        s2s_num_iters : int
+            Number of iterations for Set2Set operations
+        output_hiddens : list[int]
+            Output layer hidden dimensionality in the projection layer
+        is_classification : bool, optional
+            Whether to apply sigmoid to the output tensor, by default True
+        node_embed, edge_embed, attr_embed : Optional[nn.Module], optional
+            Embedding functions for each type of feature, by default None and
+            simply uses an `Identity` function
+        dropout : Optional[float], optional
+            Dropout probability for the convolution layers, by default None
+            which does not use dropout.
         """
         super().__init__()
 
@@ -95,14 +108,23 @@ class MEGNet(Module):
         edge_feat: torch.Tensor,
         node_feat: torch.Tensor,
         graph_attr: torch.Tensor,
-    ) -> None:
+    ) -> torch.Tensor:
         """
-        TODO: Add docs.
-        :param graph:
-        :param edge_feat:
-        :param node_feat:
-        :param graph_attr:
-        :return:
+        Forward pass of MEGNet, taking in an input DGL graph and
+        transforming the input features with encoding layers first,
+        followed by blocks of graph convolution and projection.
+
+        Parameters
+        ----------
+        graph : dgl.DGLGraph
+            _description_
+        edge_feat, node_feat, graph_attr : torch.Tensor
+            Respective feature tensors for each type of representation
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor, typically is the energy.
         """
 
         edge_feat = self.edge_encoder(self.edge_embed(edge_feat))

--- a/ocpmodels/models/dgl/megnet/megnet.py
+++ b/ocpmodels/models/dgl/megnet/megnet.py
@@ -65,7 +65,6 @@ class MEGNet(Module):
         block_out_dim = conv_hiddens[-1]
         block_args = dict(conv_hiddens=conv_hiddens, dropout=dropout, skip=True)
         blocks = []
-        from .layers import MEGNetBlock
 
         # first block
         blocks.append(MEGNetBlock(dims=[blocks_in_dim], **block_args))  # type: ignore

--- a/ocpmodels/models/dgl/megnet/megnet.py
+++ b/ocpmodels/models/dgl/megnet/megnet.py
@@ -13,9 +13,10 @@ from dgl.nn import Set2Set
 from torch.nn import Dropout, Identity, Module, ModuleList, Softplus
 
 from ocpmodels.models.dgl.megnet import MLP, MEGNetBlock, EdgeSet2Set
+from ocpmodels.models import AbstractEnergyModel
 
 
-class MEGNet(Module):
+class MEGNet(AbstractEnergyModel):
     """
     DGL implementation of MEGNet.
     """


### PR DESCRIPTION
This partially addresses #4. Here we're porting the MEGNet model (attributing to the [Materials Virtual Lab repo](https://github.com/materialsvirtuallab/m3gnet-dgl) with modifications from us) , followed by additional documentation and refactors before implementing the `Embedding` layer change.

Note that this uses a lookup table nodes only: if one wants to play around with make-believe bond orders for edge embeddings, there will be an additional refactor needed.