### PR TITLE
Hyperparameter saving in LightningDataModules

### DIFF
--- a/ocpmodels/lightning/data_utils.py
+++ b/ocpmodels/lightning/data_utils.py
@@ -57,6 +57,7 @@ class GraphDataModule(pl.LightningDataModule):
         self.dataset_class = dataset_class
         self.collate_fn = dataset_class.collate_fn
         self.transforms = transforms
+        self.save_hyperparameters(ignore=["dataset_class"])
 
     def verify_paths(self) -> None:
         """


### PR DESCRIPTION
This addresses #11 by adding a single line to the base `GraphDataModule` class that saves all hyperparameters except the dataset class because it's not needed, and probably can't serialize it either.

Verified that transform configs also get included in the hparams.yml created by the default logger.