### PR TITLE
Add leaderboard submission scripts

### DIFF
--- a/ocpmodels/datasets/task_datasets.py
+++ b/ocpmodels/datasets/task_datasets.py
@@ -59,6 +59,9 @@ class S2EFDataset(DGLDataset):
             for key in ["natoms", "y", "sid", "fid", "cell"]:
                 output_data[key] = data.get(key)
             output_data["graph"] = graph
+        # This is the case for test set data for s2ef with dgl format.
+        elif 'graph' in data.keys():
+            output_data = data
         return output_data
 
 

--- a/ocpmodels/lightning/callbacks.py
+++ b/ocpmodels/lightning/callbacks.py
@@ -70,7 +70,7 @@ class LeaderboardWriter(BasePredictionWriter):
                     if any([type(v) == str for v in value]):
                         results[key].extend(value)
                     else:
-                        if key =="chunk_ids":
+                        if key == "chunk_ids":
                             value = [value.cpu() for value in value]
                             results[key].extend(value)
                         else:
@@ -82,7 +82,6 @@ class LeaderboardWriter(BasePredictionWriter):
                 else:
                     results[key] = torch.stack(values).numpy()
 
-            # print(results)
             target = self.output_path.joinpath(f"{task_name}/{gnn_name}/{self.now}.npz")
             # make the directory in case it doesn't exist
             target.parent.mkdir(parents=True, exist_ok=True)

--- a/ocpmodels/lightning/callbacks.py
+++ b/ocpmodels/lightning/callbacks.py
@@ -1,13 +1,19 @@
-from typing import Union, Sequence, Optional, Any, Dict
-from pathlib import Path
+import json
 import os
 from datetime import datetime
+from logging import getLogger
+from pathlib import Path
+from time import time
+from typing import Any, Dict, Optional, Sequence, Union
 
 import numpy as np
-import torch
 import pytorch_lightning as pl
+import torch
+from pytorch_lightning.callbacks import BasePredictionWriter, Callback
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
-from pytorch_lightning.callbacks import BasePredictionWriter
+from torch import distributed as dist
+from torch import nn
+from torch.optim import Optimizer
 
 
 class LeaderboardWriter(BasePredictionWriter):
@@ -58,13 +64,233 @@ class LeaderboardWriter(BasePredictionWriter):
         # run on all workers for the sync to happen
         if rank_zero_only.rank == 0:
             keys = world_predictions[0].keys()
-            joint_results = {}
-            for key in keys:
-                combined_result = torch.stack(
-                    [batch[key] for batch in world_predictions]
-                )
-                joint_results[key] = combined_result.flatten(0, -2).numpy()
+            results = {key: [] for key in keys}
+            for prediction in world_predictions:
+                for key, value in prediction.items():
+                    if any([type(v) == str for v in value]):
+                        results[key].extend(value)
+                    else:
+                        if key =="chunk_ids":
+                            value = [value.cpu() for value in value]
+                            results[key].extend(value)
+                        else:
+                            results[key].extend(value.cpu())
+
+            for key, values in results.items():
+                if key == "ids":
+                    pass
+                else:
+                    results[key] = torch.stack(values).numpy()
+
+            # print(results)
             target = self.output_path.joinpath(f"{task_name}/{gnn_name}/{self.now}.npz")
             # make the directory in case it doesn't exist
             target.parent.mkdir(parents=True, exist_ok=True)
-            np.savez_compressed(target, **joint_results)
+            np.savez_compressed(target, **results)
+            print(f"\nSaved NPZ log file to: {target}\n")
+
+
+def forward_nan_hook(
+    module: nn.Module, input: torch.Tensor, output: torch.Tensor
+) -> None:
+    """
+    Create a hook that will save the input/output tensors to a module if there are NaNs
+    detected in the output tensor.
+
+    To use this function, register it as a forward hook using `nn.Module.register_forward_hook`.
+
+    Parameters
+    ----------
+    module : nn.Module
+        PyTorch nn.Module/layer of interest
+    input : torch.Tensor
+        Input tensor fed into the nn.Module
+    output : torch.Tensor
+        Output tensor as a result of module(input)
+    """
+    if torch.any(output.isnan()):
+        setattr(
+            module,
+            "nan_detection",
+            {"input": input.detach(), "output": output.detach()},
+        )
+
+
+class GradientCheckCallback(Callback):
+    """
+    Callback to monitor gradients in a model. Just before the optimizer is
+    stepped, we will inspect the gradients for every single learnable parameter.
+    If there are NaNs in the gradients, we will print out the parameter and step
+    number, and then zero out the gradients. Otherwise, we will inspect the
+    gradient norm and ensure it's above a specified threshold.
+    """
+
+    def __init__(self, thres: float = 1e-2, num_steps: int = -1) -> None:
+        super().__init__()
+        self.thres = thres
+        self.logger = getLogger("pytorch_lightning")
+        self.num_steps = num_steps
+
+    def on_before_optimizer_step(
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        optimizer: Optimizer,
+        opt_idx: int,
+    ) -> None:
+        step_number = trainer.global_step
+        # this checks to make sure we're still running the nan check
+        if self.num_steps <= step_number:
+            gradients = []
+            for (name, param) in pl_module.named_parameters():
+                if param.requires_grad and param.grad is not None:
+                    # check if there are NaNs as well
+                    if torch.any(torch.isnan(param.grad)):
+                        self.logger.debug(
+                            f"Step number {step_number} has NaN gradients for parameter {name}. Zeroing!"
+                        )
+                        # zero out gradients
+                        param.grad.zero_()
+                    else:
+                        grad_norm = param.detach().norm()
+                        # detach from the computational graph and just check the norm value
+                        if grad_norm < self.thres:
+                            gradients.append((name, grad_norm.item()))
+            if len(gradients) > 0:
+                msg = (
+                    f"Parameters with gradient norm less than {self.thres}: {gradients}"
+                )
+                self.logger.debug(msg)
+
+
+class ThroughputCallback(Callback):
+    def __init__(self, log_dir: str, batch_size: int) -> None:
+        super().__init__()
+        self.batch_size = batch_size
+        self.log_dir = log_dir
+        self.record = []
+
+    @property
+    def workers(self) -> int:
+        if dist.is_initialized():
+            return dist.get_world_size()
+        return 1
+
+    @property
+    def log_dir(self) -> Path:
+        return self._log_dir
+
+    @log_dir.setter
+    def log_dir(self, path: Union[str, Path]) -> None:
+        if isinstance(path, str):
+            path = Path(path)
+        if not path.exists():
+            os.makedirs(path, exist_ok=True)
+        self._log_dir = path
+
+    @property
+    def start_time(self) -> int:
+        return self._start_time
+
+    @start_time.setter
+    def start_time(self, value: int) -> None:
+        self._start_time = value
+
+    @property
+    def end_time(self) -> int:
+        return self._end_time
+
+    @end_time.setter
+    def end_time(self, value: int) -> None:
+        self._end_time = value
+
+    @property
+    def elapsed(self) -> int:
+        return self._end_time - self._start_time
+
+    @property
+    def throughput(self) -> float:
+        return (self.batch_size * self.workers) / self.elapsed
+
+    @rank_zero_only
+    def on_train_batch_start(
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        # get time with nanosecond precision
+        self.start_time = time()
+
+    @rank_zero_only
+    def on_train_batch_end(
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        outputs,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        self.end_time = time()
+        self.counter = batch_idx + 1
+        self.record.append(self.formatted_result)
+
+    @property
+    def formatted_result(self) -> Dict[str, Union[int, float]]:
+        result = {
+            "elapsed": self.elapsed,
+            "throughput": self.throughput,
+            "counter": self.counter,
+            "batches": self.counter * self.batch_size * self.workers,
+        }
+        return result
+
+    @rank_zero_only
+    def on_fit_end(
+        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"
+    ) -> None:
+        epoch = trainer.current_epoch
+        target = self.log_dir.joinpath(f"epoch{epoch}_throughput_measurement.json")
+        with open(target, "w+") as write_file:
+            json.dump(self.record, write_file)
+
+
+class ForwardNaNDetection(Callback):
+    def __init__(self, output_path: Union[str, Path]) -> None:
+        super().__init__()
+        if isinstance(output_path, str):
+            output_path = Path(output_path)
+        self.output_path = output_path
+        os.makedirs(self.output_path, exist_ok=True)
+
+    @property
+    def target_file(self) -> Path:
+        return self.output_path.joinpath(f"forward_nan_check_step{self.step_num}.log")
+
+    def on_fit_start(
+        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"
+    ) -> None:
+        for child in pl_module.children():
+            child.register_forward_hook(forward_nan_hook)
+
+    def on_batch_end(
+        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"
+    ) -> None:
+        self.step_num = trainer.global_step
+        all_data = []
+        for name, child in pl_module.named_children():
+            nan_data = getattr(child, "nan_detection", None)
+            if nan_data is not None:
+                nan_data["name"] = name
+                # cast tenors to strings for saving
+                nan_data["input"] = str(nan_data["input"])
+                nan_data["output"] = str(nan_data["output"])
+                all_data.append(nan_data)
+        if len(all_data) != 0:
+            with open(self.target_file, "w+") as write_file:
+                for entry in all_data:
+                    write_file.write(
+                        " ".join([f"{key}: {value}" for key, value in entry.items()])
+                    )
+                write_file.write("\n")

--- a/ocpmodels/models/base.py
+++ b/ocpmodels/models/base.py
@@ -860,6 +860,10 @@ class S2EFLitModule(OCPLitModule):
             fixed_mask = graph.ndata["fixed"] == 0
             # retrieve only forces corresponding to unfixed nodes
             predictions["forces"] = pred_force[fixed_mask]
+            natoms = tuple(batch.get('natoms').cpu().numpy().astype(int))
+            chunk_split = torch.split(graph.ndata["fixed"], natoms)
+            chunk_ids = [int((len(chunk)-sum(chunk)).cpu().numpy().astype(int)) for chunk in chunk_split]
+            predictions["chunk_ids"] = chunk_ids
         return predictions
 
 

--- a/ocpmodels/models/base.py
+++ b/ocpmodels/models/base.py
@@ -862,7 +862,11 @@ class S2EFLitModule(OCPLitModule):
             predictions["forces"] = pred_force[fixed_mask]
             natoms = tuple(batch.get('natoms').cpu().numpy().astype(int))
             chunk_split = torch.split(graph.ndata["fixed"], natoms)
-            chunk_ids = [int((len(chunk)-sum(chunk)).cpu().numpy().astype(int)) for chunk in chunk_split]
+            chunk_ids = []
+            for chunk in chunk_split:
+                ids = (len(chunk) - sum(chunk)).cpu().numpy().astype(int)
+                chunk_ids.append(int(ids))
+
             predictions["chunk_ids"] = chunk_ids
         return predictions
 

--- a/scripts/generate_leaderboard_logs.py
+++ b/scripts/generate_leaderboard_logs.py
@@ -17,10 +17,6 @@ from pytorch_lightning.loggers import CSVLogger
 from tqdm import tqdm
 from yaml import safe_load
 
-import os
-
-os.environ["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"  # set to DETAIL for runtime logging.
-
 
 def verify_input_args(args):
     # make sure all paths are valid

--- a/scripts/generate_leaderboard_logs.py
+++ b/scripts/generate_leaderboard_logs.py
@@ -1,0 +1,163 @@
+from argparse import ArgumentParser
+from copy import deepcopy
+from pathlib import Path
+
+import pytorch_lightning as pl
+from munch import Munch, munchify, unmunchify
+from ocpmodels import datasets as dsets
+from ocpmodels.datasets.transforms import DistancesTransform, GraphVariablesTransform
+
+# import the callback responsible for aggregating and formatting
+# prediction results
+from ocpmodels.lightning.callbacks import ForwardNaNDetection, LeaderboardWriter
+from ocpmodels.lightning.cli import DATAMODULE_REGISTRY, MODEL_REGISTRY
+from ocpmodels.lightning.data_utils import IS2REDGLDataModule, is2re_devset
+from ocpmodels.models import GraphConvModel, IS2RELitModule
+from pytorch_lightning.loggers import CSVLogger
+from tqdm import tqdm
+from yaml import safe_load
+
+import os
+
+os.environ["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"  # set to DETAIL for runtime logging.
+
+
+def verify_input_args(args):
+    # make sure all paths are valid
+    for key in ["backbone_config", "ckpt_path", "data_config"]:
+        assert Path(
+            getattr(args, key)
+        ).exists(), f"{key} does not correspond to a valid path! {getattr(args, key)}"
+
+    for val_path in args.val_paths:
+        assert Path(val_path).exists(), f"{val_path} does not exist!"
+
+    # make sure backbone, task, data references are valid
+    assert (
+        args.backbone in MODEL_REGISTRY
+    ), f"{args.backbone} is not a valid backbone: {MODEL_REGISTRY}"
+    # get the task lightning modules
+    lit_modules = [
+        v
+        for v in MODEL_REGISTRY
+        if any([key in v for key in ["S2EF", "IS2RE", "PointCloud"]])
+    ]
+    assert (
+        args.task in MODEL_REGISTRY
+    ), f"{args.task} is not a valid task lightning module: {lit_modules}"
+    assert args.task_data_module in DATAMODULE_REGISTRY
+
+
+def load_model(args):
+    # load in configs
+    with open(args.backbone_config, "r") as read_file:
+        backbone_yml = safe_load(read_file)
+    # configure backbone
+    backbone_cls = MODEL_REGISTRY.get(args.backbone)
+    backbone = backbone_cls(**backbone_yml["model"]["init_args"]["gnn"]["init_args"])
+    model_cls = MODEL_REGISTRY.get(args.task)
+    model = model_cls(**backbone_yml["model"]["init_args"]).load_from_checkpoint(
+        gnn=backbone, checkpoint_path=args.ckpt_path
+    )
+    return model
+
+
+def load_datamodule(args, path):
+    with open(args.data_config, "r") as read_file:
+        data_yml = safe_load(read_file)
+
+    # match the right data module
+    datamodule_cls = DATAMODULE_REGISTRY.get(args.task_data_module)
+
+    # now enter loop over all validation files
+
+    data_kwargs = deepcopy(data_yml["data"]["init_args"])
+    # patch it slightly to specialize for point clouds, which requires wrapping the dataset
+    if "PointCloud" in args.task_data_module:
+        dataset_classname = data_kwargs.get("dataset_class").split(".")[-1]
+        dset_class = getattr(dsets, dataset_classname)
+        data_kwargs["dataset_class"] = dset_class
+
+    # set the correct validation path
+    if args.pipeline.lower() == "predict":
+        data_kwargs["predict_path"] = path
+    elif args.pipeline.lower() == "validate":
+        data_kwargs["val_path"] = path
+
+    # data_kwargs["batch_size"] = 1
+
+    if args.backbone == "MEGNet":
+        datamodule = datamodule_cls(
+            transforms=[
+                DistancesTransform(),
+                GraphVariablesTransform(),
+            ],
+            **data_kwargs,
+        )
+    else:
+        datamodule = datamodule_cls(**data_kwargs)
+
+    return datamodule
+
+
+def load_logger_and_callbacks(path):
+    val_set_name = Path(path).stem
+    logger = CSVLogger(
+        save_dir=f"{args.logger.init_args.save_dir}_{val_set_name}",
+        name=f"{args.backbone}-{args.task}-{args.logger.init_args.name}",
+        version=val_set_name,
+    )
+    npz_log = logger.save_dir + "/" + logger.name
+    callbacks = LeaderboardWriter(npz_log)
+    return logger, callbacks
+
+
+def load_trainer(args, logger, callbacks):
+    trainer = pl.Trainer(
+        accelerator=args.accelerator,
+        # strategy="ddp" if args.num_devices > 1 else None,
+        strategy=None,
+        devices=args.num_devices,
+        logger=[logger],
+        callbacks=callbacks,
+    )
+    return trainer
+
+
+def main(trainer, model, datamodule, pipeline):
+    if pipeline.lower() == "predict":
+        trainer.predict(model, datamodule=datamodule)
+    elif pipeline.lower() == "validate":
+        trainer.validate(model, datamodule=datamodule)
+
+
+if __name__ == "__main__":
+    """
+    General purpose validation module.
+
+    Given a variable list of validation datasets, this script will load in
+    a model/backbone, and crank through each one, reporting the results in
+    `validation_runs/{model}-{task}/{validation set}.
+    """
+
+    argparser = ArgumentParser()
+    argparser.add_argument(
+        "--config-file",
+        type=str,
+        default="../pl-configs/predict.yml",
+        help="Configuration file for the chosen run",
+    )
+
+    cmd_args = argparser.parse_args()
+
+    with open(cmd_args.config_file) as f:
+        data_map = safe_load(f)
+
+    args = munchify(data_map).predict
+    verify_input_args(args)
+    model = load_model(args)
+    for path in tqdm(args.val_paths):
+        datamodule = load_datamodule(args, path)
+        logger, callbacks = load_logger_and_callbacks(path)
+        trainer = load_trainer(args, logger, callbacks)
+        main(trainer, model, datamodule, args.pipeline)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,90 @@
+import re
+
+import numpy as np
+
+
+def get_s2ef_ids(input):
+    pattern = r"\[(\d+)\]"
+    output = []
+    for string in input:
+        matches = re.findall(pattern, string)
+        int_values = [int(match) for match in matches]
+        output.append("_".join([str(_) for _ in int_values]))
+    return output
+
+
+def npz_convert(npz_id, npz_ood_cat, npz_ood_ads, npz_ood_both):
+    full_dict = dict()
+    datasets = {
+        "id": npz_id,
+        "ood_cat": npz_ood_cat,
+        "ood_ads": npz_ood_ads,
+        "ood_both": npz_ood_both,
+    }
+    full_dict = {}
+    for dataset_name, dataset in datasets.items():
+        ids = [item for item in [*dataset["ids"]]]
+        full_dict[f"{dataset_name}_ids"] = get_s2ef_ids(ids)
+        full_dict[f"{dataset_name}_energy"] = [
+            item.astype(float).item() for item in [*dataset["energy"]]
+        ]
+        full_dict[f"{dataset_name}_forces"] = [
+            [_.astype(float).item() for _ in item] for item in [*dataset["forces"]]
+        ]
+        try:
+            full_dict[f"{dataset_name}_chunk_idx"] = np.cumsum(
+                [item.astype(int).item() for item in [*dataset["chunk_ids"]]]
+            ).astype(int)
+        except Exception:
+            pass
+    return full_dict
+
+
+def parse_npz_for_nans(file):
+    data = np.load(file)
+    if np.isnan(data['energy']).any():
+        print("Found nans in energy!")
+    elif np.isnan(data['forces']).any():
+        print("Found nans in forces!")
+    else:
+        print("No nans found")
+
+
+def make_submission_file(args):
+    npz_id = np.load(args.id)
+    npz_ood_cat = np.load(args.ood_cat)
+    npz_ood_ads = np.load(args.ood_ads)
+    npz_ood_both = np.load(args.ood_both)
+    out_dict = npz_convert(npz_id, npz_ood_cat, npz_ood_ads, npz_ood_both)
+    np.savez_compressed(args.out_path, **out_dict)
+    print(f"Saved submission file: {args.out_path}")
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+
+    argparser = ArgumentParser()
+    argparser.add_argument(
+        "--npz-file", type=str, default="", help="npz log file to parse"
+    )
+    argparser.add_argument("--submission", action="store_true")
+    argparser.add_argument(
+        "--id", help="Path to ID results. Required for OC20 and OC22."
+    )
+    argparser.add_argument(
+        "--ood-ads", help="Path to OOD-Ads results. Required only for OC20."
+    )
+    argparser.add_argument(
+        "--ood-cat", help="Path to OOD-Cat results. Required only for OC20."
+    )
+    argparser.add_argument(
+        "--ood-both", help="Path to OOD-Both results. Required only for OC20."
+    )
+    argparser.add_argument("--out-path", default="submission_file.npz")
+    args = argparser.parse_args()
+    if args.submission:
+        make_submission_file(args)
+    else:
+        parse_npz_for_nans(args.npz_file)
+
+


### PR DESCRIPTION
Adds two files to the `./scripts` folder which help in generating submissions to the evalai leaderboard in the correct format.
Fixes a bug in how `chunk_ids` were calculated.
Adds a case in dataset loading for differently formatted s2ef test data. 
Adds callbacks: leaderboard writer, gradient check, nan check (forward pass), and throughput. 