### PR TITLE
Pre-commit workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,12 @@ repos:
           flake8-pyproject,
         ]
 -   repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 22.3.1
     hooks:
       - id: black
         language_version: python3.9
 -   repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 22.3.1
     hooks:
       - id: black-jupyter
         language_version: python3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: debug-statements
+-   repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v2.4.0
+    hooks:
+    -   id: setup-cfg-fmt
+-   repo: https://github.com/asottile/reorder-python-imports
+    rev: v3.10.0
+    hooks:
+    -   id: reorder-python-imports
+        args: [--py38-plus, --add-import, 'from __future__ import annotations']
+-   repo: https://github.com/asottile/add-trailing-comma
+    rev: v3.0.1
+    hooks:
+    -   id: add-trailing-comma
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py39-plus]
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+    -   id: flake8
+        additional_dependencies: [
+          flake8-bandit,
+          flake8-black,
+          flake8-debugger,
+          flake8-print,
+          flake8-use-fstring,
+          flake8-pyproject,
+        ]
+-   repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        language_version: python3.9
+-   repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black-jupyter
+        language_version: python3.9
+-   repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+    -   id: absolufy-imports

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The examples outlined in the next section how to get started with Open MatSci ML
 
 - `Docker`: We provide a Dockerfile inside the `docker` that can be run to install a container using standard docker commands.
 
-Additionally, for a development install, one can specify the extra packages like `black` and `pytest` with `pip install './[dev]'`.
+Additionally, for a development install, one can specify the extra packages like `black` and `pytest` with `pip install './[dev]'`. These can be
+added to the commit workflow by running `pre-commit install` to generate `git` hooks.
 
 ## Examples
 


### PR DESCRIPTION
This PR adds a `pre-commit` configuration file that can be installed with `pre-commit install`.

The commit workflow includes some specific style checks, such as trailing whitespace and catching debug statements and running `black`, as well as static checking with `flake8` including a stack of plugins like `bandit`.

Note that the whole repo doesn't actually conform with these specs right now: it should be done gradually and in a later PR.