### PR TITLE
Adding M3GNet from matgl 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@ logs
 *.traj
 experimental
 lightning_logs
-*.lmdb
-*.lmdb-lock
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,8 @@ logs
 *.traj
 experimental
 lightning_logs
-*commands*
-*kdp*
-
+*.lmdb
+*.lmdb-lock
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,12 @@ repos:
           flake8-pyproject,
         ]
 -   repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 22.3.1
     hooks:
       - id: black
         language_version: python3.9
 -   repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 22.3.1
     hooks:
       - id: black-jupyter
         language_version: python3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: debug-statements
+-   repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v2.4.0
+    hooks:
+    -   id: setup-cfg-fmt
+-   repo: https://github.com/asottile/reorder-python-imports
+    rev: v3.10.0
+    hooks:
+    -   id: reorder-python-imports
+        args: [--py38-plus, --add-import, 'from __future__ import annotations']
+-   repo: https://github.com/asottile/add-trailing-comma
+    rev: v3.0.1
+    hooks:
+    -   id: add-trailing-comma
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py39-plus]
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+    -   id: flake8
+        additional_dependencies: [
+          flake8-bandit,
+          flake8-black,
+          flake8-debugger,
+          flake8-print,
+          flake8-use-fstring,
+          flake8-pyproject,
+        ]
+-   repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        language_version: python3.9
+-   repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black-jupyter
+        language_version: python3.9
+-   repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+    -   id: absolufy-imports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ as they do not need to rely on framework abstractions to perform message passing
 to make model architectures as modular as possible, but we do not have any rigorous style enforcement
 for this type of model.
 
-### Datasets
+## Datasets
 - Dataset contributions should include a brief description of the dataset and its available fields.
 - Provide proper documentation on how to access, use, and understand the data.
 - Make sure to include data preprocessing scripts if applicable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to Open MatSciML Toolkit
+
+Thank you for considering a contribution to our project! We appreciate your support and collaboration in improving our software. To ensure that your contributions are valuable and well-structured, please follow the guidelines below:
+
+### Models
+- When contributing models, make sure they are well-documented with clear explanations and examples.
+- Include a README file with model specifications, training parameters, and any relevant information.
+- Code should be organized, well-commented, and follow the repository's coding style and conventions.
+- If the model depends on external data or dependencies, clearly specify these requirements.
+
+Models can come in two varieties, DGL and PyG. DGL based models generally will subclass the `BaseDGLModel` class while PyG uses `BaseModel`. 
+
+In DGL models, the `_forward` method should be defined which is used by the underlying task's standard `forward` method. Input data should match what is expected by the base task module:
+'''python
+    def _forward(
+        self,
+        graph: AbstractGraph,
+        node_feats: torch.Tensor,
+        pos: Optional[torch.Tensor] = None,
+        edge_feats: Optional[torch.Tensor] = None,
+        graph_feats: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Sets args/kwargs for the expected components of a graph-based
+        model. At the bare minimum, we expect some kind of abstract
+        graph structure, along with tensors of atomic coordinates and
+        numbers to process. Optionally, models can include edge and graph
+        features, but is left for concrete classes to implement how
+        these are obtained.
+
+        Parameters
+        ----------
+        graph : AbstractGraph
+            Graph structure implemented in a particular framework
+        node_feats : torch.Tensor
+            Atomic numbers or other featurizations, typically shape [N, ...] for N nuclei
+        pos : Optional[torch.Tensor]
+            Atom positions with shape [N, 3], by default None to make this optional
+            as some architectures may pass them as 'node_feats'
+        edge_feats : Optional[torch.Tensor], optional
+            Edge features to process, by default None
+        graph_feats : Optional[torch.Tensor], optional
+            Graph-level attributes/features to use, by default None
+
+        Returns
+        -------
+        torch.Tensor
+            Model output; either embedding or projected output
+        """
+'''
+
+Aside from implementing the `_forward` method of the model itself, the constituent building blocks should be broken up into their own files, respective to what their functions are. For example, layer based classes and utilities should be placed into a `layers.py` file, and other helpful functions can be placed in a `helper.py` or `utils.py` file. 
+
+Completed models can be added to the list of imports in `./matsciml/models/dgl/__init__.py`.
+
+### Datasets
+- Dataset contributions should include a brief description of the dataset and its available fields.
+- Provide proper documentation on how to access, use, and understand the data.
+- Make sure to include data preprocessing scripts if applicable.
+
+Adding a dataset usually involves interacting with an external API to query and download data. If this is the case, a separate `{dataset}_api.py` and `dataset.py` file can be used to separate out the functionalities. In the API file, a default query can be used to save data to lmdb files, and do any initial preprocessing necessary to get the data into a usable format. Keeping track of material ID's and the status of queries. 
+
+The main dataset file should take care of all of the loading, processing and collating needed to prepare data for the training pipeline. This typically involves adding the necessary key-value pairs which are expected, such as `atomic_numbers`, `pc_features`, and `targets`.
+
+The existing dataset's should be used as a template, and can be expanded upon depending on models needs.
+
+
+### Tests
+- Tests for new models and datasets should be added as necessary, following the conventions laid out for existing models and datasets.
+- Follow our testing framework and naming conventions.
+- Verify that all tests pass successfully before making a pull request.
+
+Tests for each new model and datasets should be added to their respective tests folder, and follow the conventions of the existing tests. Task specific tests may be added to the model folder itself. All relevant tests must pass in order for a pull request to be accepted and merged. 
+
+### General Guidelines
+- Make your code readable and maintainable. Use meaningful variable and function names.
+- Follow the coding standards and style guidelines set in the repository.
+- Include a clear and concise commit message that describes your changes.
+- Ensure that your code is free of linting errors and passes code formatting checks.
+- Keep your pull request focused and single-purpose. If you're addressing multiple issues, create separate pull requests for each.
+- Update documentation if your contribution adds or modifies features.
+
+Once you've prepared your contribution, please submit a pull request. Our team will review it, provide feedback if needed, and work with you to merge it into the project.
+
+We appreciate your dedication to making our project better and look forward to your contributions! If you have any questions or need assistance, feel free to reach out through the issue tracker or discussions section.
+
+Thank you for being a part of our open-source community!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ for a more complex case.
 
 ### PyG models
 
-Ideally, message passing layers implemented in PyG should inherit from the `MessagePassing` class, and implement
+Ideally, message passing layers implemented in PyG should inherit from the `torch_geometric.nn.MessagePassing` class, and implement
 the corresponding `message`, `propagate`, etc. functions as appropriate.
 
 ### Point cloud models

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,14 +11,24 @@ style consistency and run static code checkers such as `flake8` and `bandit`. Fo
 of code formatting. While not explicitly enforced, we highly encourage the use of type annotations for function arguments in addition
 to docstrings in NumPy style.
 
+## Models
 
-### Models
+At a high level, model implementations in Open MatSciML are expected to emit a system-level embedding; i.e. $B$
+vector embeddings with dimension $D$ for $B$ minibatch size, and $D$ some hyperparameter of your model, given
+some material structure comprising node, edge, and graph features.
+
 - When contributing models, make sure they are well-documented with clear explanations and examples.
 - Include a README file with model specifications, training parameters, and any relevant information.
 - Code should be organized, well-commented, and follow the repository's coding style and conventions.
 - If the model depends on external data or dependencies, clearly specify these requirements.
 
-Models can come in two varieties, DGL and PyG. DGL based models generally will subclass the `BaseDGLModel` class while PyG uses `BaseModel`. 
+While not compulsory, it is strongly recommended to inherit from one of the three abstract classes in `matsciml.models.base`
+depending on the type of data representation being used and backend: `AbstractPointCloudModel`, `AbstractDGLModel`, and
+`AbstractPyGModel`. The two main utilities of these classes are: (1) provide the same embedding table basis (e.g. for nodes
+and edges) for consistency, and (2) to abstract out common functions, particularly how to "read" data from the minibatches.
+As an example, DGL and PyG have different interfaces, and by inheriting from the right parent class, ensures that the correct
+features are mapped to the right arguments, etc. If your abstraction permits, the `_forward` method should be the only method
+you need to override.
 
 In DGL models, the `_forward` method should be defined which is used by the underlying task's standard `forward` method. Input data should match what is expected by the base task module:
 ```python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,9 @@ We recommend installing Open MatSciML Toolkit as an editable install with the re
 
 Additionally, we ask contributors to use our `pre-commit` workflow, which can be installed via `pre-commit install`, which helps enforce code
 style consistency and run static code checkers such as `flake8` and `bandit`. For the latter, we rely on `black` to do the vast majority
-of code formatting.
+of code formatting. While not explicitly enforced, we highly encourage the use of type annotations for function arguments in addition
+to docstrings in NumPy style.
+
 
 ### Models
 - When contributing models, make sure they are well-documented with clear explanations and examples.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,7 @@ to make model architectures as modular as possible, but we do not have any rigor
 for this type of model.
 
 ## Datasets
+
 - Dataset contributions should include a brief description of the dataset and its available fields.
 - Provide proper documentation on how to access, use, and understand the data.
 - Make sure to include data preprocessing scripts if applicable.
@@ -137,8 +138,8 @@ The main dataset file should take care of all of the loading, processing and col
 
 The existing dataset's should be used as a template, and can be expanded upon depending on models needs.
 
+## Tests
 
-### Tests
 - Tests for new models and datasets should be added as necessary, following the conventions laid out for existing models and datasets.
 - Follow our testing framework and naming conventions.
 - Verify that all tests pass successfully before making a pull request.
@@ -147,7 +148,8 @@ Tests for each new model and datasets should be added to their respective tests 
 
 Model tests may be added [here](https://github.com/IntelLabs/matsciml/tree/main/matsciml/models/dgl/tests), and dataset tests may be added to their respective dataset folders when created.
 
-### General Guidelines
+## General Guidelines
+
 - Make your code readable and maintainable. Use meaningful variable and function names.
 - Follow the coding standards and style guidelines set in the repository.
 - Include a clear and concise commit message that describes your changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for considering a contribution to our project! We appreciate your supp
 Models can come in two varieties, DGL and PyG. DGL based models generally will subclass the `BaseDGLModel` class while PyG uses `BaseModel`. 
 
 In DGL models, the `_forward` method should be defined which is used by the underlying task's standard `forward` method. Input data should match what is expected by the base task module:
-'''python
+```python
     def _forward(
         self,
         graph: AbstractGraph,
@@ -48,7 +48,12 @@ In DGL models, the `_forward` method should be defined which is used by the unde
         torch.Tensor
             Model output; either embedding or projected output
         """
-'''
+```
+
+In PyG, the `_forward` method takes only the `data` object:
+```python
+def _forward(self, data):
+```
 
 Aside from implementing the `_forward` method of the model itself, the constituent building blocks should be broken up into their own files, respective to what their functions are. For example, layer based classes and utilities should be placed into a `layers.py` file, and other helpful functions can be placed in a `helper.py` or `utils.py` file. 
 
@@ -72,6 +77,8 @@ The existing dataset's should be used as a template, and can be expanded upon de
 - Verify that all tests pass successfully before making a pull request.
 
 Tests for each new model and datasets should be added to their respective tests folder, and follow the conventions of the existing tests. Task specific tests may be added to the model folder itself. All relevant tests must pass in order for a pull request to be accepted and merged. 
+
+Model tests may be added [here](https://github.com/IntelLabs/matsciml/tree/main/matsciml/models/dgl/tests), and dataset tests may be added to their respective dataset folders when created.
 
 ### General Guidelines
 - Make your code readable and maintainable. Use meaningful variable and function names.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,8 @@ depending on the type of data representation being used and backend: `AbstractPo
 and edges) for consistency, and (2) to abstract out common functions, particularly how to "read" data from the minibatches.
 As an example, DGL and PyG have different interfaces, and by inheriting from the right parent class, ensures that the correct
 features are mapped to the right arguments, etc. If your abstraction permits, the `_forward` method should be the only method
-you need to override.
+you need to override:
 
-In DGL models, the `_forward` method should be defined which is used by the underlying task's standard `forward` method. Input data should match what is expected by the base task module:
 ```python
     def _forward(
         self,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,9 +105,26 @@ class AmazingModel(AbstractPyGModel):
         return graph_feats
 ```
 
-Aside from implementing the `_forward` method of the model itself, the constituent building blocks should be broken up into their own files, respective to what their functions are. For example, layer based classes and utilities should be placed into a `layers.py` file, and other helpful functions can be placed in a `helper.py` or `utils.py` file. 
+### DGL models
 
-Completed models can be added to the list of imports in `./matsciml/models/dgl/__init__.py`.
+DGL does not provide a class to inherit from for the message passing step, and instead, relies
+on users to define user-defined functions (`udf`), and extensive use of graph scopes. 
+
+We recommend reviewing the [MPNN](https://github.com/IntelLabs/matsciml/blob/main/matsciml/models/dgl/mpnn.py) wrapper
+to see a simplified case, and the [MegNet](https://github.com/IntelLabs/matsciml/tree/main/matsciml/models/dgl/megnet) implementation
+for a more complex case.
+
+### PyG models
+
+Ideally, message passing layers implemented in PyG should inherit from the `MessagePassing` class, and implement
+the corresponding `message`, `propagate`, etc. functions as appropriate.
+
+### Point cloud models
+
+Models that operate on point clouds directly are not necessarily as complex as graph architectures,
+as they do not need to rely on framework abstractions to perform message passing. Tt is still best
+to make model architectures as modular as possible, but we do not have any rigorous style enforcement
+for this type of model.
 
 ### Datasets
 - Dataset contributions should include a brief description of the dataset and its available fields.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ Thank you for considering a contribution to our project! We appreciate your supp
 
 We recommend installing Open MatSciML Toolkit as an editable install with the relevant development dependencies using `pip install -e './[dev]'`.
 
+Additionally, we ask contributors to use our `pre-commit` workflow, which can be installed via `pre-commit install`, which helps enforce code
+style consistency and run static code checkers such as `flake8` and `bandit`. For the latter, we rely on `black` to do the vast majority
+of code formatting.
+
 ### Models
 - When contributing models, make sure they are well-documented with clear explanations and examples.
 - Include a README file with model specifications, training parameters, and any relevant information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,16 @@ you need to override:
         """
 ```
 
-In PyG, the `_forward` method takes only the `data` object:
+The `**kwargs` ensures that any additional variables that are not required by your architecture (for example graph features)
+are not needed as explicit arguments.
+
+If variables/features are required by the model, one can override the `read_batch` method. See the [MPNN](https://github.com/IntelLabs/matsciml/blob/main/matsciml/models/dgl/mpnn.py)
+wrapper to see how this pattern can be used to check for data within a batch.
+
+Aside from implementing the `_forward` method of the model itself, the constituent building blocks should be broken up into their own files, respective to what their functions are. For example, layer based classes and utilities should be placed into a `layers.py` file, and other helpful functions can be placed in a `helper.py` or `utils.py` file. 
+
+Completed models can be added to the list of imports in `./matsciml/models/<framework>/__init__.py`, where `<framework>` can be `dgl` or `pyg`.
+
 ```python
 def _forward(self, data):
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Thank you for considering a contribution to our project! We appreciate your support and collaboration in improving our software. To ensure that your contributions are valuable and well-structured, please follow the guidelines below:
 
+## Environment
+
+We recommend installing Open MatSciML Toolkit as an editable install with the relevant development dependencies using `pip install -e './[dev]'`.
+
 ### Models
 - When contributing models, make sure they are well-documented with clear explanations and examples.
 - Include a README file with model specifications, training parameters, and any relevant information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,8 @@ Model tests may be added [here](https://github.com/IntelLabs/matsciml/tree/main/
 
 Once you've prepared your contribution, please submit a pull request. Our team will review it, provide feedback if needed, and work with you to merge it into the project.
 
+__If it is your first pull request, please ensure you add your name to the [contributors list](./CONTRIBUTORS.md)!__
+
 We appreciate your dedication to making our project better and look forward to your contributions! If you have any questions or need assistance, feel free to reach out through the issue tracker or discussions section.
 
 Thank you for being a part of our open-source community!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,7 @@ Model tests may be added [here](https://github.com/IntelLabs/matsciml/tree/main/
 - Ensure that your code is free of linting errors and passes code formatting checks.
 - Keep your pull request focused and single-purpose. If you're addressing multiple issues, create separate pull requests for each.
 - Update documentation if your contribution adds or modifies features.
+- Use informative type annotations: there are some defined in `matsciml.common.types` that help express what the intended inputs are.
 
 Once you've prepared your contribution, please submit a pull request. Our team will review it, provide feedback if needed, and work with you to merge it into the project.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,13 @@
+# Contributors
+
+Here we list, in alphabetical order, people who have contributed (not just code) to the past and present of Open MatSciML Toolkit:
+
+- Michael Galkin (@migalkin)
+- Carmelo Gonzales (@melo-gonzo)
+- Kin Long Kelvin Lee (@laserkelvin)
+- Santiago Miret (@smiret-intel)
+- Marcel Nassar (@marcel-n)
+- Krzysztof Sadowski (@ksadowski13)
+- Matthew Spellings (@klarh)
+
+If you have submitted a pull request with code contributions, please add your name above as part of your PR!

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The examples outlined in the next section how to get started with Open MatSci ML
 
 - `Docker`: We provide a Dockerfile inside the `docker` that can be run to install a container using standard docker commands.
 
-Additionally, for a development install, one can specify the extra packages like `black` and `pytest` with `pip install './[dev]'`.
+Additionally, for a development install, one can specify the extra packages like `black` and `pytest` with `pip install './[dev]'`. These can be
+added to the commit workflow by running `pre-commit install` to generate `git` hooks.
 
 ## Examples
 

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -1,14 +1,12 @@
 from typing import Union, List, Any, Callable, Optional, Dict
 from pathlib import Path
-import dgl
-import torch
 
 import pytorch_lightning as pl
 from matgl.ext.pymatgen import Structure2Graph
 from matgl.graph.data import M3GNetDataset
-from matgl.models import M3GNet
 from pymatgen.core import Structure
 
+from matsciml.models import M3GNet
 from matsciml.common.registry import registry
 from matsciml.datasets.materials_project import MaterialsProjectDataset
 from matsciml.lightning.data_utils import MatSciMLDataModule
@@ -36,12 +34,14 @@ class M3Dataset(MaterialsProjectDataset):
         self,
         lmdb_root_path: Union[str, Path],
         threebody_cutoff: float = 4.0,
+        cutoff_dist: float = 20.0,
         graph_labels: Union[list[Union[int, float]], None] = None,
         transforms: Optional[List[Callable[..., Any]]] = None,
     ):
         super().__init__(lmdb_root_path, transforms)
         self.threebody_cutoff = threebody_cutoff
         self.graph_labels = graph_labels
+        self.cutoff_dist = cutoff_dist
 
     def _parse_structure(
         self, data: Dict[str, Any], return_dict: Dict[str, Any]
@@ -50,24 +50,11 @@ class M3Dataset(MaterialsProjectDataset):
         structure: Union[None, Structure] = data.get("structure", None)
         self.structures = [structure]
         self.converter = Structure2Graph(
-            element_types=list(self.atomic_number_map.keys()), cutoff=5.0
+            element_types=element_types, cutoff=self.cutoff_dist
         )
         graphs, lg, sa = M3GNetDataset.process(self)
         return_dict["graph"] = graphs[0]
 
-
-def forward(
-    self,
-    g: dgl.DGLGraph,
-    state_attr: Union[torch.Tensor, None] = None,
-    l_g: Union[dgl.DGLGraph, None] = None,
-):
-    g = g["graph"]
-    return self.m3gnet_forward(g, state_attr, l_g)
-
-
-M3GNet.m3gnet_forward = M3GNet.forward
-M3GNet.forward = forward
 
 # construct a scalar regression task with SchNet encoder
 task = ScalarRegressionTask(

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -47,7 +47,6 @@ task = ScalarRegressionTask(
     encoder_class=M3GNet,
     encoder_kwargs={
         "element_types": element_types,
-        "encoder_only": False,
     },
     task_keys=["band_gap"],
 )

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -1,57 +1,22 @@
-from typing import Union, List, Any, Callable, Optional, Dict
-from pathlib import Path
-
 import pytorch_lightning as pl
-from matgl.ext.pymatgen import Structure2Graph
-from matgl.graph.data import M3GNetDataset
-from pymatgen.core import Structure
 
-from matsciml.models import M3GNet
-from matsciml.models.dgl.m3gnet import element_types
-from matsciml.common.registry import registry
-from matsciml.datasets.materials_project import MaterialsProjectDataset
+from matsciml.datasets.utils import element_types
 from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models import M3GNet
 from matsciml.models.base import ScalarRegressionTask
-
-
-@registry.register_dataset("M3Dataset")
-class M3Dataset(MaterialsProjectDataset):
-    def __init__(
-        self,
-        lmdb_root_path: Union[str, Path],
-        threebody_cutoff: float = 4.0,
-        cutoff_dist: float = 20.0,
-        graph_labels: Union[list[Union[int, float]], None] = None,
-        transforms: Optional[List[Callable[..., Any]]] = None,
-    ):
-        super().__init__(lmdb_root_path, transforms)
-        self.threebody_cutoff = threebody_cutoff
-        self.graph_labels = graph_labels
-        self.cutoff_dist = cutoff_dist
-
-    def _parse_structure(
-        self, data: Dict[str, Any], return_dict: Dict[str, Any]
-    ) -> None:
-        super()._parse_structure(data, return_dict)
-        structure: Union[None, Structure] = data.get("structure", None)
-        self.structures = [structure]
-        self.converter = Structure2Graph(
-            element_types=element_types, cutoff=self.cutoff_dist
-        )
-        graphs, lg, sa = M3GNetDataset.process(self)
-        return_dict["graph"] = graphs[0]
-
 
 # construct a scalar regression task with SchNet encoder
 task = ScalarRegressionTask(
     encoder_class=M3GNet,
     encoder_kwargs={
-        "element_types": element_types,
+        "element_types": element_types(),
     },
-    task_keys=["band_gap"],
+    task_keys=["energy_total"],
 )
 
-dm = MatSciMLDataModule.from_devset("M3Dataset", num_workers=0, batch_size=4)
+dm = MatSciMLDataModule.from_devset(
+    "M3GNomadDataset", num_workers=0, batch_size=4
+)
 
 # run a quick training loop
 trainer = pl.Trainer(fast_dev_run=10)

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -7,25 +7,11 @@ from matgl.graph.data import M3GNetDataset
 from pymatgen.core import Structure
 
 from matsciml.models import M3GNet
+from matsciml.models.dgl.m3gnet import element_types
 from matsciml.common.registry import registry
 from matsciml.datasets.materials_project import MaterialsProjectDataset
 from matsciml.lightning.data_utils import MatSciMLDataModule
 from matsciml.models.base import ScalarRegressionTask
-
-# fmt: off
-element_types = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 
-                'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 
-                'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 
-                'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr', 'Nb', 
-                'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn', 'Sb', 
-                'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm', 
-                'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu', 
-                'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 
-                'Pb', 'Bi', 'Po', 'At', 'Rn', 'Fr', 'Ra', 'Ac', 'Th', 'Pa', 
-                'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 
-                'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 
-                'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og']
-# fmt: on
 
 
 @registry.register_dataset("M3Dataset")

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -1,33 +1,85 @@
+from typing import Union, List, Any, Callable, Optional, Dict
+from pathlib import Path
+import dgl
+import torch
+
 import pytorch_lightning as pl
-
-from matsciml.models.base import ScalarRegressionTask
-from matsciml.lightning.data_utils import MatSciMLDataModule
-from matsciml.datasets.transforms import PointCloudToGraphTransform
-
+from matgl.ext.pymatgen import Structure2Graph
+from matgl.graph.data import M3GNetDataset
 from matgl.models import M3GNet
+from pymatgen.core import Structure
 
+from matsciml.common.registry import registry
+from matsciml.datasets.materials_project import MaterialsProjectDataset
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models.base import ScalarRegressionTask
+
+# fmt: off
+element_types = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 
+                'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 
+                'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 
+                'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr', 'Nb', 
+                'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn', 'Sb', 
+                'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm', 
+                'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu', 
+                'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 
+                'Pb', 'Bi', 'Po', 'At', 'Rn', 'Fr', 'Ra', 'Ac', 'Th', 'Pa', 
+                'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 
+                'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 
+                'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og']
+# fmt: on
+
+
+@registry.register_dataset("M3Dataset")
+class M3Dataset(MaterialsProjectDataset):
+    def __init__(
+        self,
+        lmdb_root_path: Union[str, Path],
+        threebody_cutoff: float = 4.0,
+        graph_labels: Union[list[Union[int, float]], None] = None,
+        transforms: Optional[List[Callable[..., Any]]] = None,
+    ):
+        super().__init__(lmdb_root_path, transforms)
+        self.threebody_cutoff = threebody_cutoff
+        self.graph_labels = graph_labels
+
+    def _parse_structure(
+        self, data: Dict[str, Any], return_dict: Dict[str, Any]
+    ) -> None:
+        super()._parse_structure(data, return_dict)
+        structure: Union[None, Structure] = data.get("structure", None)
+        self.structures = [structure]
+        self.converter = Structure2Graph(
+            element_types=list(self.atomic_number_map.keys()), cutoff=5.0
+        )
+        graphs, lg, sa = M3GNetDataset.process(self)
+        return_dict["graph"] = graphs[0]
+
+
+def forward(
+    self,
+    g: dgl.DGLGraph,
+    state_attr: Union[torch.Tensor, None] = None,
+    l_g: Union[dgl.DGLGraph, None] = None,
+):
+    g = g["graph"]
+    return self.m3gnet_forward(g, state_attr, l_g)
+
+
+M3GNet.m3gnet_forward = M3GNet.forward
+M3GNet.forward = forward
 
 # construct a scalar regression task with SchNet encoder
 task = ScalarRegressionTask(
     encoder_class=M3GNet,
     encoder_kwargs={
-        "encoder_only": True,
+        "element_types": element_types,
+        "encoder_only": False,
     },
-    output_kwargs={"lazy": False, "input_dim": 64},
     task_keys=["band_gap"],
 )
-# Materials Project data needs the PointCloudToGraphTransform when using DGL.
-dm = MatSciMLDataModule.from_devset(
-    "MaterialsProjectDataset",
-    dset_kwargs={
-        "transforms": [
-            PointCloudToGraphTransform(
-                "dgl", cutoff_dist=20.0, node_keys=["pos", "atomic_numbers"]
-            )
-        ]
-    },
-    num_workers=0,
-)
+
+dm = MatSciMLDataModule.from_devset("M3Dataset", num_workers=0, batch_size=4)
 
 # run a quick training loop
 trainer = pl.Trainer(fast_dev_run=10)

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -1,0 +1,34 @@
+import pytorch_lightning as pl
+
+from matsciml.models.base import ScalarRegressionTask
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.datasets.transforms import PointCloudToGraphTransform
+
+from matgl.models import M3GNet
+
+
+# construct a scalar regression task with SchNet encoder
+task = ScalarRegressionTask(
+    encoder_class=M3GNet,
+    encoder_kwargs={
+        "encoder_only": True,
+    },
+    output_kwargs={"lazy": False, "input_dim": 64},
+    task_keys=["band_gap"],
+)
+# Materials Project data needs the PointCloudToGraphTransform when using DGL.
+dm = MatSciMLDataModule.from_devset(
+    "MaterialsProjectDataset",
+    dset_kwargs={
+        "transforms": [
+            PointCloudToGraphTransform(
+                "dgl", cutoff_dist=20.0, node_keys=["pos", "atomic_numbers"]
+            )
+        ]
+    },
+    num_workers=0,
+)
+
+# run a quick training loop
+trainer = pl.Trainer(fast_dev_run=10)
+trainer.fit(task, datamodule=dm)

--- a/matsciml/datasets/carolina_db/dataset.py
+++ b/matsciml/datasets/carolina_db/dataset.py
@@ -1,22 +1,19 @@
-from copy import deepcopy
-from functools import cached_property
 from math import pi
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from emmet.core.symmetry import SymmetryData
-from pymatgen.core import Structure
+from matgl.ext.pymatgen import Structure2Graph
+from matgl.graph.data import M3GNetDataset
+from pymatgen.core import Lattice, Structure
 
 from matsciml.common.registry import registry
 from matsciml.common.types import BatchDict, DataDict
 from matsciml.datasets.base import PointCloudDataset
-from matsciml.datasets.utils import (
-    concatenate_keys,
-    pad_point_cloud,
-    point_cloud_featurization,
-)
+from matsciml.datasets.utils import (atomic_number_map, concatenate_keys,
+                                     element_types, pad_point_cloud,
+                                     point_cloud_featurization)
 
 
 @registry.register_dataset("CMDataset")
@@ -172,3 +169,40 @@ class CMDataset(PointCloudDataset):
         else:
             # for scalars, just return the value
             return value
+
+
+@registry.register_dataset("M3GCMDataset")
+class M3GCMDataset(CMDataset):
+    def __init__(
+        self,
+        lmdb_root_path: Union[str, Path],
+        threebody_cutoff: float = 4.0,
+        cutoff_dist: float = 20.0,
+        graph_labels: Union[list[Union[int, float]], None] = None,
+        transforms: Optional[List[Callable[..., Any]]] = None,
+    ):
+        super().__init__(lmdb_root_path, transforms)
+        self.threebody_cutoff = threebody_cutoff
+        self.graph_labels = graph_labels
+        self.cutoff_dist = cutoff_dist
+
+    def data_from_key(self, lmdb_index: int, subindex: int) -> Any:
+        return_dict = super().data_from_key(lmdb_index, subindex)
+        a, b, c, alpha, beta, gamma = return_dict["lattice_params"]
+        num_to_element = dict(
+            zip(atomic_number_map().values(), atomic_number_map().keys())
+        )
+        elements = [
+            num_to_element[int(idx.item())] for idx in return_dict["atomic_numbers"]
+        ]
+        lattice = Lattice.from_parameters(
+            a, b, c, alpha * 180 / pi, beta * 180 / pi, gamma * 180 / pi
+        )
+        structure = Structure(lattice, elements, return_dict["pos"])
+        self.structures = [structure]
+        self.converter = Structure2Graph(
+            element_types=element_types(), cutoff=self.cutoff_dist
+        )
+        graphs, lg, sa = M3GNetDataset.process(self)
+        return_dict["graph"] = graphs[0]
+        return return_dict

--- a/matsciml/datasets/materials_project/dataset.py
+++ b/matsciml/datasets/materials_project/dataset.py
@@ -79,36 +79,6 @@ class MaterialsProjectDataset(PointCloudDataset):
             2-tuple of LMDB index and subindex
         """
         return (0, index)
-    
-    @cached_property
-    def atomic_number_map(self) -> Dict[str, int]:
-        """List of element symbols and their atomic numbers.
-
-        Returns:
-            Dict[str, int]: _description_
-        """
-        # fmt: off
-        an_map = {'H': 1, 'He': 2, 'Li': 3, 'Be': 4, 'B': 5, 'C': 6, 'N': 7, 'O': 8, 
-              'F': 9, 'Ne': 10, 'Na': 11, 'Mg': 12, 'Al': 13, 'Si': 14, 'P': 15, 
-              'S': 16, 'Cl': 17, 'Ar': 18, 'K': 19, 'Ca': 20, 'Sc': 21, 'Ti': 22, 
-              'V': 23, 'Cr': 24, 'Mn': 25, 'Fe': 26, 'Co': 27, 'Ni': 28, 'Cu': 29, 
-              'Zn': 30, 'Ga': 31, 'Ge': 32, 'As': 33, 'Se': 34, 'Br': 35, 'Kr': 36, 
-              'Rb': 37, 'Sr': 38, 'Y': 39, 'Zr': 40, 'Nb': 41, 'Mo': 42, 'Tc': 43, 
-              'Ru': 44, 'Rh': 45, 'Pd': 46, 'Ag': 47, 'Cd': 48, 'In': 49, 'Sn': 50, 
-              'Sb': 51, 'Te': 52, 'I': 53, 'Xe': 54, 'Cs': 55, 'Ba': 56, 'La': 57, 
-              'Ce': 58, 'Pr': 59, 'Nd': 60, 'Pm': 61, 'Sm': 62, 'Eu': 63, 'Gd': 64, 
-              'Tb': 65, 'Dy': 66, 'Ho': 67, 'Er': 68, 'Tm': 69, 'Yb': 70, 'Lu': 71, 
-              'Hf': 72, 'Ta': 73, 'W': 74, 'Re': 75, 'Os': 76, 'Ir': 77, 'Pt': 78, 
-              'Au': 79, 'Hg': 80, 'Tl': 81, 'Pb': 82, 'Bi': 83, 'Po': 84, 'At': 85, 
-              'Rn': 86, 'Fr': 87, 'Ra': 88, 'Ac': 89, 'Th': 90, 'Pa': 91, 'U': 92, 
-              'Np': 93, 'Pu': 94, 'Am': 95, 'Cm': 96, 'Bk': 97, 'Cf': 98, 'Es': 99, 
-              'Fm': 100, 'Md': 101, 'No': 102, 'Lr': 103, 'Rf': 104, 'Db': 105, 
-              'Sg': 106, 'Bh': 107, 'Hs': 108, 'Mt': 109, 'Ds': 110, 'Rg': 111, 
-              'Cn': 112, 'Nh': 113, 'Fl': 114, 'Mc': 115, 'Lv': 116, 'Ts': 117, 
-              'Og': 118}
-        # fmt: on
-        return an_map
-
 
     def _parse_structure(
         self, data: Dict[str, Any], return_dict: Dict[str, Any]
@@ -167,26 +137,6 @@ class MaterialsProjectDataset(PointCloudDataset):
             "lattice_params": lattice_params,
         }
         return_dict["lattice_features"] = lattice_features
-    
-        
-        # from matgl.graph.data import M3GNetDataset, MGLDataLoader, collate_fn_efs
-        # from matgl.ext.pymatgen import Structure2Graph
-
-        # self.structures = [structure]
-        # self.converter = Structure2Graph(element_types=list(self.atomic_number_map.keys()), cutoff=5.0)
-        # self.threebody_cutoff = 4.0
-        # self.graph_labels = None
-        # graphs, lg, sa = M3GNetDataset.process(self)
-        import pdb; pdb.set_trace()
-        src_id, dst_id, images, bond_dist = find_points_in_spheres(
-            coords.to(torch.double).numpy(),
-            coords.to(torch.double).numpy(),
-            r=5.0,
-            pbc=np.array([1, 1, 1], dtype=int),
-            lattice=structure.lattice.matrix,
-            tol=10e-8,
-        )
-        a = 1
 
     def _parse_symmetry(
         self, data: Dict[str, Any], return_dict: Dict[str, Any]

--- a/matsciml/datasets/materials_project/dataset.py
+++ b/matsciml/datasets/materials_project/dataset.py
@@ -1,27 +1,26 @@
-from functools import cached_property
-from typing import Iterable, Tuple, Any, Dict, Union, Optional, List, Callable
-from pathlib import Path
-from math import pi
-from copy import deepcopy
-from functools import cache
-from tqdm import tqdm
-from importlib.util import find_spec
-
-import torch
-import numpy as np
 import pickle
-from pymatgen.core import Structure
-from pymatgen.analysis.graphs import StructureGraph
-from pymatgen.analysis import local_env
-from emmet.core.symmetry import SymmetryData
-from matsciml.common.types import BatchDict, DataDict
+from copy import deepcopy
+from functools import cache, cached_property
+from importlib.util import find_spec
+from math import pi
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
-from matsciml.datasets.base import PointCloudDataset
-from matsciml.datasets.utils import (
-    concatenate_keys,
-    point_cloud_featurization,
-)
+import numpy as np
+import torch
+from emmet.core.symmetry import SymmetryData
+from matgl.ext.pymatgen import Structure2Graph
+from matgl.graph.data import M3GNetDataset
+from pymatgen.analysis import local_env
+from pymatgen.analysis.graphs import StructureGraph
+from pymatgen.core import Structure
+from tqdm import tqdm
+
 from matsciml.common.registry import registry
+from matsciml.common.types import BatchDict, DataDict
+from matsciml.datasets.base import PointCloudDataset
+from matsciml.datasets.utils import (concatenate_keys, element_types,
+                                     point_cloud_featurization)
 
 _has_pyg = find_spec("torch_geometric") is not None
 
@@ -329,7 +328,7 @@ class MaterialsProjectDataset(PointCloudDataset):
 
 
 if _has_pyg:
-    from torch_geometric.data import Data, Batch
+    from torch_geometric.data import Batch, Data
 
     CrystalNN = local_env.CrystalNN(
         distance_cutoffs=None, x_diff_weight=-1, porous_adjustment=False
@@ -633,3 +632,31 @@ if _has_pyg:
                         [(lmdb_index, int(subindex)) for subindex in subindices]
                     )
             return indices
+
+
+@registry.register_dataset("M3GMaterialsProjectDataset")
+class M3GMaterialsProjectDataset(MaterialsProjectDataset):
+    def __init__(
+        self,
+        lmdb_root_path: Union[str, Path],
+        threebody_cutoff: float = 4.0,
+        cutoff_dist: float = 20.0,
+        graph_labels: Union[list[Union[int, float]], None] = None,
+        transforms: Optional[List[Callable[..., Any]]] = None,
+    ):
+        super().__init__(lmdb_root_path, transforms)
+        self.threebody_cutoff = threebody_cutoff
+        self.graph_labels = graph_labels
+        self.cutoff_dist = cutoff_dist
+
+    def _parse_structure(
+        self, data: Dict[str, Any], return_dict: Dict[str, Any]
+    ) -> None:
+        super()._parse_structure(data, return_dict)
+        structure: Union[None, Structure] = data.get("structure", None)
+        self.structures = [structure]
+        self.converter = Structure2Graph(
+            element_types=element_types(), cutoff=self.cutoff_dist
+        )
+        graphs, lg, sa = M3GNetDataset.process(self)
+        return_dict["graph"] = graphs[0]

--- a/matsciml/datasets/materials_project/dataset.py
+++ b/matsciml/datasets/materials_project/dataset.py
@@ -79,6 +79,36 @@ class MaterialsProjectDataset(PointCloudDataset):
             2-tuple of LMDB index and subindex
         """
         return (0, index)
+    
+    @cached_property
+    def atomic_number_map(self) -> Dict[str, int]:
+        """List of element symbols and their atomic numbers.
+
+        Returns:
+            Dict[str, int]: _description_
+        """
+        # fmt: off
+        an_map = {'H': 1, 'He': 2, 'Li': 3, 'Be': 4, 'B': 5, 'C': 6, 'N': 7, 'O': 8, 
+              'F': 9, 'Ne': 10, 'Na': 11, 'Mg': 12, 'Al': 13, 'Si': 14, 'P': 15, 
+              'S': 16, 'Cl': 17, 'Ar': 18, 'K': 19, 'Ca': 20, 'Sc': 21, 'Ti': 22, 
+              'V': 23, 'Cr': 24, 'Mn': 25, 'Fe': 26, 'Co': 27, 'Ni': 28, 'Cu': 29, 
+              'Zn': 30, 'Ga': 31, 'Ge': 32, 'As': 33, 'Se': 34, 'Br': 35, 'Kr': 36, 
+              'Rb': 37, 'Sr': 38, 'Y': 39, 'Zr': 40, 'Nb': 41, 'Mo': 42, 'Tc': 43, 
+              'Ru': 44, 'Rh': 45, 'Pd': 46, 'Ag': 47, 'Cd': 48, 'In': 49, 'Sn': 50, 
+              'Sb': 51, 'Te': 52, 'I': 53, 'Xe': 54, 'Cs': 55, 'Ba': 56, 'La': 57, 
+              'Ce': 58, 'Pr': 59, 'Nd': 60, 'Pm': 61, 'Sm': 62, 'Eu': 63, 'Gd': 64, 
+              'Tb': 65, 'Dy': 66, 'Ho': 67, 'Er': 68, 'Tm': 69, 'Yb': 70, 'Lu': 71, 
+              'Hf': 72, 'Ta': 73, 'W': 74, 'Re': 75, 'Os': 76, 'Ir': 77, 'Pt': 78, 
+              'Au': 79, 'Hg': 80, 'Tl': 81, 'Pb': 82, 'Bi': 83, 'Po': 84, 'At': 85, 
+              'Rn': 86, 'Fr': 87, 'Ra': 88, 'Ac': 89, 'Th': 90, 'Pa': 91, 'U': 92, 
+              'Np': 93, 'Pu': 94, 'Am': 95, 'Cm': 96, 'Bk': 97, 'Cf': 98, 'Es': 99, 
+              'Fm': 100, 'Md': 101, 'No': 102, 'Lr': 103, 'Rf': 104, 'Db': 105, 
+              'Sg': 106, 'Bh': 107, 'Hs': 108, 'Mt': 109, 'Ds': 110, 'Rg': 111, 
+              'Cn': 112, 'Nh': 113, 'Fl': 114, 'Mc': 115, 'Lv': 116, 'Ts': 117, 
+              'Og': 118}
+        # fmt: on
+        return an_map
+
 
     def _parse_structure(
         self, data: Dict[str, Any], return_dict: Dict[str, Any]
@@ -137,6 +167,26 @@ class MaterialsProjectDataset(PointCloudDataset):
             "lattice_params": lattice_params,
         }
         return_dict["lattice_features"] = lattice_features
+    
+        
+        # from matgl.graph.data import M3GNetDataset, MGLDataLoader, collate_fn_efs
+        # from matgl.ext.pymatgen import Structure2Graph
+
+        # self.structures = [structure]
+        # self.converter = Structure2Graph(element_types=list(self.atomic_number_map.keys()), cutoff=5.0)
+        # self.threebody_cutoff = 4.0
+        # self.graph_labels = None
+        # graphs, lg, sa = M3GNetDataset.process(self)
+        import pdb; pdb.set_trace()
+        src_id, dst_id, images, bond_dist = find_points_in_spheres(
+            coords.to(torch.double).numpy(),
+            coords.to(torch.double).numpy(),
+            r=5.0,
+            pbc=np.array([1, 1, 1], dtype=int),
+            lattice=structure.lattice.matrix,
+            tol=10e-8,
+        )
+        a = 1
 
     def _parse_symmetry(
         self, data: Dict[str, Any], return_dict: Dict[str, Any]

--- a/matsciml/datasets/oqmd/dataset.py
+++ b/matsciml/datasets/oqmd/dataset.py
@@ -1,22 +1,18 @@
-from copy import deepcopy
-from functools import cached_property
-from math import pi
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from emmet.core.symmetry import SymmetryData
-from pymatgen.core import Structure
+from matgl.ext.pymatgen import Structure2Graph
+from matgl.graph.data import M3GNetDataset
+from pymatgen.core import Lattice, Structure
 
 from matsciml.common.registry import registry
 from matsciml.common.types import BatchDict, DataDict
 from matsciml.datasets.base import PointCloudDataset
-from matsciml.datasets.utils import (
-    concatenate_keys,
-    pad_point_cloud,
-    point_cloud_featurization,
-)
+from matsciml.datasets.utils import (atomic_number_map, concatenate_keys,
+                                     element_types, pad_point_cloud,
+                                     point_cloud_featurization)
 
 
 @registry.register_dataset("OQMDDataset")
@@ -72,12 +68,12 @@ class OQMDDataset(PointCloudDataset):
         Dict[str, Union[Dict[str, torch.Tensor], torch.Tensor]]
             output data that is used during training
         """
-
         data = super().data_from_key(lmdb_index, subindex)
         return_dict = {}
         # coordinates remains the original particle positions
         coords = torch.tensor(data["cart_coords"])
         return_dict["pos"] = coords
+        unit_cell = data['unit_cell']
         system_size = coords.size(0)
         node_choices = self.choose_dst_nodes(system_size, self.full_pairwise)
         src_nodes, dst_nodes = node_choices["src_nodes"], node_choices["dst_nodes"]
@@ -89,6 +85,7 @@ class OQMDDataset(PointCloudDataset):
         return_dict["atomic_numbers"] = atom_numbers
         return_dict["pc_features"] = pc_features
         return_dict["sizes"] = system_size
+        return_dict["unit_cell"] = unit_cell
         return_dict.update(**node_choices)
 
         # delta_e is formation energy
@@ -166,3 +163,72 @@ class OQMDDataset(PointCloudDataset):
         else:
             # for scalars, just return the value
             return value
+
+
+@registry.register_dataset("OQMDM3GNetDataset")
+class OQMDM3GNetDataset(OQMDDataset):
+    def __init__(
+        self,
+        lmdb_root_path: Union[str, Path],
+        threebody_cutoff: float = 4.0,
+        cutoff_dist: float = 20.0,
+        graph_labels: Union[list[Union[int, float]], None] = None,
+        transforms: Optional[List[Callable[..., Any]]] = None,
+    ):
+        super().__init__(lmdb_root_path, transforms)
+        self.threebody_cutoff = threebody_cutoff
+        self.graph_labels = graph_labels
+        self.cutoff_dist = cutoff_dist
+
+    def data_from_key(self, lmdb_index: int, subindex: int) -> Any:
+        return_dict = super().data_from_key(lmdb_index, subindex)
+        num_to_element = dict(
+            zip(atomic_number_map().values(), atomic_number_map().keys())
+        )
+        elements = [
+            num_to_element[int(idx.item())] for idx in return_dict["atomic_numbers"]
+        ]
+        a, b, c, alpha, beta, gamma = self.basis_to_latparams(return_dict['unit_cell'])
+        lattice = Lattice.from_parameters(a, b, c, alpha, beta, gamma)
+        structure = Structure(lattice, elements, return_dict["pos"])
+        self.structures = [structure]
+        self.converter = Structure2Graph(
+            element_types=element_types(), cutoff=self.cutoff_dist
+        )
+        graphs, lg, sa = M3GNetDataset.process(self)
+        return_dict["graph"] = graphs[0]
+        return return_dict
+
+    def angle(self, x, y, radians=False):
+        """Return the angle between two lattice vectors
+
+        Examples:
+        >>> angle([1,0,0], [0,1,0])
+        90.0
+        """
+        if radians:
+            return np.arccos(np.dot(x, y) / (np.linalg.norm(x) * np.linalg.norm(y)))
+        else:
+            return (
+                np.arccos(np.dot(x, y) / (np.linalg.norm(x) * np.linalg.norm(y)))
+                * 180.0
+                / np.pi
+            )
+
+    def basis_to_latparams(self, basis, radians=False):
+        """Returns the lattice parameters [a, b, c, alpha, beta, gamma].
+
+        Example:
+
+        >>> basis_to_latparams([[3,0,0],[0,3,0],[0,0,5]])
+        [3, 3, 5, 90, 90, 90]
+        """
+
+        va, vb, vc = basis
+        a = np.linalg.norm(va)
+        b = np.linalg.norm(vb)
+        c = np.linalg.norm(vc)
+        alpha = self.angle(vb, vc, radians=radians)
+        beta = self.angle(vc, va, radians=radians)
+        gamma = self.angle(va, vb, radians=radians)
+        return [a, b, c, alpha, beta, gamma]

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -1,24 +1,25 @@
-from typing import List, Dict, Any, Union, Tuple, Optional, Callable, Generator
-from pathlib import Path
-from functools import partial
-import torch
-from torch.nn.utils.rnn import pad_sequence
-import lmdb
 import pickle
-from tqdm import tqdm
-from joblib import Parallel, delayed
+from functools import lru_cache, partial
 from os import makedirs
+from pathlib import Path
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
-from matsciml.common.types import DataDict, BatchDict, GraphTypes
+import lmdb
+import torch
+from joblib import Parallel, delayed
+from torch.nn.utils.rnn import pad_sequence
+from tqdm import tqdm
+
 from matsciml.common import package_registry
+from matsciml.common.types import BatchDict, DataDict, GraphTypes
 
 if package_registry["dgl"]:
     import dgl
 
 if package_registry["pyg"]:
     import torch_geometric
-    from torch_geometric.data import Data as PyGGraph
     from torch_geometric.data import Batch as PyGBatch
+    from torch_geometric.data import Data as PyGGraph
 
 
 def concatenate_keys(
@@ -543,3 +544,38 @@ def retrieve_pointcloud_node_types(pc_feats: torch.Tensor) -> Tuple[torch.Tensor
     src_types = pc_feats.sum(dim=1).argmax(-1)
     dst_types = pc_feats.sum(dim=0).argmax(-1)
     return (src_types, dst_types)
+
+
+@lru_cache(maxsize=1)
+def atomic_number_map() -> Dict[str, int]:
+    """List of element symbols and their atomic numbers.
+
+    Returns:
+        Dict[str, int]: _description_
+    """
+    # fmt: off
+    an_map = {'H': 1, 'He': 2, 'Li': 3, 'Be': 4, 'B': 5, 'C': 6, 'N': 7, 'O': 8, 
+            'F': 9, 'Ne': 10, 'Na': 11, 'Mg': 12, 'Al': 13, 'Si': 14, 'P': 15, 
+            'S': 16, 'Cl': 17, 'Ar': 18, 'K': 19, 'Ca': 20, 'Sc': 21, 'Ti': 22, 
+            'V': 23, 'Cr': 24, 'Mn': 25, 'Fe': 26, 'Co': 27, 'Ni': 28, 'Cu': 29, 
+            'Zn': 30, 'Ga': 31, 'Ge': 32, 'As': 33, 'Se': 34, 'Br': 35, 'Kr': 36, 
+            'Rb': 37, 'Sr': 38, 'Y': 39, 'Zr': 40, 'Nb': 41, 'Mo': 42, 'Tc': 43, 
+            'Ru': 44, 'Rh': 45, 'Pd': 46, 'Ag': 47, 'Cd': 48, 'In': 49, 'Sn': 50, 
+            'Sb': 51, 'Te': 52, 'I': 53, 'Xe': 54, 'Cs': 55, 'Ba': 56, 'La': 57, 
+            'Ce': 58, 'Pr': 59, 'Nd': 60, 'Pm': 61, 'Sm': 62, 'Eu': 63, 'Gd': 64, 
+            'Tb': 65, 'Dy': 66, 'Ho': 67, 'Er': 68, 'Tm': 69, 'Yb': 70, 'Lu': 71, 
+            'Hf': 72, 'Ta': 73, 'W': 74, 'Re': 75, 'Os': 76, 'Ir': 77, 'Pt': 78, 
+            'Au': 79, 'Hg': 80, 'Tl': 81, 'Pb': 82, 'Bi': 83, 'Po': 84, 'At': 85, 
+            'Rn': 86, 'Fr': 87, 'Ra': 88, 'Ac': 89, 'Th': 90, 'Pa': 91, 'U': 92, 
+            'Np': 93, 'Pu': 94, 'Am': 95, 'Cm': 96, 'Bk': 97, 'Cf': 98, 'Es': 99, 
+            'Fm': 100, 'Md': 101, 'No': 102, 'Lr': 103, 'Rf': 104, 'Db': 105, 
+            'Sg': 106, 'Bh': 107, 'Hs': 108, 'Mt': 109, 'Ds': 110, 'Rg': 111, 
+            'Cn': 112, 'Nh': 113, 'Fl': 114, 'Mc': 115, 'Lv': 116, 'Ts': 117, 
+            'Og': 118}
+    # fmt: on
+    return an_map
+
+
+@lru_cache(1)
+def element_types():
+    return list(atomic_number_map().keys())

--- a/matsciml/models/dgl/__init__.py
+++ b/matsciml/models/dgl/__init__.py
@@ -17,3 +17,4 @@ if _has_dgl:
     from matsciml.models.dgl.megnet import MEGNet
     from matsciml.models.dgl.schnet_dgl import SchNet
     from matsciml.models.dgl.mpnn import MPNN
+    from matsciml.models.dgl.m3gnet import M3GNet

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -17,18 +17,3 @@ def forward(
 
 M3GNet.m3gnet_forward = M3GNet.forward
 M3GNet.forward = forward
-
-# fmt: off
-element_types = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 
-                'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 
-                'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 
-                'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr', 'Nb', 
-                'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn', 'Sb', 
-                'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm', 
-                'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu', 
-                'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 
-                'Pb', 'Bi', 'Po', 'At', 'Rn', 'Fr', 'Ra', 'Ac', 'Th', 'Pa', 
-                'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 
-                'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 
-                'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og']
-# fmt: on

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -17,6 +17,8 @@ def forward(
 
 M3GNet.m3gnet_forward = M3GNet.forward
 M3GNet.forward = forward
+
+# fmt: off
 element_types = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 
                 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 
                 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 
@@ -29,3 +31,4 @@ element_types = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na',
                 'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 
                 'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 
                 'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og']
+# fmt: on

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -1,0 +1,31 @@
+from typing import Union
+
+import dgl
+import torch
+from matgl.models import M3GNet
+
+
+def forward(
+    self,
+    g: dgl.DGLGraph,
+    state_attr: Union[torch.Tensor, None] = None,
+    l_g: Union[dgl.DGLGraph, None] = None,
+):
+    g = g["graph"]
+    return self.m3gnet_forward(g, state_attr, l_g)
+
+
+M3GNet.m3gnet_forward = M3GNet.forward
+M3GNet.forward = forward
+element_types = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 
+                'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 
+                'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 
+                'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr', 'Nb', 
+                'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn', 'Sb', 
+                'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm', 
+                'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu', 
+                'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 
+                'Pb', 'Bi', 'Po', 'At', 'Rn', 'Fr', 'Ra', 'Ac', 'Th', 'Pa', 
+                'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 
+                'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 
+                'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og']

--- a/matsciml/models/dgl/tests/test_dgl_model_imports.py
+++ b/matsciml/models/dgl/tests/test_dgl_model_imports.py
@@ -29,3 +29,7 @@ def test_dgl_gcn():
 @pytest.mark.skipif(not _has_dgl, reason="DGL not installed; skipping DGL model tests.")
 def test_dgl_gaanet():
     from matsciml.models.dgl import GalaPotential
+
+@pytest.mark.skipif(not _has_dgl, reason="DGL not installed; skipping DGL model tests.")
+def test_dgl_gaanet():
+    from matsciml.models.dgl import M3GNet

--- a/matsciml/models/dgl/tests/test_dgl_models.py
+++ b/matsciml/models/dgl/tests/test_dgl_models.py
@@ -148,3 +148,51 @@ if package_registry["dgl"]:
         assert hasattr(g_z, "grad_fn")
         # make sure every element is finite
         assert torch.isfinite(g_z).all()
+
+
+@pytest.mark.dependency()
+def test_m3gnet_dgl(graph):
+    import numpy as np
+    from matgl.graph.compute import compute_pair_vector_and_distance
+
+    graph['graph'].ndata["node_type"] = graph['graph'].ndata['atomic_numbers']
+    graph['graph'].ndata['num_nodes'] = torch.Tensor(len(graph['graph'].ndata["node_type"]))
+    images = np.zeros((len(graph['graph'].edges()[0]), 3))
+    lattice_matrix = np.zeros((1, 3, 3))
+    pbc_offset = torch.tensor(images, dtype=torch.float64)
+    graph['graph'].edata["pbc_offset"] = pbc_offset.to(torch.int32)
+    graph['graph'].edata["pbc_offshift"] = torch.matmul(
+        pbc_offset, torch.tensor(lattice_matrix[0])
+    )
+    graph['graph'].edata["lattice"] = torch.tensor(
+        np.repeat(lattice_matrix, graph['graph'].num_edges(), axis=0), dtype=torch.float32
+    )
+    ######
+
+    bond_vec, bond_dist = compute_pair_vector_and_distance(graph['graph'])
+    graph['graph'].edata["bond_vec"] = bond_vec
+    graph['graph'].edata["bond_dist"] = bond_dist
+    element_types = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 
+                'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 
+                'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 
+                'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr', 'Nb', 
+                'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn', 'Sb', 
+                'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm', 
+                'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu', 
+                'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 
+                'Pb', 'Bi', 'Po', 'At', 'Rn', 'Fr', 'Ra', 'Ac', 'Th', 'Pa', 
+                'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 
+                'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 
+                'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og']
+
+    model = M3GNet(element_types=element_types)
+    with torch.no_grad():
+        g_z = model(graph)
+    # Scalar output right now
+    assert g_z.shape == torch.Size([])
+
+    # test with grads
+    g_z = model(graph)
+    assert hasattr(g_z, "grad_fn")
+    # make sure every element is finite
+    assert torch.isfinite(g_z).all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "mp_api==0.34.3",
   "schema>=0.7.5",
   "ase>=3.22.1",
+  "matgl==0.8.5",
 ]
 description = "PyTorch Lightning and Deep Graph Library enabled materials science deep learning pipeline"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This PR adds in the matgl repository, which implements the M3GNet model. The default model from matgl needed modification in its forward pass, which is overwritten in the matsciml model file (`./matsciml/models/dgl/m3gnet.py`). Additional modifications may be needed to output only the graph embedding prior to the final layer - this may be added as a feature to matgl itself to prevent the need to copy over code. Two tests are added to check importing the model, and a simple forward pass which checks for output dimensions and gradients. 

The input graph's are also expected to have a different structure, as well as a few more node and edge features. The processing step of matgl ([here](https://github.com/materialsvirtuallab/matgl/blob/0207660e41f7c05c412331541e8ebb98d8c9c1e9/matgl/graph/data.py#L252)) is implemented and a new dataset subclass of `MaterialsProjectDataset` is used to incorporate this processing and additional hyperparameters.

Finally, the matgl package is added as a requirement.

------------------
After addressing some comments, the subclass datasets for M3GNet are added to their respective `dataset.py` file. Additionally, the dictionary mapping atomic symbols to numbers was added to `matsciml/datasets/utils.py` file, as it is reused often. Constants were added into `NomadDataset` to convert the units to the format used by all other datasets (i.e., from Joules to eV, and from meters to angstroms). 

M3GNet is now able to run on Materials Project, Nomad, OQMD, and Carolina Materials database. 

