### PR TITLE
Pre-commit fix and adding `isort`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,12 @@ repos:
           flake8-pyproject,
         ]
 -   repo: https://github.com/psf/black
-    rev: 22.3.1
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3.9
 -   repo: https://github.com/psf/black
-    rev: 22.3.1
+    rev: 23.7.0
     hooks:
       - id: black-jupyter
         language_version: python3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
           flake8-use-fstring,
           flake8-pyproject,
         ]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
 -   repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:


### PR DESCRIPTION
This PR adds a working version of `isort` into the `pre-commit` workflow, in addition to patching up the `black` specification to something more recent. Both are verified to work on my laptop environment.