### PR TITLE
PyG implementation of E(n)-GNN

### DIFF
--- a/examples/model_demos/egnn_pyg.py
+++ b/examples/model_demos/egnn_pyg.py
@@ -3,23 +3,22 @@ import pytorch_lightning as pl
 from matsciml.models.pyg import EGNN
 from matsciml.models.base import ScalarRegressionTask
 from matsciml.lightning.data_utils import MatSciMLDataModule
-from matsciml.datasets.transforms import DistancesTransform
+from matsciml.datasets.transforms import GraphToGraphTransform
 
 """
 This example script runs through a fast development run of the IS2RE devset
 in combination with a PyG implementation of EGNN.
 """
 
-
-# construct a scalar regression task with SchNet encoder
+# construct IS2RE relaxed energy regression with PyG implementation of E(n)-GNN
 task = ScalarRegressionTask(
     encoder_class=EGNN,
     encoder_kwargs={"hidden_dim": 128, "output_dim": 64},
     task_keys=["energy_relaxed"],
 )
-# MPNN expects edge features corresponding to atom-atom distances
+# matsciml devset for OCP are serialized with DGL - this transform goes between the two frameworks
 dm = MatSciMLDataModule.from_devset(
-    "IS2REDataset", dset_kwargs={"transforms": [DistancesTransform()]}
+    "IS2REDataset", dset_kwargs={"transforms": [GraphToGraphTransform("pyg")]}
 )
 
 # run a quick training loop

--- a/examples/model_demos/egnn_pyg.py
+++ b/examples/model_demos/egnn_pyg.py
@@ -1,9 +1,8 @@
 import pytorch_lightning as pl
-
-from matsciml.models.pyg import EGNN
-from matsciml.models.base import ScalarRegressionTask
-from matsciml.lightning.data_utils import MatSciMLDataModule
 from matsciml.datasets.transforms import GraphToGraphTransform
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models.base import ScalarRegressionTask
+from matsciml.models.pyg import EGNN
 
 """
 This example script runs through a fast development run of the IS2RE devset

--- a/examples/model_demos/egnn_pyg.py
+++ b/examples/model_demos/egnn_pyg.py
@@ -1,0 +1,27 @@
+import pytorch_lightning as pl
+
+from matsciml.models.pyg import EGNN
+from matsciml.models.base import ScalarRegressionTask
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.datasets.transforms import DistancesTransform
+
+"""
+This example script runs through a fast development run of the IS2RE devset
+in combination with a PyG implementation of EGNN.
+"""
+
+
+# construct a scalar regression task with SchNet encoder
+task = ScalarRegressionTask(
+    encoder_class=EGNN,
+    encoder_kwargs={"hidden_dim": 128, "output_dim": 64},
+    task_keys=["energy_relaxed"],
+)
+# MPNN expects edge features corresponding to atom-atom distances
+dm = MatSciMLDataModule.from_devset(
+    "IS2REDataset", dset_kwargs={"transforms": [DistancesTransform()]}
+)
+
+# run a quick training loop
+trainer = pl.Trainer(fast_dev_run=10)
+trainer.fit(task, datamodule=dm)

--- a/matsciml/datasets/transforms/__init__.py
+++ b/matsciml/datasets/transforms/__init__.py
@@ -1,7 +1,3 @@
-from matsciml.datasets.transforms.representations import (
-    GraphToPointCloudTransform,
-    PointCloudToGraphTransform,
-    OCPGraphToPointCloudTransform,
-)
+from matsciml.datasets.transforms.representations import *
 
 from matsciml.datasets.transforms.props import *

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -564,6 +564,11 @@ if package_registry["dgl"]:
             data.setdefault("graph_feats", None)
             return data
 
+        def read_batch_size(self, batch: BatchDict) -> int:
+            # grabs the number of batch samples from the DGLGraph attribute
+            graph = batch["graph"]
+            return graph.batch_size
+
 
 if package_registry["pyg"]:
 
@@ -599,6 +604,10 @@ if package_registry["pyg"]:
             data["node_feats"] = node_embeddings
             data["pos"] = pos
             return data
+
+        def read_batch_size(self, batch: BatchDict) -> int:
+            graph = batch["graph"]
+            return graph.num_graphs
 
 
 class AbstractEnergyModel(pl.LightningModule):

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -253,6 +253,10 @@ class AbstractTask(ABC, pl.LightningModule):
         ...
 
     @abstractmethod
+    def read_batch_size(self, batch: BatchDict) -> Union[int, None]:
+        ...
+
+    @abstractmethod
     def _forward(self, *args, **kwargs) -> torch.Tensor:
         """
         Implements the actual logic of the architecture. Given a set
@@ -435,6 +439,10 @@ class AbstractPointCloudModel(AbstractTask):
         # should be [B, D] for B systems
         output = torch.stack([reduce(t, dim=0) for t in split_results])
         return output
+    
+    def read_batch_size(self, batch: BatchDict) -> None:
+        # returns None, because batch size can be readily determined by Lightning
+        return None
 
 
 class AbstractGraphModel(AbstractTask):

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -439,7 +439,7 @@ class AbstractPointCloudModel(AbstractTask):
         # should be [B, D] for B systems
         output = torch.stack([reduce(t, dim=0) for t in split_results])
         return output
-    
+
     def read_batch_size(self, batch: BatchDict) -> None:
         # returns None, because batch size can be readily determined by Lightning
         return None
@@ -923,9 +923,12 @@ class BaseTaskModule(pl.LightningModule):
         # prepending training flag for
         for key, value in loss_dict["log"].items():
             metrics[f"train_{key}"] = value
-        if "graph" in batch.keys():
-            batch_size = batch["graph"].batch_size
-        else:
+        try:
+            batch_size = self.encoder.read_batch_size(batch)
+        except:
+            warn(
+                "Unable to parse batch size from data, defaulting to `None` for logging."
+            )
             batch_size = None
         self.log_dict(metrics, on_step=True, prog_bar=True, batch_size=batch_size)
         return loss_dict
@@ -940,9 +943,12 @@ class BaseTaskModule(pl.LightningModule):
         # prepending training flag for
         for key, value in loss_dict["log"].items():
             metrics[f"val_{key}"] = value
-        if "graph" in batch.keys():
-            batch_size = batch["graph"].batch_size
-        else:
+        try:
+            batch_size = self.encoder.read_batch_size(batch)
+        except:
+            warn(
+                "Unable to parse batch size from data, defaulting to `None` for logging."
+            )
             batch_size = None
         self.log_dict(metrics, batch_size=batch_size)
         return loss_dict
@@ -957,9 +963,12 @@ class BaseTaskModule(pl.LightningModule):
         # prepending training flag for
         for key, value in loss_dict["log"].items():
             metrics[f"test_{key}"] = value
-        if "graph" in batch.keys():
-            batch_size = batch["graph"].batch_size
-        else:
+        try:
+            batch_size = self.encoder.read_batch_size(batch)
+        except:
+            warn(
+                "Unable to parse batch size from data, defaulting to `None` for logging."
+            )
             batch_size = None
         self.log_dict(metrics, batch_size=batch_size)
         return loss_dict
@@ -1430,9 +1439,12 @@ class ForceRegressionTask(BaseTaskModule):
         # prepending training flag
         for key, value in loss_dict["log"].items():
             metrics[f"train_{key}"] = value
-        if "graph" in batch.keys():
-            batch_size = batch["graph"].batch_size
-        else:
+        try:
+            batch_size = self.encoder.read_batch_size(batch)
+        except:
+            warn(
+                "Unable to parse batch size from data, defaulting to `None` for logging."
+            )
             batch_size = None
         self.log_dict(metrics, on_step=True, prog_bar=True, batch_size=batch_size)
         return loss_dict

--- a/matsciml/models/pyg/__init__.py
+++ b/matsciml/models/pyg/__init__.py
@@ -19,3 +19,4 @@ if _has_pyg:
     from matsciml.models.pyg.schnet import SchNetWrap
     from matsciml.models.pyg.forcenet import ForceNet
     from matsciml.models.pyg.cgcnn import CGCNN
+    from matsciml.models.pyg.egnn import EGNN

--- a/matsciml/models/pyg/egnn.py
+++ b/matsciml/models/pyg/egnn.py
@@ -1,0 +1,232 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: MIT License
+
+from __future__ import annotations
+
+import torch
+from einops import reduce
+from matsciml.common.types import AbstractGraph
+from matsciml.models.base import AbstractPyGModel
+from torch import nn
+from torch_geometric.nn import LayerNorm, MessagePassing
+from torch_geometric.nn.pool import global_add_pool
+from torch_geometric.typing import Size
+
+"""
+Some inspiration from https://github.com/lucidrains/egnn-pytorch but
+implementation was otherwise from scratch by Kelvin Lee, following
+Satorras, Hoogeboom, Welling (2022).
+"""
+
+
+class CoordinateNormalization(nn.Module):
+    def __init__(self, epsilon: float = 1e-7) -> None:
+        super().__init__()
+        self.epsilon = epsilon
+        self.scale = nn.Parameter(torch.rand(1), requires_grad=True)
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        coord_norm = coords.norm(dim=-1, keepdim=True)
+        # rescale coordinates by the norm, then rescale by learnable scale
+        new_coords = (coords / (coord_norm + self.epsilon)) * self.scale
+        return new_coords
+
+
+class EGNNConv(MessagePassing):
+    """
+    Implements a single E(n)-GNN convolution layer, or in Satorras _et al._
+    referred to as "Equivariant Graph Convolutional Layer" (EGCL).
+
+    One modification to the architecture is the addition of ``LayerNorm``
+    in the messages.
+    """
+
+    def __init__(
+        self,
+        node_dim: int,
+        hidden_dim: int,
+        out_dim: int,
+        coord_dim: int | None = None,
+        edge_dim: int = 1,
+        activation: str = "SiLU",
+        num_layers: int = 2,
+        norm_coords: bool = True,
+        norm_edge_feats: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        # default use same dimensionality as the node ones to make things simpler
+        if not edge_dim:
+            edge_dim = node_dim
+        if not coord_dim:
+            coord_dim = node_dim
+        # two sets of node features for ij, relative distance, and edge features
+        self.edge_mlp = self.make_mlp(
+            node_dim * 2 + edge_dim,
+            hidden_dim,
+            out_dim,
+            activation,
+            num_layers,
+        )
+        # include layer norm to the messages
+        if norm_edge_feats:
+            self.edge_norm = LayerNorm(hidden_dim)
+        else:
+            self.edge_norm = nn.Identity()
+        # this transforms embeds coordinates
+        self.coord_mlp = self.make_mlp(
+            coord_dim,
+            hidden_dim,
+            coord_dim,
+            activation="SiLU",
+            bias=False,
+        )
+        self.edge_projection = nn.Linear(out_dim, 1, bias=False)
+        if norm_coords:
+            self.coord_norm = CoordinateNormalization()
+        else:
+            self.coord_norm = nn.Identity()
+        self.node_mlp = self.make_mlp(
+            out_dim + node_dim,
+            hidden_dim,
+            out_dim,
+            activation="SiLU",
+        )
+
+    @staticmethod
+    def make_mlp(
+        in_dim: int,
+        hidden_dim: int,
+        out_dim: int,
+        activation: str | None,
+        num_layers: int = 2,
+        **kwargs,
+    ) -> nn.Sequential:
+        if not activation:
+            activation = nn.Identity
+        else:
+            activation = getattr(nn, activation, None)
+            if not activation:
+                raise NameError(
+                    f"Requested activation {activation}, but not found in torch.nn",
+                )
+        layers = [nn.Linear(in_dim, hidden_dim, **kwargs), activation()]
+        for _ in range(num_layers - 1):
+            layers.extend([nn.Linear(hidden_dim, hidden_dim, **kwargs), activation()])
+        layers.append(nn.Linear(hidden_dim, out_dim, **kwargs))
+        return nn.Sequential(*layers)
+
+    def message(self, atom_feats_i, atom_feats_j, edge_attr) -> torch.Tensor:
+        # coordinate distances already included as edge_attr
+        joint = torch.cat([atom_feats_i, atom_feats_j, edge_attr], dim=-1)
+        edge_feats = self.edge_mlp(joint)
+        return self.edge_norm(edge_feats)
+
+    def propagate(
+        self,
+        edge_index: torch.Tensor,
+        size: Size | None = None,
+        **kwargs,
+    ):
+        size = self._check_input(edge_index, size)
+        kwarg_dict = self._collect(self._user_args, edge_index, size, kwargs)
+        msg_kwargs = self.inspector.distribute("message", kwarg_dict)
+        agg_kwargs = self.inspector.distribute("aggregate", kwarg_dict)
+        update_kwargs = self.inspector.distribute("update", kwarg_dict)
+
+        # pull out some of the expected arguments
+        coords = kwargs.get("coords")  # shape [N, 3]
+        atom_feats = kwargs.get("atom_feats")  # shape [N, node_dim]
+        rel_coords = kwargs.get("rel_coords")  # shape [E, 3]
+
+        # eq 3, calculate messages along edges
+        msg_ij = self.message(**msg_kwargs)
+        edge_weights = self.edge_projection(msg_ij)
+
+        # eq 5, aggregated messages
+        hidden_nodes = self.aggregate(msg_ij, **agg_kwargs)
+
+        # eq 4, add weighted sum to coordinates
+        num_edges = edge_index.size(1)
+        edge_norm_factor = 1 / (num_edges - 1)
+        weighted_distances = edge_norm_factor * self.aggregate(
+            rel_coords * edge_weights,
+            **agg_kwargs,
+        )
+        # now update the coordinates
+        new_coords = self.coord_norm(coords + weighted_distances)
+
+        # eq 6, transform node features
+        new_node_feats = self.node_mlp(torch.cat([hidden_nodes, atom_feats], dim=-1))
+        return self.update((new_node_feats, new_coords), **update_kwargs)
+
+    def forward(
+        self,
+        atom_feats: torch.Tensor,
+        coords: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # becomes shape [num_edges, 3]
+        rel_coords = coords[edge_index[0]] - coords[edge_index[1]]
+        # basically sum of squares
+        rel_dist = reduce(rel_coords.square(), "edges xyz -> edges ()", "sum")
+        # combined_edge_feats = torch.cat([edge_feats, rel_dist], dim=-1)
+        new_nodes, new_coords = self.propagate(
+            edge_index,
+            atom_feats=atom_feats,
+            coords=coords,
+            rel_coords=rel_coords,
+            edge_attr=rel_dist,
+        )
+        return (new_nodes, new_coords)
+
+
+class EGNN(AbstractPyGModel):
+    def __init__(
+        self,
+        hidden_dim: int,
+        output_dim: int,
+        num_conv: int = 3,
+        num_atom_embedding: int = 100,
+        activation: str = "SiLU",
+        **kwargs,
+    ) -> None:
+        super().__init__(hidden_dim, num_atom_embedding)
+        # embeds coordinates as part of EGNN
+        self.coord_embedding = nn.Sequential(
+            nn.Linear(3, hidden_dim, bias=False),
+            nn.SiLU(),
+            nn.LayerNorm(hidden_dim),
+        )
+        # generate sequence of EGNN convolution layers
+        self.conv_layers = nn.ModuleList(
+            [
+                EGNNConv(
+                    hidden_dim,
+                    hidden_dim,
+                    hidden_dim,
+                    activation=activation,
+                    **kwargs,
+                )
+                for _ in range(num_conv)
+            ],
+        )
+        self.output = nn.Linear(hidden_dim, output_dim, bias=False)
+
+    def _forward(
+        self,
+        graph: AbstractGraph,
+        node_feats: torch.Tensor,
+        pos: torch.Tensor,
+        edge_feats: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        # embed coordinates, then lookup embeddings for atoms and bonds
+        coords = self.coord_embedding(pos)
+        # loop over each graph layer
+        for layer in self.conv_layers:
+            node_feats, coords = layer(node_feats, coords, edge_feats, graph.edge_index)
+        # use size-extensive pooling
+        pooled_data = global_add_pool(node_feats, graph.batch)
+        return self.output(pooled_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "schema>=0.7.5",
   "ase>=3.22.1",
   "matgl==0.8.5",
+  "einops==0.7.0"
 ]
 description = "PyTorch Lightning and Deep Graph Library enabled materials science deep learning pipeline"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This PR adds a PyTorch Geometric implementation of E(n)-GNN to `matsciml`, and with in, a small number of refactors/fixes to make the process work.

This implementation differs from the `dgl` version, and is significantly more simple and specialized for `matsciml` usage. I did not check for model consistency, but was able to see some model convergence in the training loss.

The auxiliary fixes that were needed:
- Testing it out on `IS2REDataset`, I had to implement a `GraphToGraphTransform` to facilitate cross-framework conversion. DGL -> PyG was needed for this particular case, and the PyG -> DGL case was also implemented albeit untested.
- Refactored batch parsing system: now the `AbstractEncoder` lineage have a `read_batch_size` function that needs to be defined, which for graph frameworks, will read the batch size from the correct attribute. This is mainly relevant for logging/metric averaging.