### PR TITLE
Adding PyG Version of FAENet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,3 @@ Local
 
 # VS Code
 .vscode/
-
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ logs
 *.traj
 experimental
 lightning_logs
+pyg-venv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ logs
 *.traj
 experimental
 lightning_logs
-pyg-venv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ depending on the type of data representation being used and backend: `AbstractPo
 and edges) for consistency, and (2) to abstract out common functions, particularly how to "read" data from the minibatches.
 As an example, DGL and PyG have different interfaces, and by inheriting from the right parent class, ensures that the correct
 features are mapped to the right arguments, etc. If your abstraction permits, the `_forward` method should be the only method
-you need to override:
+you need to override, which returns the system/graph and point/node-level embeddings in a standardized data structure:
 
 ```python
     def _forward(
@@ -39,7 +39,7 @@ you need to override:
         edge_feats: Optional[torch.Tensor] = None,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         """
         Sets args/kwargs for the expected components of a graph-based
         model. At the bare minimum, we expect some kind of abstract
@@ -64,8 +64,8 @@ you need to override:
 
         Returns
         -------
-        torch.Tensor
-            Model output; either embedding or projected output
+        matsciml.common.types.Embeddings
+            Data structure containing system/graph and point/node-level embeddings.
         """
 ```
 

--- a/examples/model_demos/faenet_pyg.py
+++ b/examples/model_demos/faenet_pyg.py
@@ -25,9 +25,9 @@ task = ScalarRegressionTask(
     },
     # output_kwargs={"lazy": False, "input_dim": 64},
     task_keys=["energy_relaxed"],
-    # task_keys=["band_gap"]
 )
-### matsciml devset for OCP are serialized with DGL - this transform goes between the two frameworks
+
+# ### matsciml devset for OCP are serialized with DGL - this transform goes between the two frameworks
 dm = MatSciMLDataModule.from_devset(
     "IS2REDataset",
     dset_kwargs={
@@ -38,19 +38,6 @@ dm = MatSciMLDataModule.from_devset(
     },
 )
 
-
-# dm = MatSciMLDataModule.from_devset(
-#     "MaterialsProjectDataset",
-#     dset_kwargs={
-#         "transforms": [
-#             PointCloudToGraphTransform(
-#                 "dgl", cutoff_dist=20.0, node_keys=["pos", "atomic_numbers"]
-#             ),
-#             GraphToGraphTransform("pyg"),
-#             FrameAveraging(frame_averaging="3D", fa_method="stochastic"),
-#         ],
-#     },
-# )
 
 # run a quick training loop
 trainer = pl.Trainer(fast_dev_run=10)

--- a/examples/model_demos/faenet_pyg.py
+++ b/examples/model_demos/faenet_pyg.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytorch_lightning as pl
 
-from matsciml.datasets.transforms import GraphToGraphTransform, FrameAveraging
+from matsciml.datasets.transforms import FrameAveraging, GraphToGraphTransform
 from matsciml.lightning.data_utils import MatSciMLDataModule
 from matsciml.models.base import ScalarRegressionTask
 from matsciml.models.pyg import FAENet
@@ -15,7 +15,13 @@ in combination with a PyG implementation of FAENet.
 # construct IS2RE relaxed energy regression with PyG implementation of FAENet
 task = ScalarRegressionTask(
     encoder_class=FAENet,
-    encoder_kwargs={"hidden_dim": 128, "output_dim": 64},
+    encoder_kwargs={
+        "pred_as_dict": False,
+        "hidden_dim": 128,
+        "output_dim": 64,
+        "regress_forces": "from_energy",
+    },
+    # output_kwargs={"lazy": False, "input_dim": 64},
     task_keys=["energy_relaxed"],
 )
 # matsciml devset for OCP are serialized with DGL - this transform goes between the two frameworks
@@ -25,7 +31,7 @@ dm = MatSciMLDataModule.from_devset(
         "transforms": [
             GraphToGraphTransform("pyg"),
             FrameAveraging(frame_averaging="3D", fa_method="stochastic"),
-        ]
+        ],
     },
 )
 

--- a/examples/model_demos/faenet_pyg.py
+++ b/examples/model_demos/faenet_pyg.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import pytorch_lightning as pl
 
-from matsciml.datasets.transforms import FrameAveraging, GraphToGraphTransform
+from matsciml.datasets.transforms import FrameAveraging
+from matsciml.datasets.transforms import GraphToGraphTransform
+from matsciml.datasets.transforms import PointCloudToGraphTransform
 from matsciml.lightning.data_utils import MatSciMLDataModule
 from matsciml.models.base import ScalarRegressionTask
 from matsciml.models.pyg import FAENet
@@ -19,12 +21,13 @@ task = ScalarRegressionTask(
         "pred_as_dict": False,
         "hidden_dim": 128,
         "output_dim": 64,
-        "regress_forces": "from_energy",
+        "tag_hidden_channels": 0,
     },
     # output_kwargs={"lazy": False, "input_dim": 64},
     task_keys=["energy_relaxed"],
+    # task_keys=["band_gap"]
 )
-# matsciml devset for OCP are serialized with DGL - this transform goes between the two frameworks
+### matsciml devset for OCP are serialized with DGL - this transform goes between the two frameworks
 dm = MatSciMLDataModule.from_devset(
     "IS2REDataset",
     dset_kwargs={
@@ -34,6 +37,20 @@ dm = MatSciMLDataModule.from_devset(
         ],
     },
 )
+
+
+# dm = MatSciMLDataModule.from_devset(
+#     "MaterialsProjectDataset",
+#     dset_kwargs={
+#         "transforms": [
+#             PointCloudToGraphTransform(
+#                 "dgl", cutoff_dist=20.0, node_keys=["pos", "atomic_numbers"]
+#             ),
+#             GraphToGraphTransform("pyg"),
+#             FrameAveraging(frame_averaging="3D", fa_method="stochastic"),
+#         ],
+#     },
+# )
 
 # run a quick training loop
 trainer = pl.Trainer(fast_dev_run=10)

--- a/examples/model_demos/faenet_pyg.py
+++ b/examples/model_demos/faenet_pyg.py
@@ -5,6 +5,7 @@ import pytorch_lightning as pl
 from matsciml.datasets.transforms import FrameAveraging
 from matsciml.datasets.transforms import GraphToGraphTransform
 from matsciml.datasets.transforms import PointCloudToGraphTransform
+from matsciml.datasets.transforms import UnitCellCalculator
 from matsciml.lightning.data_utils import MatSciMLDataModule
 from matsciml.models.base import ScalarRegressionTask
 from matsciml.models.pyg import FAENet
@@ -32,6 +33,7 @@ dm = MatSciMLDataModule.from_devset(
     "IS2REDataset",
     dset_kwargs={
         "transforms": [
+            UnitCellCalculator(),
             GraphToGraphTransform("pyg"),
             FrameAveraging(frame_averaging="3D", fa_method="stochastic"),
         ],

--- a/examples/model_demos/faenet_pyg.py
+++ b/examples/model_demos/faenet_pyg.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytorch_lightning as pl
+
+from matsciml.datasets.transforms import GraphToGraphTransform, FrameAveraging
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models.base import ScalarRegressionTask
+from matsciml.models.pyg import FAENet
+
+"""
+This example script runs through a fast development run of the IS2RE devset
+in combination with a PyG implementation of FAENet.
+"""
+
+# construct IS2RE relaxed energy regression with PyG implementation of FAENet
+task = ScalarRegressionTask(
+    encoder_class=FAENet,
+    encoder_kwargs={"hidden_dim": 128, "output_dim": 64},
+    task_keys=["energy_relaxed"],
+)
+# matsciml devset for OCP are serialized with DGL - this transform goes between the two frameworks
+dm = MatSciMLDataModule.from_devset(
+    "IS2REDataset",
+    dset_kwargs={
+        "transforms": [
+            GraphToGraphTransform("pyg"),
+            FrameAveraging(frame_averaging="3D", fa_method="stochastic"),
+        ]
+    },
+)
+
+# run a quick training loop
+trainer = pl.Trainer(fast_dev_run=10)
+trainer.fit(task, datamodule=dm)

--- a/examples/model_demos/faenet_pyg.py
+++ b/examples/model_demos/faenet_pyg.py
@@ -19,6 +19,7 @@ in combination with a PyG implementation of FAENet.
 task = ScalarRegressionTask(
     encoder_class=FAENet,
     encoder_kwargs={
+        "average_frame_embeddings": True,
         "pred_as_dict": False,
         "hidden_dim": 128,
         "output_dim": 64,

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -1,9 +1,11 @@
-from typing import Dict, Union
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Union
 
 import torch
 
 from matsciml.common import package_registry
-
 
 # for point clouds
 representations = [torch.Tensor]
@@ -27,7 +29,64 @@ DataType = Union[ModelingTypes]
 AbstractGraph = Union[GraphTypes]
 
 # for a dictionary look up of data
-DataDict = Dict[str, Union[float, DataType]]
+DataDict = dict[str, Union[float, DataType]]
 
 # for a dictionary of batched data
-BatchDict = Dict[str, Union[float, DataType, DataDict]]
+BatchDict = dict[str, Union[float, DataType, DataDict]]
+
+
+@dataclass
+class Embeddings:
+    """
+    Data structure that packs together embeddings from a model.
+    """
+
+    system_embedding: torch.Tensor | None = None
+    point_embedding: torch.Tensor | None = None
+    reduction: str | Callable | None = None
+    reduction_kwargs: dict[str, str | float] = field(default_factory=dict)
+
+    @property
+    def num_points(self) -> int:
+        if not isinstance(self.point_embedding, torch.Tensor):
+            raise ValueError("No point-level embeddings stored!")
+        return self.point_embedding.size(0)
+
+    @property
+    def batch_size(self) -> int:
+        if not isinstance(self.system_embedding, torch.Tensor):
+            raise ValueError(
+                "No system-level embeddings stored, can't determine batch size!",
+            )
+        return self.system_embedding.size(0)
+
+    def reduce_point_embeddings(
+        self,
+        reduction: str | Callable | None = None,
+        **reduction_kwargs,
+    ) -> torch.Tensor:
+        """
+        Perform a reduction/readout of the point-level embeddings to obtain
+        system/graph-level embeddings.
+
+        This function provides a regular interface for obtaining system-level
+        embeddings by either passing a function that functions via:
+
+        ``system_level = reduce(point_level)``
+
+        or by passing a ``str`` name of a function from ``torch`` such as ``mean``.
+        """
+        assert isinstance(
+            self.point_embedding,
+            torch.Tensor,
+        ), "No point-level embeddings stored to reduce."
+        if not reduction:
+            reduction = self.reduction
+        if isinstance(reduction, str):
+            reduction = getattr(torch, reduction)
+        if not reduction:
+            raise ValueError("No method for reduction passed.")
+        self.reduction_kwargs.update(reduction_kwargs)
+        system_embeddings = reduction(self.point_embedding, **self.reduction_kwargs)
+        self.system_embedding = system_embeddings
+        return system_embeddings

--- a/matsciml/datasets/materials_project/dataset.py
+++ b/matsciml/datasets/materials_project/dataset.py
@@ -1,10 +1,20 @@
+from __future__ import annotations
+
 import pickle
 from copy import deepcopy
-from functools import cache, cached_property
+from functools import cache
+from functools import cached_property
 from importlib.util import find_spec
 from math import pi
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any
+from typing import Callable
+from typing import Dict
+from collections.abc import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 import numpy as np
 import torch
@@ -13,14 +23,17 @@ from matgl.ext.pymatgen import Structure2Graph
 from matgl.graph.data import M3GNetDataset
 from pymatgen.analysis import local_env
 from pymatgen.analysis.graphs import StructureGraph
+from pymatgen.core import Lattice
 from pymatgen.core import Structure
 from tqdm import tqdm
 
 from matsciml.common.registry import registry
-from matsciml.common.types import BatchDict, DataDict
+from matsciml.common.types import BatchDict
+from matsciml.common.types import DataDict
 from matsciml.datasets.base import PointCloudDataset
-from matsciml.datasets.utils import (concatenate_keys, element_types,
-                                     point_cloud_featurization)
+from matsciml.datasets.utils import concatenate_keys
+from matsciml.datasets.utils import element_types
+from matsciml.datasets.utils import point_cloud_featurization
 
 _has_pyg = find_spec("torch_geometric") is not None
 
@@ -59,7 +72,7 @@ def item_from_structure(data: Any, *keys: str) -> Any:
 class MaterialsProjectDataset(PointCloudDataset):
     __devset__ = Path(__file__).parents[0].joinpath("devset")
 
-    def index_to_key(self, index: int) -> Tuple[int]:
+    def index_to_key(self, index: int) -> tuple[int]:
         """
         Method that maps a global index value to a pair of indices.
 
@@ -80,7 +93,7 @@ class MaterialsProjectDataset(PointCloudDataset):
         return (0, index)
 
     def _parse_structure(
-        self, data: Dict[str, Any], return_dict: Dict[str, Any]
+        self, data: dict[str, Any], return_dict: dict[str, Any],
     ) -> None:
         """
         Parse the standardized Structure data and format into torch Tensors.
@@ -101,10 +114,10 @@ class MaterialsProjectDataset(PointCloudDataset):
             If `Structure` is not found in the data; currently the workflow
             intends for you to have the data structure in place.
         """
-        structure: Union[None, Structure] = data.get("structure", None)
+        structure: None | Structure = data.get("structure", None)
         if structure is None:
             raise ValueError(
-                "Structure not found in data - workflow needs a structure to use!"
+                "Structure not found in data - workflow needs a structure to use!",
             )
         coords = torch.from_numpy(structure.cart_coords).float()
         system_size = len(coords)
@@ -114,7 +127,7 @@ class MaterialsProjectDataset(PointCloudDataset):
         atom_numbers = torch.LongTensor(structure.atomic_numbers)
         # uses one-hot encoding featurization
         pc_features = point_cloud_featurization(
-            atom_numbers[src_nodes], atom_numbers[dst_nodes], 100
+            atom_numbers[src_nodes], atom_numbers[dst_nodes], 100,
         )
         # keep atomic numbers for graph featurization
         return_dict["atomic_numbers"] = atom_numbers
@@ -122,14 +135,20 @@ class MaterialsProjectDataset(PointCloudDataset):
         return_dict["sizes"] = system_size
         return_dict.update(**chosen_nodes)
         return_dict["distance_matrix"] = torch.from_numpy(
-            structure.distance_matrix
+            structure.distance_matrix,
         ).float()
         # grab lattice properties
         space_group = structure.get_space_group_info()[-1]
         # convert lattice angles into radians
+        abc = structure.lattice.abc
+        angles = structure.lattice.angles
+        lattice_matrix = torch.Tensor(Lattice.from_parameters(*abc, *angles).matrix)
+        # import pdb; pdb.set_trace()
+        return_dict['cell'] = lattice_matrix.unsqueeze(0)
+        return_dict['natoms'] = len(atom_numbers)
         lattice_params = torch.FloatTensor(
             structure.lattice.abc
-            + tuple(a * (pi / 180.0) for a in structure.lattice.angles)
+            + tuple(a * (pi / 180.0) for a in structure.lattice.angles),
         )
         lattice_features = {
             "space_group": space_group,
@@ -138,7 +157,7 @@ class MaterialsProjectDataset(PointCloudDataset):
         return_dict["lattice_features"] = lattice_features
 
     def _parse_symmetry(
-        self, data: Dict[str, Any], return_dict: Dict[str, Any]
+        self, data: dict[str, Any], return_dict: dict[str, Any],
     ) -> None:
         """
         Parse out symmetry information from the `SymmetryData` structure.
@@ -151,7 +170,7 @@ class MaterialsProjectDataset(PointCloudDataset):
             Output dictionary that contains the training sample. Mutates
             in place.
         """
-        symmetry: Union[SymmetryData, None] = data.get("symmetry", None)
+        symmetry: SymmetryData | None = data.get("symmetry", None)
         if symmetry is None:
             return
         else:
@@ -163,7 +182,7 @@ class MaterialsProjectDataset(PointCloudDataset):
             return_dict["symmetry"] = symmetry_data
 
     @property
-    def target_keys(self) -> Dict[str, List[str]]:
+    def target_keys(self) -> dict[str, list[str]]:
         # This returns the standardized dictionary of task_type/key mapping.
         keys = getattr(self, "_target_keys", None)
         if not keys:
@@ -172,7 +191,7 @@ class MaterialsProjectDataset(PointCloudDataset):
         return self._target_keys
 
     @property
-    def target_key_list(self) -> Union[List[str], None]:
+    def target_key_list(self) -> list[str] | None:
         # this returns a flat list of keys, primarily used in the `data_from_key`
         # call. This does not provide the task type/key mapping used to initialize
         # output heads
@@ -186,7 +205,7 @@ class MaterialsProjectDataset(PointCloudDataset):
             return _keys
 
     @target_keys.setter
-    def target_keys(self, values: Dict[str, List[str]]) -> None:
+    def target_keys(self, values: dict[str, list[str]]) -> None:
         remove_keys = []
         copy_dict = deepcopy(values)
         # loop over the keys and remove empty tasks
@@ -198,8 +217,8 @@ class MaterialsProjectDataset(PointCloudDataset):
         self._target_keys = copy_dict
 
     def data_from_key(
-        self, lmdb_index: int, subindex: int
-    ) -> Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]:
+        self, lmdb_index: int, subindex: int,
+    ) -> dict[str, torch.Tensor | dict[str, torch.Tensor]]:
         """
         Extract data out of the PyMatGen data structure and format into PyTorch happy structures.
 
@@ -224,7 +243,7 @@ class MaterialsProjectDataset(PointCloudDataset):
         Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]
             A single sample/material from Materials Project.
         """
-        data: Dict[str, Any] = super().data_from_key(lmdb_index, subindex)
+        data: dict[str, Any] = super().data_from_key(lmdb_index, subindex)
         return_dict = {}
         # parse out relevant structure/lattice data
         self._parse_structure(data, return_dict)
@@ -232,7 +251,7 @@ class MaterialsProjectDataset(PointCloudDataset):
         # assume every other key are targets
         not_targets = set(
             ["structure", "symmetry", "fields_not_requested", "formula_pretty"]
-            + data["fields_not_requested"]
+            + data["fields_not_requested"],
         )
         # target_keys = getattr(self, "_target_keys", None)
         target_keys = self.target_key_list
@@ -263,8 +282,8 @@ class MaterialsProjectDataset(PointCloudDataset):
 
     @staticmethod
     def _standardize_values(
-        value: Union[float, Iterable[float]]
-    ) -> Union[torch.Tensor, float]:
+        value: float | Iterable[float],
+    ) -> torch.Tensor | float:
         """
         Standardizes targets to be ingested by a model.
 
@@ -299,7 +318,7 @@ class MaterialsProjectDataset(PointCloudDataset):
             return value
 
     @cached_property
-    def dataset_target_norm(self) -> Tuple[torch.Tensor, torch.Tensor]:
+    def dataset_target_norm(self) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Compute the dataset average for targets.
 
@@ -317,7 +336,7 @@ class MaterialsProjectDataset(PointCloudDataset):
         return (targets.mean(0, keepdim=True), targets.std(0, keepdim=True))
 
     @staticmethod
-    def collate_fn(batch: List[DataDict]) -> BatchDict:
+    def collate_fn(batch: list[DataDict]) -> BatchDict:
         # since this class returns point clouds by default, we have to pad
         # the atom-centered point cloud data
         return concatenate_keys(
@@ -331,7 +350,7 @@ if _has_pyg:
     from torch_geometric.data import Batch, Data
 
     CrystalNN = local_env.CrystalNN(
-        distance_cutoffs=None, x_diff_weight=-1, porous_adjustment=False
+        distance_cutoffs=None, x_diff_weight=-1, porous_adjustment=False,
     )
 
     @registry.register_dataset("PyGMaterialsProjectDataset")
@@ -346,9 +365,9 @@ if _has_pyg:
 
         def __init__(
             self,
-            lmdb_root_path: Union[str, Path],
+            lmdb_root_path: str | Path,
             cutoff_dist: float = 5.0,
-            transforms: Optional[List[Callable]] = None,
+            transforms: list[Callable] | None = None,
         ) -> None:
             """
             Instantiate a `PyGMaterialsProjectDataset` object.
@@ -391,8 +410,8 @@ if _has_pyg:
             self._cutoff_dist = value
 
         def data_from_key(
-            self, lmdb_index: int, subindex: int
-        ) -> Dict[str, Union[torch.Tensor, Data, Dict[str, torch.Tensor]]]:
+            self, lmdb_index: int, subindex: int,
+        ) -> dict[str, torch.Tensor | Data | dict[str, torch.Tensor]]:
             """
             Maps a pair of indices to a specific data sample from LMDB.
 
@@ -441,8 +460,8 @@ if _has_pyg:
 
         @staticmethod
         def collate_fn(
-            batch: List[Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]]
-        ) -> Dict[str, Union[torch.Tensor, Data, Dict[str, torch.Tensor]]]:
+            batch: list[dict[str, torch.Tensor | dict[str, torch.Tensor]]],
+        ) -> dict[str, torch.Tensor | Data | dict[str, torch.Tensor]]:
             """
             Collate function for DGLGraph variant of the Materials Project.
 
@@ -467,9 +486,9 @@ if _has_pyg:
     class PyGCdvaeDataset(PyGMaterialsProjectDataset):
         def __init__(
             self,
-            lmdb_root_path: Union[str, Path],
+            lmdb_root_path: str | Path,
             cutoff_dist: float = 5.0,
-            transforms: Optional[List[Callable]] = None,
+            transforms: list[Callable] | None = None,
             max_atoms: int = 25,
         ) -> None:
             super().__init__(lmdb_root_path, cutoff_dist, transforms)
@@ -479,10 +498,10 @@ if _has_pyg:
             self.scaler = None
 
         def data_from_key(
-            self, lmdb_index: int, subindex: int
-        ) -> Dict[str, Union[torch.Tensor, Data, Dict[str, torch.Tensor]]]:
+            self, lmdb_index: int, subindex: int,
+        ) -> dict[str, torch.Tensor | Data | dict[str, torch.Tensor]]:
             data = super(PyGMaterialsProjectDataset, self).data_from_key(
-                lmdb_index, subindex
+                lmdb_index, subindex,
             )
             num_nodes = len(data["atomic_numbers"])
             if num_nodes > 25:
@@ -515,15 +534,15 @@ if _has_pyg:
             return data
 
         def _parse_structure(
-            self, data: Dict[str, Any], return_dict: Dict[str, Any]
+            self, data: dict[str, Any], return_dict: dict[str, Any],
         ) -> None:
             """
             The same as OG with the addition of jimages field
             """
-            structure: Union[None, Structure] = data.get("structure", None)
+            structure: None | Structure = data.get("structure", None)
             if structure is None:
                 raise ValueError(
-                    "Structure not found in data - workflow needs a structure to use!"
+                    "Structure not found in data - workflow needs a structure to use!",
                 )
             coords = torch.from_numpy(structure.cart_coords).float()
             return_dict["pos"] = coords[None, :] - coords[:, None]
@@ -534,7 +553,7 @@ if _has_pyg:
             # return_dict["pc_features"] = pc_features
             return_dict["num_particles"] = len(atom_numbers)
             return_dict["distance_matrix"] = torch.from_numpy(
-                structure.distance_matrix
+                structure.distance_matrix,
             ).float()
 
             crystal_graph = StructureGraph.with_local_env_strategy(structure, CrystalNN)
@@ -549,8 +568,10 @@ if _has_pyg:
 
             # grab lattice properties
             # SUPER SLOW
+            abc = structure.lattice.abc
+            angles = structure.lattice.angles
             lattice_params = torch.FloatTensor(
-                structure.lattice.abc + tuple(structure.lattice.angles)
+                abc + tuple(angles),
             )
             lattice_features = {
                 "lattice_params": lattice_params,
@@ -558,7 +579,7 @@ if _has_pyg:
             return_dict["lattice_features"] = lattice_features
 
         @cache
-        def _load_keys(self) -> List[Tuple[int, int]]:
+        def _load_keys(self) -> list[tuple[int, int]]:
             """
             Load in all of the indices from each LMDB file. This creates an
             easy lookup of which data point is mapped to which total dataset
@@ -592,9 +613,9 @@ if _has_pyg:
     class CdvaeLMDBDataset(PyGMaterialsProjectDataset):
         def __init__(
             self,
-            lmdb_root_path: Union[str, Path],
+            lmdb_root_path: str | Path,
             cutoff_dist: float = 5.0,
-            transforms: Optional[List[Callable]] = None,
+            transforms: list[Callable] | None = None,
             max_atoms: int = 25,
         ) -> None:
             super().__init__(lmdb_root_path, cutoff_dist, transforms)
@@ -604,20 +625,20 @@ if _has_pyg:
             self.scaler = None
 
         def data_from_key(
-            self, lmdb_index: int, subindex: int
-        ) -> Dict[str, Union[torch.Tensor, Data, Dict[str, torch.Tensor]]]:
+            self, lmdb_index: int, subindex: int,
+        ) -> dict[str, torch.Tensor | Data | dict[str, torch.Tensor]]:
             # The LMDB dataset already has prepared PyG graphs
             data = super(MaterialsProjectDataset, self).data_from_key(
-                lmdb_index, subindex
+                lmdb_index, subindex,
             )
             return data
 
-        def index_to_key(self, index: int) -> Tuple[int]:
+        def index_to_key(self, index: int) -> tuple[int]:
             """Look up the index number in the list of LMDB keys"""
             return self.keys[index]
 
         @cache
-        def _load_keys(self) -> List[Tuple[int, int]]:
+        def _load_keys(self) -> list[tuple[int, int]]:
             indices = []
             for lmdb_index, env in enumerate(self._envs):
                 with env.begin() as txn:
@@ -629,7 +650,7 @@ if _has_pyg:
                     # filter out non-numeric keys
                     subindices = filter(lambda x: x.isnumeric(), lmdb_keys)
                     indices.extend(
-                        [(lmdb_index, int(subindex)) for subindex in subindices]
+                        [(lmdb_index, int(subindex)) for subindex in subindices],
                     )
             return indices
 
@@ -638,11 +659,11 @@ if _has_pyg:
 class M3GMaterialsProjectDataset(MaterialsProjectDataset):
     def __init__(
         self,
-        lmdb_root_path: Union[str, Path],
+        lmdb_root_path: str | Path,
         threebody_cutoff: float = 4.0,
         cutoff_dist: float = 20.0,
-        graph_labels: Union[list[Union[int, float]], None] = None,
-        transforms: Optional[List[Callable[..., Any]]] = None,
+        graph_labels: list[int | float] | None = None,
+        transforms: list[Callable[..., Any]] | None = None,
     ):
         super().__init__(lmdb_root_path, transforms)
         self.threebody_cutoff = threebody_cutoff
@@ -650,13 +671,13 @@ class M3GMaterialsProjectDataset(MaterialsProjectDataset):
         self.cutoff_dist = cutoff_dist
 
     def _parse_structure(
-        self, data: Dict[str, Any], return_dict: Dict[str, Any]
+        self, data: dict[str, Any], return_dict: dict[str, Any],
     ) -> None:
         super()._parse_structure(data, return_dict)
-        structure: Union[None, Structure] = data.get("structure", None)
+        structure: None | Structure = data.get("structure", None)
         self.structures = [structure]
         self.converter = Structure2Graph(
-            element_types=element_types(), cutoff=self.cutoff_dist
+            element_types=element_types(), cutoff=self.cutoff_dist,
         )
         graphs, lg, sa = M3GNetDataset.process(self)
         return_dict["graph"] = graphs[0]

--- a/matsciml/datasets/materials_project/dataset.py
+++ b/matsciml/datasets/materials_project/dataset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pickle
+from collections.abc import Iterable
 from copy import deepcopy
 from functools import cache
 from functools import cached_property
@@ -10,7 +11,6 @@ from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
-from collections.abc import Iterable
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -139,12 +139,6 @@ class MaterialsProjectDataset(PointCloudDataset):
         ).float()
         # grab lattice properties
         space_group = structure.get_space_group_info()[-1]
-        # convert lattice angles into radians
-        abc = structure.lattice.abc
-        angles = structure.lattice.angles
-        lattice_matrix = torch.Tensor(Lattice.from_parameters(*abc, *angles).matrix)
-        # import pdb; pdb.set_trace()
-        return_dict['cell'] = lattice_matrix.unsqueeze(0)
         return_dict['natoms'] = len(atom_numbers)
         lattice_params = torch.FloatTensor(
             structure.lattice.abc

--- a/matsciml/datasets/transforms/__init__.py
+++ b/matsciml/datasets/transforms/__init__.py
@@ -1,3 +1,5 @@
 from matsciml.datasets.transforms.representations import *
 
 from matsciml.datasets.transforms.props import *
+
+from matsciml.datasets.transforms.frame_averaging import FrameAveraging

--- a/matsciml/datasets/transforms/frame_averaging.py
+++ b/matsciml/datasets/transforms/frame_averaging.py
@@ -1,7 +1,6 @@
 # Frame Averaging implementation from: https://github.com/vict0rsch/faenet/tree/main
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
 from __future__ import annotations
 
 import math
@@ -22,8 +21,6 @@ if package_registry["dgl"]:
 
 if package_registry["pyg"]:
     import torch_geometric
-
-
 
 
 def compute_frames(

--- a/matsciml/datasets/transforms/frame_averaging.py
+++ b/matsciml/datasets/transforms/frame_averaging.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+
+from matsciml.common import DataDict, package_registry
+from matsciml.common.types import DataDict
+from matsciml.datasets.transforms.base import AbstractDataTransform
+
+if package_registry["dgl"]:
+    import dgl
+
+if package_registry["pyg"]:
+    import torch_geometric
+
+
+########
+import math
+import numbers
+import random
+from copy import deepcopy
+from itertools import product
+
+import torch
+import torch.nn as nn
+import torch_geometric
+from torch_geometric.nn import radius_graph
+from torch_geometric.transforms import LinearTransformation
+
+# Frame Averaging implementation from: https://github.com/vict0rsch/faenet/tree/main
+
+
+def compute_frames(
+    eigenvec,
+    pos,
+    cell,
+    fa_method="stochastic",
+    pos_3D=None,
+    det_index=0,
+):
+    """Compute all `frames` for a given graph, i.e. all possible
+    canonical representations of the 3D graph (of all euclidean transformations).
+
+    Args:
+        eigenvec (tensor): eigenvectors matrix
+        pos (tensor): centered position vector
+        cell (tensor): cell direction (dxd)
+        fa_method (str): the Frame Averaging (FA) inspired technique
+            chosen to select frames: stochastic-FA (stochastic), deterministic-FA (det),
+            Full-FA (all) or SE(3)-FA (se3).
+        pos_3D: for 2D FA, pass atoms' 3rd position coordinate.
+
+    Returns:
+        (list): 3D position tensors of projected representation
+    """
+    dim = pos.shape[1]  # to differentiate between 2D or 3D case
+    plus_minus_list = list(product([1, -1], repeat=dim))
+    plus_minus_list = [torch.tensor(x) for x in plus_minus_list]
+    all_fa_pos = []
+    all_cell = []
+    all_rots = []
+    assert fa_method in {
+        "all",
+        "stochastic",
+        "det",
+        "se3-all",
+        "se3-stochastic",
+        "se3-det",
+    }
+    se3 = fa_method in {
+        "se3-all",
+        "se3-stochastic",
+        "se3-det",
+    }
+    fa_cell = deepcopy(cell)
+
+    if fa_method == "det" or fa_method == "se3-det":
+        sum_eigenvec = torch.sum(eigenvec, axis=0)
+        plus_minus_list = [torch.where(sum_eigenvec >= 0, 1.0, -1.0)]
+
+    for pm in plus_minus_list:
+        # Append new graph positions to list
+        new_eigenvec = pm * eigenvec
+
+        # Consider frame if it passes above check
+        fa_pos = pos @ new_eigenvec
+
+        if pos_3D is not None:
+            full_eigenvec = torch.eye(3)
+            fa_pos = torch.cat((fa_pos, pos_3D.unsqueeze(1)), dim=1)
+            full_eigenvec[:2, :2] = new_eigenvec
+            new_eigenvec = full_eigenvec
+
+        if cell is not None:
+            fa_cell = cell @ new_eigenvec
+
+        # Check if determinant is 1 for SE(3) case
+        if se3 and not torch.allclose(
+            torch.linalg.det(new_eigenvec),
+            torch.tensor(1.0),
+            atol=1e-03,
+        ):
+            continue
+
+        all_fa_pos.append(fa_pos)
+        all_cell.append(fa_cell)
+        all_rots.append(new_eigenvec.unsqueeze(0))
+
+    # Handle rare case where no R is positive orthogonal
+    if all_fa_pos == []:
+        all_fa_pos.append(fa_pos)
+        all_cell.append(fa_cell)
+        all_rots.append(new_eigenvec.unsqueeze(0))
+
+    # Return frame(s) depending on method fa_method
+    if fa_method == "all" or fa_method == "se3-all":
+        return all_fa_pos, all_cell, all_rots
+
+    elif fa_method == "det" or fa_method == "se3-det":
+        return [all_fa_pos[det_index]], [all_cell[det_index]], [all_rots[det_index]]
+
+    index = random.randint(0, len(all_fa_pos) - 1)
+    return [all_fa_pos[index]], [all_cell[index]], [all_rots[index]]
+
+
+def check_constraints(eigenval, eigenvec, dim=3):
+    """Check that the requirements for frame averaging are satisfied
+
+    Args:
+        eigenval (tensor): eigenvalues
+        eigenvec (tensor): eigenvectors
+        dim (int): 2D or 3D frame averaging
+    """
+    # Check eigenvalues are different
+    if dim == 3:
+        if (eigenval[1] / eigenval[0] > 0.90) or (eigenval[2] / eigenval[1] > 0.90):
+            print("Eigenvalues are quite similar")
+    else:
+        if eigenval[1] / eigenval[0] > 0.90:
+            print("Eigenvalues are quite similar")
+
+    # Check eigenvectors are orthonormal
+    if not torch.allclose(eigenvec @ eigenvec.T, torch.eye(dim), atol=1e-03):
+        print("Matrix not orthogonal")
+
+    # Check determinant of eigenvectors is 1
+    if not torch.allclose(torch.linalg.det(eigenvec), torch.tensor(1.0), atol=1e-03):
+        print("Determinant is not 1")
+
+
+def frame_averaging_3D(pos, cell=None, fa_method="stochastic", check=False):
+    """Computes new positions for the graph atoms using
+    frame averaging, which itself builds on the PCA of atom positions.
+    Base case for 3D inputs.
+
+    Args:
+        pos (tensor): positions of atoms in the graph
+        cell (tensor): unit cell of the graph. None if no pbc.
+        fa_method (str): FA method used
+            (stochastic, det, all, se3-all, se3-det, se3-stochastic)
+        check (bool): check if constraints are satisfied. Default: False.
+
+    Returns:
+        (tensor): updated atom positions
+        (tensor): updated unit cell
+        (tensor): the rotation matrix used (PCA)
+    """
+
+    # Compute centroid and covariance
+    pos = pos - pos.mean(dim=0, keepdim=True)
+    C = torch.matmul(pos.t(), pos)
+
+    # Eigendecomposition
+    eigenval, eigenvec = torch.linalg.eigh(C)
+
+    # Sort, if necessary
+    idx = eigenval.argsort(descending=True)
+    eigenvec = eigenvec[:, idx]
+    eigenval = eigenval[idx]
+
+    # Check if constraints are satisfied
+    if check:
+        check_constraints(eigenval, eigenvec, 3)
+
+    # Compute fa_pos
+    fa_pos, fa_cell, fa_rot = compute_frames(eigenvec, pos, cell, fa_method)
+
+    # No need to update distances, they are preserved.
+
+    return fa_pos, fa_cell, fa_rot
+
+
+def frame_averaging_2D(pos, cell=None, fa_method="stochastic", check=False):
+    """Computes new positions for the graph atoms using
+    frame averaging, which itself builds on the PCA of atom positions.
+    2D case: we project the atoms on the plane orthogonal to the z-axis.
+    Motivation: sometimes, the z-axis is not the most relevant one (e.g. fixed).
+
+    Args:
+        pos (tensor): positions of atoms in the graph
+        cell (tensor): unit cell of the graph. None if no pbc.
+        fa_method (str): FA method used (stochastic, det, all, se3)
+        check (bool): check if constraints are satisfied. Default: False.
+
+    Returns:
+        (tensor): updated atom positions
+        (tensor): updated unit cell
+        (tensor): the rotation matrix used (PCA)
+    """
+
+    # Compute centroid and covariance
+    pos_2D = pos[:, :2] - pos[:, :2].mean(dim=0, keepdim=True)
+    C = torch.matmul(pos_2D.t(), pos_2D)
+
+    # Eigendecomposition
+    eigenval, eigenvec = torch.linalg.eigh(C)
+    # Sort eigenvalues
+    idx = eigenval.argsort(descending=True)
+    eigenval = eigenval[idx]
+    eigenvec = eigenvec[:, idx]
+
+    # Check if constraints are satisfied
+    if check:
+        check_constraints(eigenval, eigenvec, 3)
+
+    # Compute all frames
+    fa_pos, fa_cell, fa_rot = compute_frames(
+        eigenvec,
+        pos_2D,
+        cell,
+        fa_method,
+        pos[:, 2],
+    )
+    # No need to update distances, they are preserved.
+
+    return fa_pos, fa_cell, fa_rot
+
+
+def data_augmentation(g, d=3, *args):
+    """Data augmentation: randomly rotated graphs are added
+    in the dataloader transform.
+
+    Args:
+        g (data.Data): single graph
+        d (int): dimension of the DA rotation (2D around z-axis or 3D)
+        rotation (str, optional): around which axis do we rotate it.
+            Defaults to 'z'.
+
+    Returns:
+        (data.Data): rotated graph
+    """
+
+    # Sampling a random rotation within [-180, 180] for all axes.
+    if d == 3:
+        transform = RandomRotate([-180, 180], [0, 1, 2])  # 3D
+    else:
+        transform = RandomRotate([-180, 180], [2])  # 2D around z-axis
+
+    # Rotate graph
+    graph_rotated, _, _ = transform(g)
+
+    return graph_rotated
+
+
+class RandomRotate:
+    r"""Rotates node positions around a specific axis by a randomly sampled
+    factor within a given interval.
+
+    Args:
+        degrees (tuple or float): Rotation interval from which the rotation
+            angle is sampled. If `degrees` is a number instead of a
+            tuple, the interval is given by :math:`[-\mathrm{degrees},
+            \mathrm{degrees}]`.
+        axes (int, optional): The rotation axes. (default: `[0, 1, 2]`)
+    """
+
+    def __init__(self, degrees, axes=[0, 1, 2]):
+        if isinstance(degrees, numbers.Number):
+            degrees = (-abs(degrees), abs(degrees))
+        assert isinstance(degrees, (tuple, list)) and len(degrees) == 2
+        self.degrees = degrees
+        self.axes = axes
+
+    def __call__(self, data):
+        if data.pos.size(-1) == 2:
+            degree = math.pi * random.uniform(*self.degrees) / 180.0
+            sin, cos = math.sin(degree), math.cos(degree)
+            matrix = [[cos, sin], [-sin, cos]]
+        else:
+            m1, m2, m3 = torch.eye(3), torch.eye(3), torch.eye(3)
+            if 0 in self.axes:
+                degree = math.pi * random.uniform(*self.degrees) / 180.0
+                sin, cos = math.sin(degree), math.cos(degree)
+                m1 = torch.tensor([[1, 0, 0], [0, cos, sin], [0, -sin, cos]])
+            if 1 in self.axes:
+                degree = math.pi * random.uniform(*self.degrees) / 180.0
+                sin, cos = math.sin(degree), math.cos(degree)
+                m2 = torch.tensor([[cos, 0, -sin], [0, 1, 0], [sin, 0, cos]])
+            if 2 in self.axes:
+                degree = math.pi * random.uniform(*self.degrees) / 180.0
+                sin, cos = math.sin(degree), math.cos(degree)
+                m3 = torch.tensor([[cos, sin, 0], [-sin, cos, 0], [0, 0, 1]])
+
+            matrix = torch.mm(torch.mm(m1, m2), m3)
+
+        data_rotated = LinearTransformation(matrix)(data)
+        if torch_geometric.__version__.startswith("2."):
+            matrix = matrix.T
+
+        # LinearTransformation only rotates `.pos`; need to rotate `.cell` too.
+        if hasattr(data_rotated, "cell"):
+            data_rotated.cell = torch.matmul(
+                data_rotated.cell,
+                matrix.to(data_rotated.cell.device),
+            )
+        # And .force too
+        if hasattr(data_rotated, "force"):
+            data_rotated.force = torch.matmul(
+                data_rotated.force,
+                matrix.to(data_rotated.force.device),
+            )
+
+        return (
+            data_rotated,
+            matrix,
+            torch.inverse(matrix),
+        )
+
+    def __repr__(self):
+        return "{}({}, axis={})".format(
+            self.__class__.__name__,
+            self.degrees,
+            self.axis,
+        )
+
+
+class FrameAveraging(AbstractDataTransform):
+    r"""Frame Averaging (FA) Transform for (PyG) Data objects (e.g. 3D atomic graphs).
+
+    Computes new atomic positions (`fa_pos`) for all datapoints, as well as
+    new unit cells (`fa_cell`) attributes for crystal structures, when applicable.
+    The rotation matrix (`fa_rot`) used for the frame averaging is also stored.
+
+    Args:
+        frame_averaging (str): Transform method used.
+            Can be 2D FA, 3D FA, Data Augmentation or no FA, respectively denoted by
+            (`"2D"`, `"3D"`, `"DA"`, `""`)
+        fa_method (str): the actual frame averaging technique used.
+            "stochastic" refers to sampling one frame at random (at each epoch),
+            "det" to chosing deterministically one frame, and "all" to using all frames.
+            The prefix "se3-" refers to the SE(3) equivariant version of the method.
+            "" means that no frame averaging is used.
+            (`""`, `"stochastic"`, `"all"`, `"det"`, `"se3-stochastic"`, `"se3-all"`, `"se3-det"`)
+
+    Returns:
+        (data.Data): updated data object with new positions (+ unit cell) attributes
+        and the rotation matrices used for the frame averaging transform.
+    """
+
+    def __init__(self, frame_averaging=None, fa_method=None):
+        self.fa_method = (
+            "stochastic" if (fa_method is None or fa_method == "") else fa_method
+        )
+        self.frame_averaging = "" if frame_averaging is None else frame_averaging
+        self.inactive = not self.frame_averaging
+        assert self.frame_averaging in {
+            "",
+            "2D",
+            "3D",
+            "DA",
+        }
+        assert self.fa_method in {
+            "",
+            "stochastic",
+            "det",
+            "all",
+            "se3-stochastic",
+            "se3-det",
+            "se3-all",
+        }
+
+        if self.frame_averaging:
+            if self.frame_averaging == "2D":
+                self.fa_func = frame_averaging_2D
+            elif self.frame_averaging == "3D":
+                self.fa_func = frame_averaging_3D
+            elif self.frame_averaging == "DA":
+                self.fa_func = data_augmentation
+            else:
+                raise ValueError(f"Unknown frame averaging: {self.frame_averaging}")
+
+    def __call__(self, data):
+        """The only requirement for the data is to have a `pos` attribute."""
+        graph = data["graph"]
+        if self.inactive:
+            return data
+        elif self.frame_averaging == "DA":
+            return self.fa_func(data, self.fa_method)
+        else:
+            graph.fa_pos, graph.fa_cell, graph.fa_rot = self.fa_func(
+                graph.pos,
+                data["cell"] if "cell" in data else None,
+                self.fa_method,
+            )
+            data["graph"] = graph
+            return data

--- a/matsciml/datasets/transforms/frame_averaging.py
+++ b/matsciml/datasets/transforms/frame_averaging.py
@@ -1,12 +1,20 @@
+# Frame Averaging implementation from: https://github.com/vict0rsch/faenet/tree/main
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from __future__ import annotations
 
-from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Union
+import math
+import numbers
+import random
+from copy import deepcopy
+from itertools import product
 
 import torch
+import torch_geometric
+from torch_geometric.transforms import LinearTransformation
 
-from matsciml.common import DataDict, package_registry
-from matsciml.common.types import DataDict
+from matsciml.common import package_registry
 from matsciml.datasets.transforms.base import AbstractDataTransform
 
 if package_registry["dgl"]:
@@ -16,20 +24,6 @@ if package_registry["pyg"]:
     import torch_geometric
 
 
-########
-import math
-import numbers
-import random
-from copy import deepcopy
-from itertools import product
-
-import torch
-import torch.nn as nn
-import torch_geometric
-from torch_geometric.nn import radius_graph
-from torch_geometric.transforms import LinearTransformation
-
-# Frame Averaging implementation from: https://github.com/vict0rsch/faenet/tree/main
 
 
 def compute_frames(

--- a/matsciml/datasets/transforms/props.py
+++ b/matsciml/datasets/transforms/props.py
@@ -87,7 +87,7 @@ class GraphVariablesTransform(AbstractDataTransform):
     @staticmethod
     def _get_atomic_charge(
         graph: dgl.DGLGraph, mol_mask: torch.Tensor,
-    ) -> List[torch.Tensor]:
+    ) -> list[torch.Tensor]:
         # extract out nodes that belong to the molecule
         surf_mask = ~mol_mask
         output = []
@@ -99,7 +99,7 @@ class GraphVariablesTransform(AbstractDataTransform):
     @staticmethod
     def _get_distance_features(
         graph: dgl.DGLGraph, mol_mask: torch.Tensor,
-    ) -> List[torch.Tensor]:
+    ) -> list[torch.Tensor]:
         """
         Compute spatial features for the graph level variables.
         This computes two summary features: the average bond length
@@ -323,7 +323,7 @@ class GraphReordering(AbstractDataTransform):
     """
 
     def __init__(
-        self, node_algo: Optional[str] = None, edge_algo: str = "src", **sort_kwargs,
+        self, node_algo: str | None = None, edge_algo: str = "src", **sort_kwargs,
     ) -> None:
         super().__init__()
         self.node_algo = node_algo
@@ -396,7 +396,7 @@ class COMShift(AbstractDataTransform):
 
 class ScaleRegressionTargets(AbstractDataTransform):
     def __init__(
-        self, value: Optional[float] = None, values: Optional[Dict[str, float]] = None,
+        self, value: float | None = None, values: dict[str, float] | None = None,
     ) -> None:
         if value is None and values is None:
             raise ValueError(
@@ -429,8 +429,11 @@ class UnitCellCalculator(AbstractDataTransform):
                 f"No lattice parameters available to calculate unit cell matrix.",
             )
         abc, angles = lattice_params[:3], lattice_params[3:]
+        angles = torch.FloatTensor(
+            tuple(angle * (180.0 / torch.pi) for angle in angles),
+        )
         lattice_matrix = torch.Tensor(Lattice.from_parameters(*abc, *angles).matrix)
-        data['cell'] = lattice_matrix.unsqueeze(0)
+        data["cell"] = lattice_matrix.unsqueeze(0)
         return data
 
 

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1309,6 +1309,8 @@ class ForceRegressionTask(BaseTaskModule):
             else:
                 # assume point cloud otherwise
                 pos: torch.Tensor = batch.get("pos")
+                # no frame averaging architecture yet for point clouds
+                fa_rot = None
             if pos is None:
                 raise ValueError(
                     f"No atomic positions were found in batch - neither as standalone tensor nor graph."
@@ -1325,11 +1327,11 @@ class ForceRegressionTask(BaseTaskModule):
                 embeddings = batch.get("embeddings")
             else:
                 embeddings = self.encoder(batch)
-            outputs = self.process_embedding(embeddings, pos)
+            outputs = self.process_embedding(embeddings, pos, fa_rot)
         return outputs
 
     def process_embedding(
-        self, embeddings: Embeddings, pos: torch.Tensor
+        self, embeddings: Embeddings, pos: torch.Tensor, fa_rot: Union[None, torch.Tensor] = None
     ) -> Dict[str, torch.Tensor]:
         outputs = {}
         energy = self.output_heads["energy"](embeddings.system_embedding)

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1296,7 +1296,13 @@ class ForceRegressionTask(BaseTaskModule):
         with dynamic_gradients_context(True, self.has_rnn):
             # first ensure that positions tensor is backprop ready
             if "graph" in batch:
-                pos: torch.Tensor = batch["graph"].ndata.get("pos")
+                graph = batch["graph"]
+                # the DGL case
+                if hasattr(graph, "ndata"):
+                    pos: torch.Tensor = graph.ndata.get("pos")
+                else:
+                    # otherwise assume it's PyG
+                    pos: torch.Tensor = graph.pos
             else:
                 # assume point cloud otherwise
                 pos: torch.Tensor = batch.get("pos")

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1300,9 +1300,12 @@ class ForceRegressionTask(BaseTaskModule):
                 # the DGL case
                 if hasattr(graph, "ndata"):
                     pos: torch.Tensor = graph.ndata.get("pos")
+                    # for frame averaging
+                    fa_rot = graph.ndata.get("fa_rot", None)
                 else:
                     # otherwise assume it's PyG
                     pos: torch.Tensor = graph.pos
+                    fa_rot = getattr(graph, "fa_rot", None)
             else:
                 # assume point cloud otherwise
                 pos: torch.Tensor = batch.get("pos")

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -1,13 +1,15 @@
-from typing import Callable, Optional, Union, Type, Any
-from importlib import import_module
+from __future__ import annotations
+
 from copy import deepcopy
+from importlib import import_module
+from typing import Any, Callable, Optional, Type, Union
 
 import torch
 from torch import nn
 from torch.nn.parameter import Parameter
 
 
-def get_class_from_name(class_path: str) -> Type[Any]:
+def get_class_from_name(class_path: str) -> type[Any]:
     """
     Load in a specified module, and retrieve a class within
     that module.
@@ -42,9 +44,9 @@ class OutputBlock(nn.Module):
     def __init__(
         self,
         output_dim: int,
-        activation: Optional[Union[nn.Module, Type[nn.Module], Callable, str]] = None,
-        norm: Optional[Union[nn.Module, Type[nn.Module], Callable, str]] = None,
-        input_dim: Optional[int] = None,
+        activation: nn.Module | type[nn.Module] | Callable | str | None = None,
+        norm: nn.Module | type[nn.Module] | Callable | str | None = None,
+        input_dim: int | None = None,
         lazy: bool = True,
         bias: bool = True,
         dropout: float = 0.0,
@@ -77,13 +79,13 @@ class OutputBlock(nn.Module):
             activation = nn.Identity
         if isinstance(activation, str):
             activation = get_class_from_name(activation)
-        if isinstance(activation, Type):
+        if isinstance(activation, type):
             activation = activation()
         if norm is None:
             norm = nn.Identity
         if isinstance(norm, str):
             norm = get_class_from_name(norm)
-        if isinstance(norm, Type):
+        if isinstance(norm, type):
             norm = norm()
         self.residual = residual
         if lazy:
@@ -91,14 +93,17 @@ class OutputBlock(nn.Module):
         else:
             if not lazy and not input_dim:
                 raise ValueError(
-                    f"Non-lazy model specified for 'OutputBlock', but no 'input_dim' was passed."
+                    f"Non-lazy model specified for 'OutputBlock', but no 'input_dim' was passed.",
                 )
             linear = nn.Linear(input_dim, output_dim, bias=bias)
         dropout = nn.Dropout(dropout)
         # be liberal about deepcopy, to make sure we don't duplicate weights
         # when we don't intend to
         self.layers = nn.Sequential(
-            linear, deepcopy(activation), deepcopy(norm), deepcopy(dropout)
+            linear,
+            deepcopy(activation),
+            deepcopy(norm),
+            deepcopy(dropout),
         )
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:
@@ -135,10 +140,10 @@ class OutputHead(nn.Module):
         output_dim: int,
         hidden_dim: int,
         num_hidden: int = 1,
-        activation: Optional[Union[nn.Module, Type[nn.Module], Callable, str]] = None,
-        norm: Optional[Union[nn.Module, Type[nn.Module], Callable, str]] = None,
-        act_last: Optional[Union[nn.Module, Type[nn.Module], Callable, str]] = None,
-        input_dim: Optional[int] = None,
+        activation: nn.Module | type[nn.Module] | Callable | str | None = None,
+        norm: nn.Module | type[nn.Module] | Callable | str | None = None,
+        act_last: nn.Module | type[nn.Module] | Callable | str | None = None,
+        input_dim: int | None = None,
         lazy: bool = True,
         bias: bool = True,
         dropout: float = 0.0,
@@ -200,7 +205,7 @@ class OutputHead(nn.Module):
                     residual=residual,
                 )
                 for _ in range(num_hidden)
-            ]
+            ],
         )
         # last layer does not use residual or normalization
         blocks.append(
@@ -212,7 +217,7 @@ class OutputHead(nn.Module):
                 lazy=lazy,
                 bias=bias,
                 residual=False,
-            )
+            ),
         )
         self.blocks = nn.Sequential(*blocks)
         self.lazy = lazy
@@ -220,6 +225,8 @@ class OutputHead(nn.Module):
     def forward(self, embedding: torch.Tensor) -> torch.Tensor:
         if not self.lazy:
             expected_shape = self.blocks[0].input_dim
+            if isinstance(embedding, dict):
+                embedding = next(iter(embedding.values()))
             assert (
                 embedding.size(-1) == expected_shape
             ), f"Incoming encoder output dim ({embedding.size(-1)}) does not match the expected 'OutputBlock' dim ({expected_shape})"
@@ -245,7 +252,7 @@ class RMSNorm(nn.Module):
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:
         tensor_norm: torch.Tensor = torch.norm(data, p=2, dim=-1, keepdim=True)
-        rms_values = torch.sqrt((tensor_norm * self.input_dim))
+        rms_values = torch.sqrt(tensor_norm * self.input_dim)
         # apply the RMSNorm to inputs
         norm_output = (data / (rms_values + self.eps)) * self.scale
         if self.has_bias:
@@ -289,11 +296,13 @@ class PartialRMSNorm(RMSNorm):
     def forward(self, data: torch.Tensor) -> torch.Tensor:
         # split the input data along partial
         split_tensor, _ = torch.split(
-            data, [self.partial_length, self.input_dim - self.partial_length], dim=-1
+            data,
+            [self.partial_length, self.input_dim - self.partial_length],
+            dim=-1,
         )
         # compute norm based on the split portion
         tensor_norm: torch.Tensor = torch.norm(split_tensor, p=2, dim=1)
-        rms_values = torch.sqrt((tensor_norm * self.partial_length))
+        rms_values = torch.sqrt(tensor_norm * self.partial_length)
         norm_output = (data / (rms_values + self.eps)) * self.scale
         if self.has_bias:
             norm_output = norm_output + self.bias

--- a/matsciml/models/dgl/egnn/egnn.py
+++ b/matsciml/models/dgl/egnn/egnn.py
@@ -7,8 +7,8 @@ import dgl
 import torch
 import torch.nn as nn
 from dgl.nn.pytorch.glob import AvgPooling, MaxPooling, SumPooling, WeightAndSum
-from matsciml.common.types import BatchDict, DataDict
 
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 from matsciml.models.base import AbstractDGLModel
 from matsciml.models.dgl.egnn.egnn_model import EGNN, MLP
 
@@ -185,7 +185,7 @@ class PLEGNNBackbone(AbstractDGLModel):
         edge_feats: Optional[torch.Tensor] = None,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Implement the forward method, which computes the energy of
         a molecular graph.
@@ -210,12 +210,11 @@ class PLEGNNBackbone(AbstractDGLModel):
 
         Returns
         -------
-        torch.Tensor
-            Graph embeddings, or output value if not 'encoder_only'
+        Embeddings
+            Data structure containing node and graph level embeddings.
+            Node embeddings correspond to after the node projection layer.
         """
         n_z, _ = self.embed(graph, node_feats, pos)
         n_z = self.node_projection(n_z)
         g_z = self.readout(graph, n_z)
-        if self.encoder_only:
-            return g_z
-        return self.prediction(g_z)
+        return Embeddings(g_z, n_z)

--- a/matsciml/models/dgl/gaanet/gaanet.py
+++ b/matsciml/models/dgl/gaanet/gaanet.py
@@ -12,6 +12,7 @@ import dgl
 
 from .gaanet_model import MLP, MomentumNorm, LayerNorm, TiedMultivectorAttention
 import geometric_algebra_attention.pytorch as gala
+from matsciml.common.types import Embeddings
 
 
 class GalaPotential(AbstractPointCloudModel):
@@ -250,7 +251,7 @@ class GalaPotential(AbstractPointCloudModel):
         mask: Optional[torch.Tensor] = None,
         sizes: Optional[List[int]] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Map input data onto the Gala architecture.
 
@@ -292,10 +293,8 @@ class GalaPotential(AbstractPointCloudModel):
 
         Returns
         -------
-        torch.Tensor
-            If ``encoder_only``, emits a 2D tensor of shape ``[B, hidden_dim]``.
-            Otherwise, emits a 2D tensor of shape ``[B, 1]`` corresponding to
-            the system energy of each point cloud.
+        Embeddings
+            Data structure containing point cloud embeddings.
         """
         positions = torch.div(pc_pos, 1)
 
@@ -347,4 +346,6 @@ class GalaPotential(AbstractPointCloudModel):
         # are actually padding nodes
         if isinstance(mask, torch.Tensor) and sizes:
             last = self.mask_model_output(last, mask, sizes, self.hparams.extensive)
-        return last
+        # TODO map point level embeddings as well
+        embeddings = Embeddings(last)
+        return embeddings

--- a/matsciml/models/dgl/megnet/megnet.py
+++ b/matsciml/models/dgl/megnet/megnet.py
@@ -14,8 +14,8 @@ import torch
 from torch import nn
 from dgl.nn import Set2Set
 from torch.nn import Dropout, Identity, Module, ModuleList, Softplus
-from matsciml.common.types import BatchDict, DataDict
 
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 from matsciml.models.dgl.megnet import MLP, MEGNetBlock, EdgeSet2Set
 from matsciml.models.base import AbstractDGLModel
 
@@ -179,7 +179,7 @@ class MEGNet(AbstractDGLModel):
         graph_feats: torch.Tensor,
         pos: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Implement the forward method, which computes the energy of
         a molecular graph.
@@ -204,8 +204,8 @@ class MEGNet(AbstractDGLModel):
 
         Returns
         -------
-        torch.Tensor
-            Graph embeddings, or output value if not 'encoder_only'
+        Embeddings
+            Data structure containing graph and node level embeddings.
         """
         edge_feats = self.edge_encoder(self.edge_embed(edge_feats))
         node_feats = self.node_encoder(node_feats)
@@ -222,11 +222,5 @@ class MEGNet(AbstractDGLModel):
 
         if self.dropout:
             vec = self.dropout(vec)  # pylint: disable=E1102
-        if not self.encoder_only:
-            output = self.output_proj(vec)
-            if self.is_classification:
-                output = torch.sigmoid(output)
-        else:
-            output = vec
-
-        return output
+        embeddings = Embeddings(vec, node_vec)
+        return embeddings

--- a/matsciml/models/dgl/mpnn.py
+++ b/matsciml/models/dgl/mpnn.py
@@ -9,8 +9,8 @@ import dgl
 import torch
 from torch import nn
 from dgl.nn.pytorch import glob
-from matsciml.common.types import BatchDict, DataDict
 
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 from matsciml.models.base import AbstractDGLModel
 
 
@@ -114,7 +114,7 @@ class MPNN(AbstractDGLModel):
         edge_feats: torch.Tensor,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Implement the forward method, which computes the energy of
         a molecular graph.
@@ -139,12 +139,12 @@ class MPNN(AbstractDGLModel):
 
         Returns
         -------
-        torch.Tensor
-            Graph embeddings, or output value if not 'encoder_only'
+        Embeddings
+            Data structure with graph and node level embeddings packed.
+            Node embeddings are from the last message passing layer.
         """
         node_feats = self.join_position_embeddings(pos, node_feats)
         n_z = self.model(graph, node_feats, edge_feats)
         g_z = self.readout(graph, n_z)
-        if self.encoder_only:
-            return g_z
-        return self.output(g_z)
+        embeddings = Embeddings(g_z, n_z)
+        return embeddings

--- a/matsciml/models/dgl/schnet_dgl.py
+++ b/matsciml/models/dgl/schnet_dgl.py
@@ -11,7 +11,7 @@ from torch import nn
 from dgl.nn.pytorch import glob
 
 from matsciml.models.base import AbstractDGLModel
-from matsciml.common.types import BatchDict, DataDict
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 
 
 class SchNet(AbstractDGLModel):
@@ -133,7 +133,7 @@ class SchNet(AbstractDGLModel):
         pos: Optional[torch.Tensor] = None,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Implement the forward method, which computes the energy of
         a molecular graph.
@@ -158,11 +158,9 @@ class SchNet(AbstractDGLModel):
 
         Returns
         -------
-        torch.Tensor
-            Graph embeddings, or output value if not 'encoder_only'
+        Embeddings
+            Data structure holding graph and node level embeddings.
         """
         n_z = self.model(graph, node_feats, edge_feats)
         g_z = self.readout(graph, n_z)
-        if self.encoder_only:
-            return g_z
-        return self.output(g_z)
+        return Embeddings(g_z, n_z)

--- a/matsciml/models/pyg/__init__.py
+++ b/matsciml/models/pyg/__init__.py
@@ -4,6 +4,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 try:
     import torch_geometric
@@ -14,9 +15,10 @@ except ImportError:
 
 # load models if we have PyG installed
 if _has_pyg:
-    from matsciml.models.pyg.dimenet_plus_plus import DimeNetPlusPlusWrap
-    from matsciml.models.pyg.dimenet import DimeNetWrap
-    from matsciml.models.pyg.schnet import SchNetWrap
-    from matsciml.models.pyg.forcenet import ForceNet
     from matsciml.models.pyg.cgcnn import CGCNN
+    from matsciml.models.pyg.dimenet import DimeNetWrap
+    from matsciml.models.pyg.dimenet_plus_plus import DimeNetPlusPlusWrap
     from matsciml.models.pyg.egnn import EGNN
+    from matsciml.models.pyg.faenet import FAENet
+    from matsciml.models.pyg.forcenet import ForceNet
+    from matsciml.models.pyg.schnet import SchNetWrap

--- a/matsciml/models/pyg/dimenet.py
+++ b/matsciml/models/pyg/dimenet.py
@@ -4,14 +4,18 @@ Copyright (c) Facebook, Inc. and its affiliates.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
-from __future__ import annotations
 
 import torch
-from torch import nn, scatter
-from torch.sparse import Tensor as SparseTensor
+from torch import nn
 from torch_geometric.nn import DimeNet, radius_graph
+from torch_scatter import scatter
+from torch_sparse import SparseTensor
 
-from matsciml.common.utils import conditional_grad, get_pbc_distances, radius_graph_pbc
+from matsciml.common.utils import (
+    conditional_grad,
+    get_pbc_distances,
+    radius_graph_pbc,
+)
 
 
 class DimeNetWrap(DimeNet):
@@ -85,7 +89,7 @@ class DimeNetWrap(DimeNet):
         self.otf_graph = otf_graph
         self.max_angles_per_image = max_angles_per_image
 
-        super().__init__(
+        super(DimeNetWrap, self).__init__(
             hidden_channels=hidden_channels,
             out_channels=num_targets,
             num_blocks=num_blocks,
@@ -104,10 +108,7 @@ class DimeNetWrap(DimeNet):
 
         value = torch.arange(row.size(0), device=row.device)
         adj_t = SparseTensor(
-            row=col,
-            col=row,
-            value=value,
-            sparse_sizes=(num_nodes, num_nodes),
+            row=col, col=row, value=value, sparse_sizes=(num_nodes, num_nodes)
         )
         adj_t_row = adj_t[row]
         num_triplets = adj_t_row.set_value(None).sum(dim=1).to(torch.long)
@@ -138,9 +139,7 @@ class DimeNetWrap(DimeNet):
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data,
-                self.cutoff,
-                50,
+                data, self.cutoff, 50
             )
             data.edge_index = edge_index
             data.cell_offsets = cell_offsets
@@ -211,8 +210,7 @@ class DimeNetWrap(DimeNet):
 
         # Interaction blocks.
         for interaction_block, output_block in zip(
-            self.interaction_blocks,
-            self.output_blocks[1:],
+            self.interaction_blocks, self.output_blocks[1:]
         ):
             x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
             P += output_block(x, rbf, i, num_nodes=pos.size(0))

--- a/matsciml/models/pyg/dimenet.py
+++ b/matsciml/models/pyg/dimenet.py
@@ -4,18 +4,14 @@ Copyright (c) Facebook, Inc. and its affiliates.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 import torch
-from torch import nn
+from torch import nn, scatter
+from torch.sparse import Tensor as SparseTensor
 from torch_geometric.nn import DimeNet, radius_graph
-from torch_scatter import scatter
-from torch_sparse import SparseTensor
 
-from matsciml.common.utils import (
-    conditional_grad,
-    get_pbc_distances,
-    radius_graph_pbc,
-)
+from matsciml.common.utils import conditional_grad, get_pbc_distances, radius_graph_pbc
 
 
 class DimeNetWrap(DimeNet):
@@ -89,7 +85,7 @@ class DimeNetWrap(DimeNet):
         self.otf_graph = otf_graph
         self.max_angles_per_image = max_angles_per_image
 
-        super(DimeNetWrap, self).__init__(
+        super().__init__(
             hidden_channels=hidden_channels,
             out_channels=num_targets,
             num_blocks=num_blocks,
@@ -108,7 +104,10 @@ class DimeNetWrap(DimeNet):
 
         value = torch.arange(row.size(0), device=row.device)
         adj_t = SparseTensor(
-            row=col, col=row, value=value, sparse_sizes=(num_nodes, num_nodes)
+            row=col,
+            col=row,
+            value=value,
+            sparse_sizes=(num_nodes, num_nodes),
         )
         adj_t_row = adj_t[row]
         num_triplets = adj_t_row.set_value(None).sum(dim=1).to(torch.long)
@@ -139,7 +138,9 @@ class DimeNetWrap(DimeNet):
 
         if self.otf_graph:
             edge_index, cell_offsets, neighbors = radius_graph_pbc(
-                data, self.cutoff, 50
+                data,
+                self.cutoff,
+                50,
             )
             data.edge_index = edge_index
             data.cell_offsets = cell_offsets
@@ -210,7 +211,8 @@ class DimeNetWrap(DimeNet):
 
         # Interaction blocks.
         for interaction_block, output_block in zip(
-            self.interaction_blocks, self.output_blocks[1:]
+            self.interaction_blocks,
+            self.output_blocks[1:],
         ):
             x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
             P += output_block(x, rbf, i, num_nodes=pos.size(0))

--- a/matsciml/models/pyg/egnn.py
+++ b/matsciml/models/pyg/egnn.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import torch
 from einops import reduce
-from matsciml.common.types import AbstractGraph
+from matsciml.common.types import AbstractGraph, Embeddings
 from matsciml.models.base import AbstractPyGModel
 from torch import nn
 from torch_geometric.nn import LayerNorm, MessagePassing
@@ -232,7 +232,7 @@ class EGNN(AbstractPyGModel):
         pos: torch.Tensor,
         edge_feats: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         # embed coordinates, then lookup embeddings for atoms and bonds
         coords = self.coord_embedding(pos)
         # loop over each graph layer
@@ -240,4 +240,5 @@ class EGNN(AbstractPyGModel):
             node_feats, coords = layer(node_feats, coords, edge_feats, graph.edge_index)
         # use size-extensive pooling
         pooled_data = global_add_pool(node_feats, graph.batch)
-        return self.output(pooled_data)
+        embeddings = Embeddings(pooled_data, node_feats)
+        return embeddings

--- a/matsciml/models/pyg/faenet/README.md
+++ b/matsciml/models/pyg/faenet/README.md
@@ -1,0 +1,19 @@
+# Frame Averaging Equivariant Network (FAENet)
+## Implementation details
+A high level description of the model: with frame averaging, the forward pass (`_forward`) iterates
+through each canonical frame and passes it through the architecture. The core difference between this
+implementation and the original is the fact that `_forward` emits an `Embeddings` data structure
+consistent with the rest of the Open MatSciML Toolkit pipeline: the individual task output heads
+are responsible for regression/classification, and so this FAENet _only encodes_. The `output_dim`
+argument was conventionally used for property prediction (i.e. 1 for energy outputs), but we repurpose
+it here as effectively the embedding dimension that gets passed into task output heads. For
+the interest parties, `energy_forward` is more or less the core logic now (`_forward` -> `first_forward` -> `energy_forward`).
+
+The rotations needed for equivariant forces have subsequently been moved out from `_forward`, and into
+the respective tasks (`ForceRegressionTask` and `GradFreeRegressionTask`). In principle, the
+usage should be the same as other graph-based models in `matsciml`.
+
+The last difference to this implementation of FAENet is the additional hyperparameter,
+`average_frame_embeddings` that gets passed into the `__init__` method of `FAENet`. If
+set to `True`, the `_forward` method emits a single embedding for each graph/node where
+we average the embeddings over frames (i.e. frame-averaged embedding).

--- a/matsciml/models/pyg/faenet/__init__.py
+++ b/matsciml/models/pyg/faenet/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from matsciml.models.pyg.faenet.faenet import FAENet

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -510,9 +510,6 @@ class FAENet(AbstractPyGModel):
         else:
             preds = self(batch)
 
-        if preds["energy"].shape[-1] == 1:
-            preds["energy"] = preds["energy"].view(-1)
-
         return preds["energy"]
 
     def forces_as_energy_grad(self, pos, energy):

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -446,10 +446,11 @@ class FAENet(AbstractPyGModel):
             e_all, f_all, gt_all = [], [], []
 
             # Compute model prediction for each frame
-            for i in range(len(batch.fa_pos)):
-                batch.pos = batch.fa_pos[i]
+            for frame_idx, frame in enumerate(batch.fa_pos):
+                # set positions to current frame
+                batch.pos = frame
                 if crystal_task:
-                    batch.cell = batch.fa_cell[i]
+                    batch.cell = batch.fa_cell[frame_idx]
                 # Forward pass
                 preds = self.first_forward(deepcopy(batch))
                 if not self.pred_as_dict:
@@ -461,7 +462,7 @@ class FAENet(AbstractPyGModel):
                 # Force predictions are rotated back to be equivariant
                 if preds.get("forces") is not None:
                     fa_rot = torch.repeat_interleave(
-                        batch.fa_rot[i],
+                        batch.fa_rot[frame_idx],
                         batch.natoms,
                         dim=0,
                     )
@@ -478,7 +479,7 @@ class FAENet(AbstractPyGModel):
                 if preds.get("forces_grad_target") is not None:
                     if fa_rot is None:
                         fa_rot = torch.repeat_interleave(
-                            batch.fa_rot[i],
+                            batch.fa_rot[frame_idx],
                             batch.natoms,
                             dim=0,
                         )

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -255,7 +255,9 @@ class FAENet(AbstractPyGModel):
         data["graph"].edge_index = edge_index
         data["graph"].cell_offsets = cell_offsets
         data["graph"].neighbors = neighbors
-        atomic_numbers, batch, edge_index, rel_pos, edge_weight = self.get_embed_inputs(data['graph'])
+        atomic_numbers, batch, edge_index, rel_pos, edge_weight = self.get_embed_inputs(
+            data["graph"]
+        )
         edge_attr = self.distance_expansion(edge_weight)  # RBF of pairwise distances
         node_embeddings = self.atom_embedding(atomic_numbers, rel_pos, edge_attr)
         # optionally can fuse into a single tensor with `self.join_position_embeddings`
@@ -415,12 +417,20 @@ class FAENet(AbstractPyGModel):
             batch.pos = original_pos
             batch.cell = original_cell
             # now stack up embeddings into a single tensor
-            node_embeddings = torch.stack([frame.point_embedding for frame in all_embeddings], dim=1)
-            graph_embeddings = torch.stack([frame.system_embedding for frame in all_embeddings], dim=1)
+            node_embeddings = torch.stack(
+                [frame.point_embedding for frame in all_embeddings], dim=1
+            )
+            graph_embeddings = torch.stack(
+                [frame.system_embedding for frame in all_embeddings], dim=1
+            )
             # if we're averaging the frame embeddings directly
             if self.average_frame_embeddings:
-                node_embeddings = reduce(node_embeddings, "b f h -> b h", reduction="mean")
-                graph_embeddings = reduce(graph_embeddings, "b f h -> b h", reduction="mean")
+                node_embeddings = reduce(
+                    node_embeddings, "b f h -> b h", reduction="mean"
+                )
+                graph_embeddings = reduce(
+                    graph_embeddings, "b f h -> b h", reduction="mean"
+                )
             all_embeddings = Embeddings(graph_embeddings, node_embeddings)
 
         # Traditional case (no frame averaging)

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -428,10 +428,15 @@ class FAENet(AbstractPyGModel):
         crystal_task = True
         batch = graph
 
-        if isinstance(batch, list):
-            batch = batch[0]
         if not hasattr(batch, "natoms"):
             batch.natoms = torch.unique(batch.batch, return_counts=True)[1]
+
+        # check that frame averaging properties are available
+        for key in ["fa_pos", "fa_cell", "fa_rot"]:
+            if not hasattr(batch, key):
+                raise KeyError(
+                    f"Graph is expected to have property {key}: include frame averaging transform!",
+                )
 
         # Distinguish Frame Averaging prediction from traditional case.
         if frame_averaging and frame_averaging != "DA":

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -268,7 +268,7 @@ class FAENet(AbstractPyGModel):
         if self.decoder:
             return self.decoder(preds["hidden_state"])
 
-    def energy_forward(self, data, preproc=True) -> torch.Tensor:
+    def energy_forward(self, data, preproc=True) -> Embeddings:
         """Predicts any graph-level property (e.g. energy) for 3D atomic systems.
 
         Args:
@@ -329,8 +329,11 @@ class FAENet(AbstractPyGModel):
         # Atom skip-co
         if self.skip_co == "concat_atom":
             energy_skip_co.append(h)
-            h = self.act(self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)))
-        return h
+            node_embedding = self.act(self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)))
+        else:
+            node_embedding = h
+        graph_embedding = self.output_block(node_embedding, edge_index, edge_weight, batch, alpha)
+        return Embeddings(graph_embedding, node_embedding)
 
     def first_forward(
         self,

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -244,7 +244,6 @@ class FAENet(AbstractPyGModel):
             data[key] = getattr(graph, key, None)
         pos: torch.Tensor = getattr(graph, "pos")
         data["pos"] = pos
-        # data = super().read_batch(batch)
         data["graph"].cell = batch["cell"]
         data["graph"].natoms = batch["natoms"].squeeze(-1).to(torch.int32)
         edge_index, cell_offsets, neighbors = radius_graph_pbc(

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -256,7 +256,8 @@ class FAENet(AbstractPyGModel):
     def forces_forward(self, preds):
         """Predicts forces for 3D atomic systems.
         Can be utilised to predict any atom-level property.
-
+        
+        TODO remove this as it is no longer needed
         Args:
             preds (dict): dictionnary with final atomic representations
                 (hidden_state) and predicted properties (e.g. energy)
@@ -504,6 +505,8 @@ class FAENet(AbstractPyGModel):
 
     def forces_as_energy_grad(self, pos, energy):
         """Computes forces from energy gradient
+
+        TODO remove this as it's no longer needed
 
         Args:
             pos (tensor): 3D atom positions

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -10,9 +10,7 @@ import torch
 from torch import nn
 from torch.nn import Linear
 
-from matsciml.common.types import AbstractGraph, Embeddings
-from matsciml.common.types import BatchDict
-from matsciml.common.types import DataDict
+from matsciml.common.types import AbstractGraph, BatchDict, DataDict, Embeddings
 from matsciml.common.utils import radius_graph_pbc
 from matsciml.models.base import AbstractPyGModel
 from matsciml.models.pyg.faenet.helper import *
@@ -329,10 +327,18 @@ class FAENet(AbstractPyGModel):
         # Atom skip-co
         if self.skip_co == "concat_atom":
             energy_skip_co.append(h)
-            node_embedding = self.act(self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)))
+            node_embedding = self.act(
+                self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)),
+            )
         else:
             node_embedding = h
-        graph_embedding = self.output_block(node_embedding, edge_index, edge_weight, batch, alpha)
+        graph_embedding = self.output_block(
+            node_embedding,
+            edge_index,
+            edge_weight,
+            batch,
+            alpha,
+        )
         return Embeddings(graph_embedding, node_embedding)
 
     def first_forward(

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -337,7 +337,9 @@ class FAENet(AbstractPyGModel):
         graph: AbstractGraph,
         **kwargs,
     ) -> torch.Tensor:
-        """Main Forward pass.
+        """
+        Actually flowing data through architecture. First we predict
+        the energy, and optionally gradients.
 
         Args:
             data (Data): input data object, with 3D atom positions (pos)

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -104,6 +104,7 @@ class FAENet(AbstractPyGModel):
         regress_forces: str | None = None,
         force_decoder_type: str | None = "mlp",
         force_decoder_model_config: dict | None = {"hidden_channels": 128},
+        embedding_size: int = 100,
         **kwargs,
     ):
         super().__init__(atom_embedding_dim=118)
@@ -130,6 +131,7 @@ class FAENet(AbstractPyGModel):
         self.tag_hidden_channels = tag_hidden_channels
         self.preprocess = preprocess
         self.pred_as_dict = pred_as_dict
+        self.emb_size = embedding_size
 
         if isinstance(self.preprocess, str):
             self.preprocess = eval(self.preprocess)
@@ -168,6 +170,7 @@ class FAENet(AbstractPyGModel):
             self.phys_embeds,
             self.act,
             self.second_layer_MLP,
+            self.emb_size,
         )
 
         # Interaction block

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -5,360 +5,16 @@ Simple, scalable and expressive model for property prediction on 3D atomic syste
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Dict, Optional, Union
 
 import torch
 from torch import nn
-from torch.nn import Embedding, Linear
-from torch_geometric.nn import LayerNorm, MessagePassing
-from torch_geometric.nn.norm import GraphNorm
-from torch_geometric.nn.pool import global_add_pool
-from torch_geometric.typing import Size
+from torch.nn import Linear
 
-from matsciml.common.types import AbstractGraph
+from matsciml.common.types import AbstractGraph, BatchDict, DataDict
+from matsciml.common.utils import radius_graph_pbc
 from matsciml.models.base import AbstractPyGModel
 from matsciml.models.pyg.faenet.helper import *
 from matsciml.models.pyg.faenet.layers import *
-
-
-class EmbeddingBlock(nn.Module):
-    """Initialise atom and edge representations."""
-
-    def __init__(
-        self,
-        num_gaussians,
-        num_filters,
-        hidden_channels,
-        tag_hidden_channels,
-        pg_hidden_channels,
-        phys_hidden_channels,
-        phys_embeds,
-        act,
-        second_layer_MLP,
-    ):
-        super().__init__()
-        self.act = act
-        self.use_tag = tag_hidden_channels > 0
-        self.use_pg = pg_hidden_channels > 0
-        self.use_mlp_phys = phys_hidden_channels > 0 and phys_embeds
-        self.second_layer_MLP = second_layer_MLP
-
-        # --- Node embedding ---
-
-        # Phys embeddings
-        self.phys_emb = PhysEmbedding(
-            props=phys_embeds,
-            props_grad=phys_hidden_channels > 0,
-            pg=self.use_pg,
-        )
-        # With MLP
-        if self.use_mlp_phys:
-            self.phys_lin = Linear(self.phys_emb.n_properties, phys_hidden_channels)
-        else:
-            phys_hidden_channels = self.phys_emb.n_properties
-
-        # Period + group embeddings
-        if self.use_pg:
-            self.period_embedding = Embedding(
-                self.phys_emb.period_size,
-                pg_hidden_channels,
-            )
-            self.group_embedding = Embedding(
-                self.phys_emb.group_size,
-                pg_hidden_channels,
-            )
-
-        # Tag embedding
-        if tag_hidden_channels:
-            self.tag_embedding = Embedding(3, tag_hidden_channels)
-
-        # Main embedding
-        self.emb = Embedding(
-            85,
-            hidden_channels
-            - tag_hidden_channels
-            - phys_hidden_channels
-            - 2 * pg_hidden_channels,
-        )
-
-        # MLP
-        self.lin = Linear(hidden_channels, hidden_channels)
-        if self.second_layer_MLP:
-            self.lin_2 = Linear(hidden_channels, hidden_channels)
-
-        # --- Edge embedding ---
-        self.lin_e1 = Linear(3, num_filters // 2)  # r_ij
-        self.lin_e12 = Linear(num_gaussians, num_filters - (num_filters // 2))  # d_ij
-
-        if self.second_layer_MLP:
-            self.lin_e2 = Linear(num_filters, num_filters)
-
-        self.reset_parameters()
-
-    def reset_parameters(self):
-        self.emb.reset_parameters()
-        if self.use_mlp_phys:
-            nn.init.xavier_uniform_(self.phys_lin.weight)
-        if self.use_tag:
-            self.tag_embedding.reset_parameters()
-        if self.use_pg:
-            self.period_embedding.reset_parameters()
-            self.group_embedding.reset_parameters()
-        nn.init.xavier_uniform_(self.lin.weight)
-        self.lin.bias.data.fill_(0)
-        nn.init.xavier_uniform_(self.lin_e1.weight)
-        self.lin_e1.bias.data.fill_(0)
-        if self.second_layer_MLP:
-            nn.init.xavier_uniform_(self.lin_2.weight)
-            self.lin_2.bias.data.fill_(0)
-            nn.init.xavier_uniform_(self.lin_e2.weight)
-            self.lin_e2.bias.data.fill_(0)
-
-    def forward(self, z, rel_pos, edge_attr, tag=None, subnodes=None):
-        """Forward pass of the Embedding block.
-        Called in FAENet to generate initial atom and edge representations.
-
-        Args:
-            z (tensor): atomic numbers. (num_atoms, )
-            rel_pos (tensor): relative atomic positions. (num_edges, 3)
-            edge_attr (tensor): RBF of pairwise distances. (num_edges, num_gaussians)
-            tag (tensor, optional): atom information specific to OCP. Defaults to None.
-
-        Returns:
-            (tensor, tensor): atom embeddings, edge embeddings
-        """
-
-        # --- Edge embedding --
-        rel_pos = self.lin_e1(rel_pos)  # r_ij
-        edge_attr = self.lin_e12(edge_attr)  # d_ij
-        e = torch.cat((rel_pos, edge_attr), dim=1)
-        e = self.act(e)  # can comment out
-
-        if self.second_layer_MLP:
-            # e = self.lin_e2(e)
-            e = self.act(self.lin_e2(e))
-
-        # --- Node embedding --
-
-        # Create atom embeddings based on its characteristic number
-        h = self.emb(z)
-
-        if self.phys_emb.device != h.device:
-            self.phys_emb = self.phys_emb.to(h.device)
-
-        # Concat tag embedding
-        if self.use_tag:
-            h_tag = self.tag_embedding(tag)
-            h = torch.cat((h, h_tag), dim=1)
-
-        # Concat physics embeddings
-        if self.phys_emb.n_properties > 0:
-            h_phys = self.phys_emb.properties[z]
-            if self.use_mlp_phys:
-                h_phys = self.phys_lin(h_phys)
-            h = torch.cat((h, h_phys), dim=1)
-
-        # Concat period & group embedding
-        if self.use_pg:
-            h_period = self.period_embedding(self.phys_emb.period[z])
-            h_group = self.group_embedding(self.phys_emb.group[z])
-            h = torch.cat((h, h_period, h_group), dim=1)
-
-        # MLP
-        h = self.act(self.lin(h))
-        if self.second_layer_MLP:
-            h = self.act(self.lin_2(h))
-
-        return h, e
-
-
-class InteractionBlock(MessagePassing):
-    """Updates atom representations through custom message passing."""
-
-    def __init__(
-        self,
-        hidden_channels,
-        num_filters,
-        act,
-        mp_type,
-        complex_mp,
-        graph_norm,
-    ):
-        super().__init__()
-        self.act = act
-        self.mp_type = mp_type
-        self.hidden_channels = hidden_channels
-        self.complex_mp = complex_mp
-        self.graph_norm = graph_norm
-        if graph_norm:
-            self.graph_norm = GraphNorm(
-                hidden_channels if "updown" not in self.mp_type else num_filters,
-            )
-
-        if self.mp_type == "simple":
-            self.lin_h = nn.Linear(hidden_channels, hidden_channels)
-
-        elif self.mp_type == "updownscale":
-            self.lin_geom = nn.Linear(num_filters, num_filters)
-            self.lin_down = nn.Linear(hidden_channels, num_filters)
-            self.lin_up = nn.Linear(num_filters, hidden_channels)
-
-        elif self.mp_type == "updownscale_base":
-            self.lin_geom = nn.Linear(num_filters + 2 * hidden_channels, num_filters)
-            self.lin_down = nn.Linear(hidden_channels, num_filters)
-            self.lin_up = nn.Linear(num_filters, hidden_channels)
-
-        elif self.mp_type == "updown_local_env":
-            self.lin_down = nn.Linear(hidden_channels, num_filters)
-            self.lin_geom = nn.Linear(num_filters, num_filters)
-            self.lin_up = nn.Linear(2 * num_filters, hidden_channels)
-
-        else:  # base
-            self.lin_geom = nn.Linear(
-                num_filters + 2 * hidden_channels,
-                hidden_channels,
-            )
-            self.lin_h = nn.Linear(hidden_channels, hidden_channels)
-
-        if self.complex_mp:
-            self.other_mlp = nn.Linear(hidden_channels, hidden_channels)
-
-        self.reset_parameters()
-
-    def reset_parameters(self):
-        if self.mp_type != "simple":
-            nn.init.xavier_uniform_(self.lin_geom.weight)
-            self.lin_geom.bias.data.fill_(0)
-        if self.complex_mp:
-            nn.init.xavier_uniform_(self.other_mlp.weight)
-            self.other_mlp.bias.data.fill_(0)
-        if self.mp_type in {"updownscale", "updownscale_base", "updown_local_env"}:
-            nn.init.xavier_uniform_(self.lin_up.weight)
-            self.lin_up.bias.data.fill_(0)
-            nn.init.xavier_uniform_(self.lin_down.weight)
-            self.lin_down.bias.data.fill_(0)
-        else:
-            nn.init.xavier_uniform_(self.lin_h.weight)
-            self.lin_h.bias.data.fill_(0)
-
-    def forward(self, h, edge_index, e):
-        """Forward pass of the Interaction block.
-        Called in FAENet forward pass to update atom representations.
-
-        Args:
-            h (tensor): atom embedddings. (num_atoms, hidden_channels)
-            edge_index (tensor): adjacency matrix. (2, num_edges)
-            e (tensor): edge embeddings. (num_edges, num_filters)
-
-        Returns:
-            (tensor): updated atom embeddings
-        """
-        # Define edge embedding
-        if self.mp_type in {"base", "updownscale_base"}:
-            e = torch.cat([e, h[edge_index[0]], h[edge_index[1]]], dim=1)
-
-        if self.mp_type in {
-            "updownscale",
-            "base",
-            "updownscale_base",
-        }:
-            e = self.act(self.lin_geom(e))
-
-        # --- Message Passing block --
-
-        if self.mp_type == "updownscale" or self.mp_type == "updownscale_base":
-            h = self.act(self.lin_down(h))  # downscale node rep.
-            h = self.propagate(edge_index, x=h, W=e)  # propagate
-            if self.graph_norm:
-                h = self.act(self.graph_norm(h))
-            h = self.act(self.lin_up(h))  # upscale node rep.
-
-        elif self.mp_type == "updown_local_env":
-            h = self.act(self.lin_down(h))
-            chi = self.propagate(edge_index, x=h, W=e, local_env=True)
-            e = self.lin_geom(e)
-            h = self.propagate(edge_index, x=h, W=e)  # propagate
-            if self.graph_norm:
-                h = self.act(self.graph_norm(h))
-            h = torch.cat((h, chi), dim=1)
-            h = self.lin_up(h)
-
-        elif self.mp_type in {"base", "simple"}:
-            h = self.propagate(edge_index, x=h, W=e)  # propagate
-            if self.graph_norm:
-                h = self.act(self.graph_norm(h))
-            h = self.act(self.lin_h(h))
-
-        else:
-            raise ValueError("mp_type provided does not exist")
-
-        if self.complex_mp:
-            h = self.act(self.other_mlp(h))
-
-        return h
-
-    def message(self, x_j, W, local_env=None):
-        if local_env is not None:
-            return W
-        else:
-            return x_j * W
-
-
-class OutputBlock(nn.Module):
-    """Compute task-specific predictions from final atom representations."""
-
-    def __init__(self, energy_head, hidden_channels, act, out_dim=1):
-        super().__init__()
-        self.energy_head = energy_head
-        self.act = act
-
-        self.lin1 = Linear(hidden_channels, hidden_channels // 2)
-        self.lin2 = Linear(hidden_channels // 2, out_dim)
-
-        if self.energy_head == "weighted-av-final-embeds":
-            self.w_lin = Linear(hidden_channels, 1)
-
-    def reset_parameters(self):
-        nn.init.xavier_uniform_(self.lin1.weight)
-        self.lin1.bias.data.fill_(0)
-        nn.init.xavier_uniform_(self.lin2.weight)
-        self.lin2.bias.data.fill_(0)
-        if self.energy_head == "weighted-av-final-embeds":
-            nn.init.xavier_uniform_(self.w_lin.weight)
-            self.w_lin.bias.data.fill_(0)
-
-    def forward(self, h, edge_index, edge_weight, batch, alpha):
-        """Forward pass of the Output block.
-        Called in FAENet to make prediction from final atom representations.
-
-        Args:
-            h (tensor): atom representations. (num_atoms, hidden_channels)
-            edge_index (tensor): adjacency matrix. (2, num_edges)
-            edge_weight (tensor): edge weights. (num_edges, )
-            batch (tensor): batch indices. (num_atoms, )
-            alpha (tensor): atom attention weights for late energy head. (num_atoms, )
-
-        Returns:
-            (tensor): graph-level representation (e.g. energy prediction)
-        """
-        if self.energy_head == "weighted-av-final-embeds":
-            alpha = self.w_lin(h)
-
-        # MLP
-        h = self.lin1(h)
-        h = self.act(h)
-        h = self.lin2(h)
-
-        if self.energy_head in {
-            "weighted-av-initial-embeds",
-            "weighted-av-final-embeds",
-        }:
-            h = h * alpha
-
-        # Global pooling
-        out = torch.scatter(h, batch, dim=0, reduce="add")
-
-        return out
 
 
 class FAENet(AbstractPyGModel):
@@ -560,8 +216,37 @@ class FAENet(AbstractPyGModel):
                 self.hidden_channels,
             )
 
-    # FAENet's forward pass in done in BaseModel, inherited here.
-    # It uses forces_forward() and energy_forward() defined below.
+    def read_batch(self, batch: BatchDict) -> DataDict:
+        r"""
+        Extracts data needed by FAENet from the batch and graph
+        structures.
+
+        Node features
+        Edge features
+
+        Parameters
+        ----------
+        batch : BatchDict
+            Batch of data to be processed
+
+        Returns
+        -------
+        DataDict
+            Input data for FAENet as a dictionary.
+        """
+
+        data = super().read_batch(batch)
+        data["graph"].cell = batch["cell"]
+        data["graph"].natoms = batch["natoms"].squeeze(-1).to(torch.int32)
+        edge_index, cell_offsets, neighbors = radius_graph_pbc(
+            data["graph"],
+            self.cutoff,
+            50,
+        )
+        data["graph"].edge_index = edge_index
+        data["graph"].cell_offsets = cell_offsets
+        data["graph"].neighbors = neighbors
+        return data
 
     def forces_forward(self, preds):
         """Predicts forces for 3D atomic systems.
@@ -593,9 +278,7 @@ class FAENet(AbstractPyGModel):
         # Pre-process data (e.g. pbc, cutoff graph, etc.)
         # Should output all necessary attributes, in correct format.
         if preproc:
-            import pdb
-
-            pdb.set_trace()
+            # import pdb; pdb.set_trace()
             z, batch, edge_index, rel_pos, edge_weight = self.preprocess(
                 data,
                 self.cutoff,
@@ -657,7 +340,15 @@ class FAENet(AbstractPyGModel):
 
         return preds
 
-    def forward(self, data, mode="train", preproc=True):
+    # def _forward(self, data, mode="train", preproc=True):
+    def _forward(
+        self,
+        graph: AbstractGraph,
+        node_feats: torch.Tensor,
+        pos: torch.Tensor,
+        edge_feats: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
         """Main Forward pass.
 
         Args:
@@ -669,7 +360,9 @@ class FAENet(AbstractPyGModel):
         Returns:
             (dict): predicted energy, forces and final atomic hidden states
         """
-        data = data["graph"]
+        mode = "train"
+        preproc = True
+        data = graph
         grad_forces = forces = None
 
         # energy gradient w.r.t. positions will be computed
@@ -712,22 +405,22 @@ class FAENet(AbstractPyGModel):
 
         return preds
 
-    # def _forward(
-    #     self,
-    #     batch,
-    #     model,
-    #     frame_averaging,
-    #     mode="train",
-    #     crystal_task=True,
-    # ):
-    def _forward(
+    def final_forward(
         self,
-        graph: AbstractGraph,
-        node_feats: torch.Tensor,
-        pos: torch.Tensor,
-        edge_feats: torch.Tensor | None = None,
-        **kwargs,
-    ) -> torch.Tensor:
+        batch,
+        model,
+        frame_averaging,
+        mode="train",
+        crystal_task=True,
+    ):
+        # def _forward(
+        #     self,
+        #     graph: AbstractGraph,
+        #     node_feats: torch.Tensor,
+        #     pos: torch.Tensor,
+        #     edge_feats: torch.Tensor | None = None,
+        #     **kwargs,
+        # ) -> torch.Tensor:
         """Perform a model forward pass when frame averaging is applied.
 
         Args:
@@ -751,9 +444,6 @@ class FAENet(AbstractPyGModel):
         frame_averaging = "3D"
         mode = "train"
         crystal_task = True
-        import pdb
-
-        pdb.set_trace()
 
         if isinstance(batch, list):
             batch = batch[0]

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -11,6 +11,7 @@ from einops import reduce
 from torch import nn
 from torch.nn import Linear
 
+from matsciml.common.registry import registry
 from matsciml.common.types import AbstractGraph
 from matsciml.common.types import BatchDict
 from matsciml.common.types import DataDict
@@ -21,6 +22,7 @@ from matsciml.models.pyg.faenet.helper import *
 from matsciml.models.pyg.faenet.layers import *
 
 
+@registry.register_model("FAENet")
 class FAENet(AbstractPyGModel):
     r"""Non-symmetry preserving GNN model for 3D atomic systems,
     called FAENet: Frame Averaging Equivariant Network.

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -10,7 +10,9 @@ import torch
 from torch import nn
 from torch.nn import Linear
 
-from matsciml.common.types import AbstractGraph, BatchDict, DataDict
+from matsciml.common.types import AbstractGraph
+from matsciml.common.types import BatchDict
+from matsciml.common.types import DataDict
 from matsciml.common.utils import radius_graph_pbc
 from matsciml.models.base import AbstractPyGModel
 from matsciml.models.pyg.faenet.helper import *
@@ -358,9 +360,6 @@ class FAENet(AbstractPyGModel):
         if self.training:
             mode = "train"
         else:
-            import pdb
-
-            pdb.set_trace()
             mode = "inference"
         preproc = True
         data = graph
@@ -436,7 +435,6 @@ class FAENet(AbstractPyGModel):
 
         frame_averaging = "3D"
         crystal_task = True
-
         batch = graph
 
         if isinstance(batch, list):

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -1,0 +1,859 @@
+"""
+FAENet: Frame Averaging Equivariant graph neural Network
+Simple, scalable and expressive model for property prediction on 3D atomic systems.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Dict, Optional, Union
+
+import torch
+from torch import nn
+from torch.nn import Embedding, Linear
+from torch_geometric.nn import LayerNorm, MessagePassing
+from torch_geometric.nn.norm import GraphNorm
+from torch_geometric.nn.pool import global_add_pool
+from torch_geometric.typing import Size
+
+from matsciml.common.types import AbstractGraph
+from matsciml.models.base import AbstractPyGModel
+from matsciml.models.pyg.faenet.helper import *
+from matsciml.models.pyg.faenet.layers import *
+
+
+class EmbeddingBlock(nn.Module):
+    """Initialise atom and edge representations."""
+
+    def __init__(
+        self,
+        num_gaussians,
+        num_filters,
+        hidden_channels,
+        tag_hidden_channels,
+        pg_hidden_channels,
+        phys_hidden_channels,
+        phys_embeds,
+        act,
+        second_layer_MLP,
+    ):
+        super().__init__()
+        self.act = act
+        self.use_tag = tag_hidden_channels > 0
+        self.use_pg = pg_hidden_channels > 0
+        self.use_mlp_phys = phys_hidden_channels > 0 and phys_embeds
+        self.second_layer_MLP = second_layer_MLP
+
+        # --- Node embedding ---
+
+        # Phys embeddings
+        self.phys_emb = PhysEmbedding(
+            props=phys_embeds,
+            props_grad=phys_hidden_channels > 0,
+            pg=self.use_pg,
+        )
+        # With MLP
+        if self.use_mlp_phys:
+            self.phys_lin = Linear(self.phys_emb.n_properties, phys_hidden_channels)
+        else:
+            phys_hidden_channels = self.phys_emb.n_properties
+
+        # Period + group embeddings
+        if self.use_pg:
+            self.period_embedding = Embedding(
+                self.phys_emb.period_size,
+                pg_hidden_channels,
+            )
+            self.group_embedding = Embedding(
+                self.phys_emb.group_size,
+                pg_hidden_channels,
+            )
+
+        # Tag embedding
+        if tag_hidden_channels:
+            self.tag_embedding = Embedding(3, tag_hidden_channels)
+
+        # Main embedding
+        self.emb = Embedding(
+            85,
+            hidden_channels
+            - tag_hidden_channels
+            - phys_hidden_channels
+            - 2 * pg_hidden_channels,
+        )
+
+        # MLP
+        self.lin = Linear(hidden_channels, hidden_channels)
+        if self.second_layer_MLP:
+            self.lin_2 = Linear(hidden_channels, hidden_channels)
+
+        # --- Edge embedding ---
+        self.lin_e1 = Linear(3, num_filters // 2)  # r_ij
+        self.lin_e12 = Linear(num_gaussians, num_filters - (num_filters // 2))  # d_ij
+
+        if self.second_layer_MLP:
+            self.lin_e2 = Linear(num_filters, num_filters)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        self.emb.reset_parameters()
+        if self.use_mlp_phys:
+            nn.init.xavier_uniform_(self.phys_lin.weight)
+        if self.use_tag:
+            self.tag_embedding.reset_parameters()
+        if self.use_pg:
+            self.period_embedding.reset_parameters()
+            self.group_embedding.reset_parameters()
+        nn.init.xavier_uniform_(self.lin.weight)
+        self.lin.bias.data.fill_(0)
+        nn.init.xavier_uniform_(self.lin_e1.weight)
+        self.lin_e1.bias.data.fill_(0)
+        if self.second_layer_MLP:
+            nn.init.xavier_uniform_(self.lin_2.weight)
+            self.lin_2.bias.data.fill_(0)
+            nn.init.xavier_uniform_(self.lin_e2.weight)
+            self.lin_e2.bias.data.fill_(0)
+
+    def forward(self, z, rel_pos, edge_attr, tag=None, subnodes=None):
+        """Forward pass of the Embedding block.
+        Called in FAENet to generate initial atom and edge representations.
+
+        Args:
+            z (tensor): atomic numbers. (num_atoms, )
+            rel_pos (tensor): relative atomic positions. (num_edges, 3)
+            edge_attr (tensor): RBF of pairwise distances. (num_edges, num_gaussians)
+            tag (tensor, optional): atom information specific to OCP. Defaults to None.
+
+        Returns:
+            (tensor, tensor): atom embeddings, edge embeddings
+        """
+
+        # --- Edge embedding --
+        rel_pos = self.lin_e1(rel_pos)  # r_ij
+        edge_attr = self.lin_e12(edge_attr)  # d_ij
+        e = torch.cat((rel_pos, edge_attr), dim=1)
+        e = self.act(e)  # can comment out
+
+        if self.second_layer_MLP:
+            # e = self.lin_e2(e)
+            e = self.act(self.lin_e2(e))
+
+        # --- Node embedding --
+
+        # Create atom embeddings based on its characteristic number
+        h = self.emb(z)
+
+        if self.phys_emb.device != h.device:
+            self.phys_emb = self.phys_emb.to(h.device)
+
+        # Concat tag embedding
+        if self.use_tag:
+            h_tag = self.tag_embedding(tag)
+            h = torch.cat((h, h_tag), dim=1)
+
+        # Concat physics embeddings
+        if self.phys_emb.n_properties > 0:
+            h_phys = self.phys_emb.properties[z]
+            if self.use_mlp_phys:
+                h_phys = self.phys_lin(h_phys)
+            h = torch.cat((h, h_phys), dim=1)
+
+        # Concat period & group embedding
+        if self.use_pg:
+            h_period = self.period_embedding(self.phys_emb.period[z])
+            h_group = self.group_embedding(self.phys_emb.group[z])
+            h = torch.cat((h, h_period, h_group), dim=1)
+
+        # MLP
+        h = self.act(self.lin(h))
+        if self.second_layer_MLP:
+            h = self.act(self.lin_2(h))
+
+        return h, e
+
+
+class InteractionBlock(MessagePassing):
+    """Updates atom representations through custom message passing."""
+
+    def __init__(
+        self,
+        hidden_channels,
+        num_filters,
+        act,
+        mp_type,
+        complex_mp,
+        graph_norm,
+    ):
+        super().__init__()
+        self.act = act
+        self.mp_type = mp_type
+        self.hidden_channels = hidden_channels
+        self.complex_mp = complex_mp
+        self.graph_norm = graph_norm
+        if graph_norm:
+            self.graph_norm = GraphNorm(
+                hidden_channels if "updown" not in self.mp_type else num_filters,
+            )
+
+        if self.mp_type == "simple":
+            self.lin_h = nn.Linear(hidden_channels, hidden_channels)
+
+        elif self.mp_type == "updownscale":
+            self.lin_geom = nn.Linear(num_filters, num_filters)
+            self.lin_down = nn.Linear(hidden_channels, num_filters)
+            self.lin_up = nn.Linear(num_filters, hidden_channels)
+
+        elif self.mp_type == "updownscale_base":
+            self.lin_geom = nn.Linear(num_filters + 2 * hidden_channels, num_filters)
+            self.lin_down = nn.Linear(hidden_channels, num_filters)
+            self.lin_up = nn.Linear(num_filters, hidden_channels)
+
+        elif self.mp_type == "updown_local_env":
+            self.lin_down = nn.Linear(hidden_channels, num_filters)
+            self.lin_geom = nn.Linear(num_filters, num_filters)
+            self.lin_up = nn.Linear(2 * num_filters, hidden_channels)
+
+        else:  # base
+            self.lin_geom = nn.Linear(
+                num_filters + 2 * hidden_channels,
+                hidden_channels,
+            )
+            self.lin_h = nn.Linear(hidden_channels, hidden_channels)
+
+        if self.complex_mp:
+            self.other_mlp = nn.Linear(hidden_channels, hidden_channels)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.mp_type != "simple":
+            nn.init.xavier_uniform_(self.lin_geom.weight)
+            self.lin_geom.bias.data.fill_(0)
+        if self.complex_mp:
+            nn.init.xavier_uniform_(self.other_mlp.weight)
+            self.other_mlp.bias.data.fill_(0)
+        if self.mp_type in {"updownscale", "updownscale_base", "updown_local_env"}:
+            nn.init.xavier_uniform_(self.lin_up.weight)
+            self.lin_up.bias.data.fill_(0)
+            nn.init.xavier_uniform_(self.lin_down.weight)
+            self.lin_down.bias.data.fill_(0)
+        else:
+            nn.init.xavier_uniform_(self.lin_h.weight)
+            self.lin_h.bias.data.fill_(0)
+
+    def forward(self, h, edge_index, e):
+        """Forward pass of the Interaction block.
+        Called in FAENet forward pass to update atom representations.
+
+        Args:
+            h (tensor): atom embedddings. (num_atoms, hidden_channels)
+            edge_index (tensor): adjacency matrix. (2, num_edges)
+            e (tensor): edge embeddings. (num_edges, num_filters)
+
+        Returns:
+            (tensor): updated atom embeddings
+        """
+        # Define edge embedding
+        if self.mp_type in {"base", "updownscale_base"}:
+            e = torch.cat([e, h[edge_index[0]], h[edge_index[1]]], dim=1)
+
+        if self.mp_type in {
+            "updownscale",
+            "base",
+            "updownscale_base",
+        }:
+            e = self.act(self.lin_geom(e))
+
+        # --- Message Passing block --
+
+        if self.mp_type == "updownscale" or self.mp_type == "updownscale_base":
+            h = self.act(self.lin_down(h))  # downscale node rep.
+            h = self.propagate(edge_index, x=h, W=e)  # propagate
+            if self.graph_norm:
+                h = self.act(self.graph_norm(h))
+            h = self.act(self.lin_up(h))  # upscale node rep.
+
+        elif self.mp_type == "updown_local_env":
+            h = self.act(self.lin_down(h))
+            chi = self.propagate(edge_index, x=h, W=e, local_env=True)
+            e = self.lin_geom(e)
+            h = self.propagate(edge_index, x=h, W=e)  # propagate
+            if self.graph_norm:
+                h = self.act(self.graph_norm(h))
+            h = torch.cat((h, chi), dim=1)
+            h = self.lin_up(h)
+
+        elif self.mp_type in {"base", "simple"}:
+            h = self.propagate(edge_index, x=h, W=e)  # propagate
+            if self.graph_norm:
+                h = self.act(self.graph_norm(h))
+            h = self.act(self.lin_h(h))
+
+        else:
+            raise ValueError("mp_type provided does not exist")
+
+        if self.complex_mp:
+            h = self.act(self.other_mlp(h))
+
+        return h
+
+    def message(self, x_j, W, local_env=None):
+        if local_env is not None:
+            return W
+        else:
+            return x_j * W
+
+
+class OutputBlock(nn.Module):
+    """Compute task-specific predictions from final atom representations."""
+
+    def __init__(self, energy_head, hidden_channels, act, out_dim=1):
+        super().__init__()
+        self.energy_head = energy_head
+        self.act = act
+
+        self.lin1 = Linear(hidden_channels, hidden_channels // 2)
+        self.lin2 = Linear(hidden_channels // 2, out_dim)
+
+        if self.energy_head == "weighted-av-final-embeds":
+            self.w_lin = Linear(hidden_channels, 1)
+
+    def reset_parameters(self):
+        nn.init.xavier_uniform_(self.lin1.weight)
+        self.lin1.bias.data.fill_(0)
+        nn.init.xavier_uniform_(self.lin2.weight)
+        self.lin2.bias.data.fill_(0)
+        if self.energy_head == "weighted-av-final-embeds":
+            nn.init.xavier_uniform_(self.w_lin.weight)
+            self.w_lin.bias.data.fill_(0)
+
+    def forward(self, h, edge_index, edge_weight, batch, alpha):
+        """Forward pass of the Output block.
+        Called in FAENet to make prediction from final atom representations.
+
+        Args:
+            h (tensor): atom representations. (num_atoms, hidden_channels)
+            edge_index (tensor): adjacency matrix. (2, num_edges)
+            edge_weight (tensor): edge weights. (num_edges, )
+            batch (tensor): batch indices. (num_atoms, )
+            alpha (tensor): atom attention weights for late energy head. (num_atoms, )
+
+        Returns:
+            (tensor): graph-level representation (e.g. energy prediction)
+        """
+        if self.energy_head == "weighted-av-final-embeds":
+            alpha = self.w_lin(h)
+
+        # MLP
+        h = self.lin1(h)
+        h = self.act(h)
+        h = self.lin2(h)
+
+        if self.energy_head in {
+            "weighted-av-initial-embeds",
+            "weighted-av-final-embeds",
+        }:
+            h = h * alpha
+
+        # Global pooling
+        out = torch.scatter(h, batch, dim=0, reduce="add")
+
+        return out
+
+
+class FAENet(AbstractPyGModel):
+    r"""Non-symmetry preserving GNN model for 3D atomic systems,
+    called FAENet: Frame Averaging Equivariant Network.
+
+    Args:
+        cutoff (float): Cutoff distance for interatomic interactions.
+            (default: :obj:`6.0`)
+        preprocess (callable): Pre-processing function for the data. This function
+            should accept a data object as input and return a tuple containing the following:
+            atomic numbers, batch indices, final adjacency, relative positions, pairwise distances.
+            Examples of valid preprocessing functions include `pbc_preprocess`,
+            `base_preprocess`, or custom functions.
+        act (str): Activation function
+            (default: `swish`)
+        max_num_neighbors (int): The maximum number of neighbors to
+            collect for each node within the :attr:`cutoff` distance.
+            (default: `40`)
+        hidden_channels (int): Hidden embedding size.
+            (default: `128`)
+        tag_hidden_channels (int): Hidden tag embedding size.
+            (default: :obj:`32`)
+        pg_hidden_channels (int): Hidden period and group embedding size.
+            (default: :obj:`32`)
+        phys_embeds (bool): Do we include fixed physics-aware embeddings.
+            (default: :obj: `True`)
+        phys_hidden_channels (int): Hidden size of learnable physics-aware embeddings.
+            (default: :obj:`0`)
+        num_interactions (int): The number of interaction (i.e. message passing) blocks.
+            (default: :obj:`4`)
+        num_gaussians (int): The number of gaussians :math:`\mu` to encode distance info.
+            (default: :obj:`50`)
+        num_filters (int): The size of convolutional filters.
+            (default: :obj:`128`)
+        second_layer_MLP (bool): Use 2-layers MLP at the end of the Embedding block.
+            (default: :obj:`False`)
+        skip_co (str): Add a skip connection between each interaction block and
+            energy-head. (`False`, `"add"`, `"concat"`, `"concat_atom"`)
+        mp_type (str): Specificies the Message Passing type of the interaction block.
+            (`"base"`, `"updownscale_base"`, `"updownscale"`, `"updown_local_env"`, `"simple"`):
+        graph_norm (bool): Whether to apply batch norm after every linear layer.
+            (default: :obj:`True`)
+        complex_mp (bool); Whether to add a second layer MLP at the end of each Interaction
+            (default: :obj:`True`)
+        energy_head (str): Method to compute energy prediction
+            from atom representations.
+            (`None`, `"weighted-av-initial-embeds"`, `"weighted-av-final-embeds"`)
+        out_dim (int): size of the output tensor for graph-level predicted properties ("energy")
+            Allows to predict multiple properties at the same time.
+            (default: :obj:`1`)
+        pred_as_dict (bool): Set to False to return a (property) prediction tensor.
+            By default, predictions are returned as a dictionary with several keys (e.g. energy, forces)
+            (default: :obj:`True`)
+        regress_forces (str): Specifies if we predict forces or not, and how
+            do we predict them. (`None` or `""`, `"direct"`, `"direct_with_gradient_target"`)
+        force_decoder_type (str): Specifies the type of force decoder
+            (`"simple"`, `"mlp"`, `"res"`, `"res_updown"`)
+        force_decoder_model_config (dict): contains information about the
+            for decoder architecture (e.g. number of layers, hidden size).
+    """
+
+    def __init__(
+        self,
+        cutoff: float = 6.0,
+        preprocess: str | callable = "pbc_preprocess",
+        act: str = "swish",
+        max_num_neighbors: int = 40,
+        hidden_channels: int = 128,
+        tag_hidden_channels: int = 32,
+        pg_hidden_channels: int = 32,
+        phys_embeds: bool = True,
+        phys_hidden_channels: int = 0,
+        num_interactions: int = 4,
+        num_gaussians: int = 50,
+        num_filters: int = 128,
+        second_layer_MLP: bool = True,
+        skip_co: str = "concat",
+        mp_type: str = "updownscale_base",
+        graph_norm: bool = True,
+        complex_mp: bool = False,
+        energy_head: str | None = None,
+        out_dim: int = 1,
+        pred_as_dict: bool = True,
+        regress_forces: str | None = None,
+        force_decoder_type: str | None = "mlp",
+        force_decoder_model_config: dict | None = {"hidden_channels": 128},
+        **kwargs,
+    ):
+        super().__init__(atom_embedding_dim=118)
+
+        self.act = act
+        self.complex_mp = complex_mp
+        self.cutoff = cutoff
+        self.energy_head = energy_head
+        self.force_decoder_type = force_decoder_type
+        self.force_decoder_model_config = force_decoder_model_config
+        self.graph_norm = graph_norm
+        self.hidden_channels = hidden_channels
+        self.max_num_neighbors = max_num_neighbors
+        self.mp_type = mp_type
+        self.num_filters = num_filters
+        self.num_gaussians = num_gaussians
+        self.num_interactions = num_interactions
+        self.pg_hidden_channels = pg_hidden_channels
+        self.phys_embeds = phys_embeds
+        self.phys_hidden_channels = phys_hidden_channels
+        self.regress_forces = regress_forces
+        self.second_layer_MLP = second_layer_MLP
+        self.skip_co = skip_co
+        self.tag_hidden_channels = tag_hidden_channels
+        self.preprocess = preprocess
+        self.pred_as_dict = pred_as_dict
+
+        if isinstance(self.preprocess, str):
+            self.preprocess = eval(self.preprocess)
+
+        if not isinstance(self.regress_forces, str):
+            assert self.regress_forces is False or self.regress_forces is None, (
+                "regress_forces must be a string "
+                + "('', 'direct', 'direct_with_gradient_target') or False or None"
+            )
+            self.regress_forces = ""
+
+        if self.mp_type == "simple":
+            self.num_filters = self.hidden_channels
+
+        self.act = (
+            (getattr(nn.functional, self.act) if self.act != "swish" else swish)
+            if isinstance(self.act, str)
+            else self.act
+        )
+        assert callable(self.act), (
+            "act must be a callable function or a string "
+            + "describing that function in torch.nn.functional"
+        )
+
+        # Gaussian Basis
+        self.distance_expansion = GaussianSmearing(0.0, self.cutoff, self.num_gaussians)
+
+        # Embedding block
+        self.embed_block = EmbeddingBlock(
+            self.num_gaussians,
+            self.num_filters,
+            self.hidden_channels,
+            self.tag_hidden_channels,
+            self.pg_hidden_channels,
+            self.phys_hidden_channels,
+            self.phys_embeds,
+            self.act,
+            self.second_layer_MLP,
+        )
+
+        # Interaction block
+        self.interaction_blocks = nn.ModuleList(
+            [
+                InteractionBlock(
+                    self.hidden_channels,
+                    self.num_filters,
+                    self.act,
+                    self.mp_type,
+                    self.complex_mp,
+                    self.graph_norm,
+                )
+                for _ in range(self.num_interactions)
+            ],
+        )
+
+        # Output block
+        self.output_block = OutputBlock(
+            self.energy_head,
+            self.hidden_channels,
+            self.act,
+            out_dim,
+        )
+
+        # Energy head
+        if self.energy_head == "weighted-av-initial-embeds":
+            self.w_lin = Linear(self.hidden_channels, 1)
+
+        # Force head
+        self.decoder = (
+            ForceDecoder(
+                self.force_decoder_type,
+                self.hidden_channels,
+                self.force_decoder_model_config,
+                self.act,
+            )
+            if "direct" in self.regress_forces
+            else None
+        )
+
+        # Skip co
+        if self.skip_co == "concat":
+            self.mlp_skip_co = Linear(out_dim * (self.num_interactions + 1), out_dim)
+        elif self.skip_co == "concat_atom":
+            self.mlp_skip_co = Linear(
+                ((self.num_interactions + 1) * self.hidden_channels),
+                self.hidden_channels,
+            )
+
+    # FAENet's forward pass in done in BaseModel, inherited here.
+    # It uses forces_forward() and energy_forward() defined below.
+
+    def forces_forward(self, preds):
+        """Predicts forces for 3D atomic systems.
+        Can be utilised to predict any atom-level property.
+
+        Args:
+            preds (dict): dictionnary with final atomic representations
+                (hidden_state) and predicted properties (e.g. energy)
+                for each graph
+
+        Returns:
+            (dict): additional predicted properties, at an atom-level (e.g. forces)
+        """
+        if self.decoder:
+            return self.decoder(preds["hidden_state"])
+
+    def energy_forward(self, data, preproc=True):
+        """Predicts any graph-level property (e.g. energy) for 3D atomic systems.
+
+        Args:
+            data (data.Batch): Batch of graphs data objects.
+            preproc (bool): Whether to apply (any given) preprocessing to the graph.
+                Default to True.
+
+        Returns:
+            (dict): predicted properties for each graph (key: "energy")
+                and final atomic representations (key: "hidden_state")
+        """
+        # Pre-process data (e.g. pbc, cutoff graph, etc.)
+        # Should output all necessary attributes, in correct format.
+        if preproc:
+            import pdb
+
+            pdb.set_trace()
+            z, batch, edge_index, rel_pos, edge_weight = self.preprocess(
+                data,
+                self.cutoff,
+                self.max_num_neighbors,
+            )
+        else:
+            rel_pos = data.pos[data.edge_index[0]] - data.pos[data.edge_index[1]]
+            z, batch, edge_index, rel_pos, edge_weight = (
+                data.atomic_numbers.long(),
+                data.batch,
+                data.edge_index,
+                rel_pos,
+                rel_pos.norm(dim=-1),
+            )
+
+        edge_attr = self.distance_expansion(edge_weight)  # RBF of pairwise distances
+        assert z.dim() == 1 and z.dtype == torch.long
+
+        # Embedding block
+        h, e = self.embed_block(
+            z,
+            rel_pos,
+            edge_attr,
+            data.tags if hasattr(data, "tags") else None,
+        )
+
+        # Compute atom weights for late energy head
+        if self.energy_head == "weighted-av-initial-embeds":
+            alpha = self.w_lin(h)
+        else:
+            alpha = None
+
+        # Interaction blocks
+        energy_skip_co = []
+        for interaction in self.interaction_blocks:
+            if self.skip_co == "concat_atom":
+                energy_skip_co.append(h)
+            elif self.skip_co:
+                energy_skip_co.append(
+                    self.output_block(h, edge_index, edge_weight, batch, alpha),
+                )
+            h = h + interaction(h, edge_index, e)
+
+        # Atom skip-co
+        if self.skip_co == "concat_atom":
+            energy_skip_co.append(h)
+            h = self.act(self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)))
+
+        energy = self.output_block(h, edge_index, edge_weight, batch, alpha)
+
+        # Skip-connection
+        energy_skip_co.append(energy)
+        if self.skip_co == "concat":
+            energy = self.mlp_skip_co(torch.cat(energy_skip_co, dim=1))
+        elif self.skip_co == "add":
+            energy = sum(energy_skip_co)
+
+        preds = {"energy": energy, "hidden_state": h}
+
+        return preds
+
+    def forward(self, data, mode="train", preproc=True):
+        """Main Forward pass.
+
+        Args:
+            data (Data): input data object, with 3D atom positions (pos)
+            mode (str): train or inference mode
+            preproc (bool): Whether to preprocess (pbc, cutoff graph)
+                the input graph or point cloud. Default: True.
+
+        Returns:
+            (dict): predicted energy, forces and final atomic hidden states
+        """
+        data = data["graph"]
+        grad_forces = forces = None
+
+        # energy gradient w.r.t. positions will be computed
+        if mode == "train" or self.regress_forces == "from_energy":
+            data.pos.requires_grad_(True)
+
+        # predict energy
+        preds = self.energy_forward(data, preproc)
+
+        if self.regress_forces:
+            if self.regress_forces in {"direct", "direct_with_gradient_target"}:
+                # predict forces
+                forces = self.forces_forward(preds)
+
+            if mode == "train" or self.regress_forces == "from_energy":
+                if "gemnet" in self.__class__.__name__.lower():
+                    # gemnet forces are already computed
+                    grad_forces = forces
+                else:
+                    # compute forces from energy gradient
+                    grad_forces = self.forces_as_energy_grad(data.pos, preds["energy"])
+
+            if self.regress_forces == "from_energy":
+                # predicted forces are the energy gradient
+                preds["forces"] = grad_forces
+            elif self.regress_forces in {"direct", "direct_with_gradient_target"}:
+                # predicted forces are the model's direct forces
+                preds["forces"] = forces
+                if mode == "train":
+                    # Store the energy gradient as target for "direct_with_gradient_target"
+                    # Use it as a metric only in "direct" mode.
+                    preds["forces_grad_target"] = grad_forces.detach()
+            else:
+                raise ValueError(
+                    f"Unknown forces regression mode {self.regress_forces}",
+                )
+
+        if not self.pred_as_dict:
+            return preds["energy"]
+
+        return preds
+
+    # def _forward(
+    #     self,
+    #     batch,
+    #     model,
+    #     frame_averaging,
+    #     mode="train",
+    #     crystal_task=True,
+    # ):
+    def _forward(
+        self,
+        graph: AbstractGraph,
+        node_feats: torch.Tensor,
+        pos: torch.Tensor,
+        edge_feats: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Perform a model forward pass when frame averaging is applied.
+
+        Args:
+            batch (data.Batch): batch of graphs with attributes:
+                - original atom positions (`pos`)
+                - batch indices (to which graph in batch each atom belongs to) (`batch`)
+                - frame averaged positions, cell and rotation matrices (`fa_pos`, `fa_cell`, `fa_rot`)
+            model: model instance
+            frame_averaging (str): symmetry preserving method (already) applied
+                ("2D", "3D", "DA", "")
+            mode (str, optional): model mode. Defaults to "train".
+                ("train", "eval")
+            crystal_task (bool, optional): Whether crystals (molecules) are considered.
+                If they are, the unit cell (3x3) is affected by frame averaged and expected as attribute.
+                (default: :obj:`True`)
+
+        Returns:
+            (dict): model predictions tensor for "energy" and "forces".
+        """
+
+        frame_averaging = "3D"
+        mode = "train"
+        crystal_task = True
+        import pdb
+
+        pdb.set_trace()
+
+        if isinstance(batch, list):
+            batch = batch[0]
+        if not hasattr(batch, "natoms"):
+            batch.natoms = torch.unique(batch.batch, return_counts=True)[1]
+
+        # Distinguish Frame Averaging prediction from traditional case.
+        if frame_averaging and frame_averaging != "DA":
+            original_pos = batch.pos
+            if crystal_task:
+                original_cell = batch.cell
+            e_all, f_all, gt_all = [], [], []
+
+            # Compute model prediction for each frame
+            for i in range(len(batch.fa_pos)):
+                batch.pos = batch.fa_pos[i]
+                if crystal_task:
+                    batch.cell = batch.fa_cell[i]
+                # Forward pass
+                preds = model(deepcopy(batch), mode=mode)
+                e_all.append(preds["energy"])
+                fa_rot = None
+
+                # Force predictions are rotated back to be equivariant
+                if preds.get("forces") is not None:
+                    fa_rot = torch.repeat_interleave(
+                        batch.fa_rot[i],
+                        batch.natoms,
+                        dim=0,
+                    )
+                    # Transform forces to guarantee equivariance of FA method
+                    g_forces = (
+                        preds["forces"]
+                        .view(-1, 1, 3)
+                        .bmm(fa_rot.transpose(1, 2).to(preds["forces"].device))
+                        .view(-1, 3)
+                    )
+                    f_all.append(g_forces)
+
+                # Energy conservation loss
+                if preds.get("forces_grad_target") is not None:
+                    if fa_rot is None:
+                        fa_rot = torch.repeat_interleave(
+                            batch.fa_rot[i],
+                            batch.natoms,
+                            dim=0,
+                        )
+                    # Transform gradients to stay consistent with FA
+                    g_grad_target = (
+                        preds["forces_grad_target"]
+                        .view(-1, 1, 3)
+                        .bmm(
+                            fa_rot.transpose(1, 2).to(
+                                preds["forces_grad_target"].device,
+                            ),
+                        )
+                        .view(-1, 3)
+                    )
+                    gt_all.append(g_grad_target)
+
+            batch.pos = original_pos
+            if crystal_task:
+                batch.cell = original_cell
+
+            # Average predictions over frames
+            preds["energy"] = sum(e_all) / len(e_all)
+            if len(f_all) > 0 and all(y is not None for y in f_all):
+                preds["forces"] = sum(f_all) / len(f_all)
+            if len(gt_all) > 0 and all(y is not None for y in gt_all):
+                preds["forces_grad_target"] = sum(gt_all) / len(gt_all)
+
+        # Traditional case (no frame averaging)
+        else:
+            preds = model(batch, mode=mode)
+
+        if preds["energy"].shape[-1] == 1:
+            preds["energy"] = preds["energy"].view(-1)
+
+        return preds
+
+    def forces_as_energy_grad(self, pos, energy):
+        """Computes forces from energy gradient
+
+        Args:
+            pos (tensor): 3D atom positions
+            energy (tensor): system's predicted energy
+
+        Returns:
+            (tensor): forces as the energy gradient w.r.t. atom positions
+        """
+
+        return -1 * (
+            torch.autograd.grad(
+                energy,
+                pos,
+                grad_outputs=torch.ones_like(energy),
+                create_graph=True,
+            )[0]
+        )
+
+    @property
+    def num_params(self):
+        return sum(p.numel() for p in self.parameters())

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -422,7 +422,7 @@ class FAENet(AbstractPyGModel):
                 if crystal_task:
                     batch.cell = batch.fa_cell[frame_idx]
                 # Forward pass
-                embeddings = self.first_forward(deepcopy(batch))
+                embeddings = self.first_forward(batch)
                 all_embeddings.append(embeddings)
             batch.pos = original_pos
             batch.cell = original_cell

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -81,6 +81,9 @@ class FAENet(AbstractPyGModel):
             (`"simple"`, `"mlp"`, `"res"`, `"res_updown"`)
         force_decoder_model_config (dict): contains information about the
             for decoder architecture (e.g. number of layers, hidden size).
+        frame_averaging (str): Transform method *already* used.
+            Can be 2D FA, 3D FA, Data Augmentation or no FA, respectively denoted by
+            (`"2D"`, `"3D"`, `"DA"`, `""`)
     """
 
     def __init__(
@@ -110,6 +113,7 @@ class FAENet(AbstractPyGModel):
         force_decoder_model_config: dict | None = {"hidden_channels": 128},
         embedding_size: int = 100,
         average_frame_embeddings: bool = False,
+        frame_averaging: str = "3D",
         **kwargs,
     ):
         super().__init__(atom_embedding_dim=118)
@@ -138,6 +142,7 @@ class FAENet(AbstractPyGModel):
         self.pred_as_dict = pred_as_dict
         self.emb_size = embedding_size
         self.average_frame_embeddings = average_frame_embeddings
+        self.frame_averaging = frame_averaging
 
         if isinstance(self.preprocess, str):
             self.preprocess = eval(self.preprocess)
@@ -390,7 +395,7 @@ class FAENet(AbstractPyGModel):
             (dict): model predictions tensor for "energy" and "forces".
         """
 
-        frame_averaging = "3D"
+
         crystal_task = True
         batch = graph
 
@@ -405,7 +410,7 @@ class FAENet(AbstractPyGModel):
                 )
 
         # Distinguish Frame Averaging prediction from traditional case.
-        if frame_averaging and frame_averaging != "DA":
+        if self.frame_averaging and self.frame_averaging != "DA":
             original_pos = batch.pos
             original_cell = getattr(batch, "cell", None)
 

--- a/matsciml/models/pyg/faenet/helper.py
+++ b/matsciml/models/pyg/faenet/helper.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Dict
+from typing import Tuple
 
 import torch
 import torch.nn as nn
 from torch_geometric.nn import radius_graph
-
-
-def swish(x):
-    """Swish activation function"""
-    return torch.nn.functional.silu(x)
 
 
 def get_pbc_distances(
@@ -20,7 +16,7 @@ def get_pbc_distances(
     neighbors: torch.Tensor,
     return_offsets: bool = False,
     return_rel_pos: bool = False,
-) -> Dict[str, torch.Tensor]:
+) -> dict[str, torch.Tensor]:
     """Compute distances between atoms with periodic boundary conditions
 
     Args:
@@ -67,8 +63,8 @@ def get_pbc_distances(
 
 
 def base_preprocess(
-    data, cutoff: int = 6.0, max_num_neighbors: int = 40
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    data, cutoff: int = 6.0, max_num_neighbors: int = 40,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Preprocess datapoint: create a cutoff graph,
         compute distances and relative positions.
 
@@ -104,8 +100,8 @@ def base_preprocess(
 
 
 def pbc_preprocess(
-    data, cutoff: int = 6.0, max_num_neighbors: int = 40
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    data, cutoff: int = 6.0, max_num_neighbors: int = 40,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Preprocess datapoint using periodic boundary conditions
         to improve the existing graph.
 

--- a/matsciml/models/pyg/faenet/helper.py
+++ b/matsciml/models/pyg/faenet/helper.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import math
+import numbers
+import random
+
+import torch
+import torch.nn as nn
+import torch_geometric
+from torch_geometric.nn import radius_graph
+from torch_geometric.transforms import LinearTransformation
+
+
+def swish(x):
+    """Swish activation function"""
+    return torch.nn.functional.silu(x)
+
+
+def get_pbc_distances(
+    pos,
+    edge_index,
+    cell,
+    cell_offsets,
+    neighbors,
+    return_offsets=False,
+    return_rel_pos=False,
+):
+    """Compute distances between atoms with periodic boundary conditions
+
+    Args:
+        pos (tensor): (N, 3) tensor of atomic positions
+        edge_index (tensor): (2, E) tensor of edge indices
+        cell (tensor): (3, 3) tensor of cell vectors
+        cell_offsets (tensor): (N, 3) tensor of cell offsets
+        neighbors (tensor): (N, 3) tensor of neighbor indices
+        return_offsets (bool): return the offsets
+        return_rel_pos (bool): return the relative positions vectors
+
+    Returns:
+        (dict): dictionary with the updated edge_index, atom distances,
+            and optionally the offsets and distance vectors.
+    """
+    rel_pos = pos[edge_index[0]] - pos[edge_index[1]]
+
+    # correct for pbc
+    neighbors = neighbors.to(cell.device)
+    cell = torch.repeat_interleave(cell, neighbors, dim=0)
+    offsets = cell_offsets.float().view(-1, 1, 3).bmm(cell.float()).view(-1, 3)
+    rel_pos += offsets
+
+    # compute distances
+    distances = rel_pos.norm(dim=-1)
+
+    # redundancy: remove zero distances
+    nonzero_idx = torch.arange(len(distances), device=distances.device)[distances != 0]
+    edge_index = edge_index[:, nonzero_idx]
+    distances = distances[nonzero_idx]
+
+    out = {
+        "edge_index": edge_index,
+        "distances": distances,
+    }
+
+    if return_rel_pos:
+        out["rel_pos"] = rel_pos[nonzero_idx]
+
+    if return_offsets:
+        out["offsets"] = offsets[nonzero_idx]
+
+    return out
+
+
+def base_preprocess(data, cutoff=6.0, max_num_neighbors=40):
+    """Preprocess datapoint: create a cutoff graph,
+        compute distances and relative positions.
+
+        Args:
+        data (data.Data): data object with specific attributes:
+                - batch (N): index of the graph to which each atom belongs to in this batch
+                - pos (N,3): atom positions
+                - atomic_numbers (N): atomic numbers of each atom in the batch
+                - edge_index (2,E): edge indices, for all graphs of the batch
+            With B is the batch size, N the number of atoms in the batch (across all graphs),
+            and E the number of edges in the batch.
+            If these attributes are not present, implement your own preprocess function.
+        cutoff (int): cutoff radius (in Angstrom)
+        max_num_neighbors (int): maximum number of neighbors per node.
+
+    Returns:
+        (tuple): atomic_numbers, batch, sparse adjacency matrix, relative positions, distances
+    """
+    edge_index = radius_graph(
+        data.pos,
+        r=cutoff,
+        batch=data.batch,
+        max_num_neighbors=max_num_neighbors,
+    )
+    rel_pos = data.pos[edge_index[0]] - data.pos[edge_index[1]]
+    return (
+        data.atomic_numbers.long(),
+        data.batch,
+        edge_index,
+        rel_pos,
+        rel_pos.norm(dim=-1),
+    )
+
+
+def pbc_preprocess(data, cutoff=6.0, max_num_neighbors=40):
+    """Preprocess datapoint using periodic boundary conditions
+        to improve the existing graph.
+
+    Args:
+        data (data.Data): data object with specific attributes. B is the batch size,
+            N the number of atoms in the batch (across all graphs), E the number of edges in the batch.
+                - batch (N): index of the graph to which each atom belongs to in this batch
+                - pos (N,3): atom positions
+                - atomic_numbers (N): atomic numbers of each atom in the batch
+                - cell (B, 3, 3): unit cell containing each graph, for materials.
+                - cell_offsets (E, 3): cell offsets for each edge, for materials
+                - neighbors (B): total number of edges inside each graph.
+                - edge_index (2,E): edge indices, for all graphs of the batch
+            If these attributes are not present, implement your own preprocess function.
+
+    Returns:
+        (tuple): atomic_numbers, batch, sparse adjacency matrix, relative positions, distances
+    """
+    import pdb
+
+    pdb.set_trace()
+    out = get_pbc_distances(
+        data.pos,
+        data.edge_index,
+        data["cell"],
+        data.cell_offsets,
+        data.neighbors,
+        return_rel_pos=True,
+    )
+
+    return (
+        data.atomic_numbers.long(),
+        data.batch,
+        out["edge_index"],
+        out["rel_pos"],
+        out["distances"],
+    )
+
+
+class GaussianSmearing(nn.Module):
+    r"""Smears a distance distribution by a Gaussian function."""
+
+    def __init__(self, start=0.0, stop=5.0, num_gaussians=50):
+        super().__init__()
+        offset = torch.linspace(start, stop, num_gaussians)
+        self.coeff = -0.5 / (offset[1] - offset[0]).item() ** 2
+        self.register_buffer("offset", offset)
+
+    def forward(self, dist):
+        dist = dist.view(-1, 1) - self.offset.view(1, -1)
+        return torch.exp(self.coeff * torch.pow(dist, 2))

--- a/matsciml/models/pyg/faenet/helper.py
+++ b/matsciml/models/pyg/faenet/helper.py
@@ -124,9 +124,6 @@ def pbc_preprocess(data, cutoff=6.0, max_num_neighbors=40):
     Returns:
         (tuple): atomic_numbers, batch, sparse adjacency matrix, relative positions, distances
     """
-    import pdb
-
-    pdb.set_trace()
     out = get_pbc_distances(
         data.pos,
         data.edge_index,

--- a/matsciml/models/pyg/faenet/layers.py
+++ b/matsciml/models/pyg/faenet/layers.py
@@ -1,21 +1,28 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Dict, Optional, Union
+from typing import Dict
+from typing import Optional
+from typing import Union
 
 import pandas as pd
 import torch
 import torch.nn as nn
-from mendeleev.fetch import fetch_ionization_energies, fetch_table
+from mendeleev.fetch import fetch_ionization_energies
+from mendeleev.fetch import fetch_table
 from torch import nn
-from torch.nn import Embedding, Linear
-from torch_geometric.nn import LayerNorm, MessagePassing
+from torch.nn import Embedding
+from torch.nn import Linear
+from torch_geometric.nn import LayerNorm
+from torch_geometric.nn import MessagePassing
 from torch_geometric.nn.norm import GraphNorm
 from torch_geometric.nn.pool import global_add_pool
 from torch_geometric.typing import Size
 from torch_scatter import scatter
 
-from matsciml.common.types import AbstractGraph, BatchDict, DataDict
+from matsciml.common.types import AbstractGraph
+from matsciml.common.types import BatchDict
+from matsciml.common.types import DataDict
 from matsciml.models.base import AbstractPyGModel
 from matsciml.models.pyg.faenet.helper import *
 from matsciml.models.pyg.faenet.layers import *
@@ -256,7 +263,6 @@ class EmbeddingBlock(nn.Module):
         # Create atom embeddings based on its characteristic number
         h = self.emb(z)
 
-        # import pdb; pdb.set_trace()
         # if self.phys_emb.device != h.device:
         #     self.phys_emb = self.phys_emb.to(h.device)
 
@@ -275,7 +281,9 @@ class EmbeddingBlock(nn.Module):
         # Concat period & group embedding
         if self.use_pg:
             h_period = self.period_embedding(self.phys_emb.period[z])
-            h_group = self.group_embedding(self.phys_emb.group[z])
+            # z = tensor([55, 63, 68, 47, 41,  6, 28,  6, 12, 51, 30, 47, 67,  7, 24, 26])
+            # CG: if this isnt added, how can 0 of embedding be used? also 19 goes out of range
+            h_group = self.group_embedding(self.phys_emb.group[z]-1)
             h = torch.cat((h, h_period, h_group), dim=1)
 
         # MLP

--- a/matsciml/models/pyg/faenet/layers.py
+++ b/matsciml/models/pyg/faenet/layers.py
@@ -1,9 +1,23 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from typing import Dict, Optional, Union
+
 import pandas as pd
 import torch
 import torch.nn as nn
 from mendeleev.fetch import fetch_ionization_energies, fetch_table
+from torch import nn
+from torch.nn import Embedding, Linear
+from torch_geometric.nn import LayerNorm, MessagePassing
+from torch_geometric.nn.norm import GraphNorm
+from torch_geometric.nn.pool import global_add_pool
+from torch_geometric.typing import Size
+
+from matsciml.common.types import AbstractGraph, BatchDict, DataDict
+from matsciml.models.base import AbstractPyGModel
+from matsciml.models.pyg.faenet.helper import *
+from matsciml.models.pyg.faenet.layers import *
 
 
 class PhysEmbedding(nn.Module):
@@ -119,7 +133,344 @@ class PhysEmbedding(nn.Module):
                 self.register_buffer("properties", properties)
 
 
-import torch.nn as nn
+class EmbeddingBlock(nn.Module):
+    """Initialise atom and edge representations."""
+
+    def __init__(
+        self,
+        num_gaussians,
+        num_filters,
+        hidden_channels,
+        tag_hidden_channels,
+        pg_hidden_channels,
+        phys_hidden_channels,
+        phys_embeds,
+        act,
+        second_layer_MLP,
+    ):
+        super().__init__()
+        self.act = act
+        self.use_tag = tag_hidden_channels > 0
+        self.use_pg = pg_hidden_channels > 0
+        self.use_mlp_phys = phys_hidden_channels > 0 and phys_embeds
+        self.second_layer_MLP = second_layer_MLP
+
+        # --- Node embedding ---
+
+        # Phys embeddings
+        self.phys_emb = PhysEmbedding(
+            props=phys_embeds,
+            props_grad=phys_hidden_channels > 0,
+            pg=self.use_pg,
+        )
+        # With MLP
+        if self.use_mlp_phys:
+            self.phys_lin = Linear(self.phys_emb.n_properties, phys_hidden_channels)
+        else:
+            phys_hidden_channels = self.phys_emb.n_properties
+
+        # Period + group embeddings
+        if self.use_pg:
+            self.period_embedding = Embedding(
+                self.phys_emb.period_size,
+                pg_hidden_channels,
+            )
+            self.group_embedding = Embedding(
+                self.phys_emb.group_size,
+                pg_hidden_channels,
+            )
+
+        # Tag embedding
+        if tag_hidden_channels:
+            self.tag_embedding = Embedding(3, tag_hidden_channels)
+
+        # Main embedding
+        self.emb = Embedding(
+            85,
+            hidden_channels
+            - tag_hidden_channels
+            - phys_hidden_channels
+            - 2 * pg_hidden_channels,
+        )
+
+        # MLP
+        self.lin = Linear(hidden_channels, hidden_channels)
+        if self.second_layer_MLP:
+            self.lin_2 = Linear(hidden_channels, hidden_channels)
+
+        # --- Edge embedding ---
+        self.lin_e1 = Linear(3, num_filters // 2)  # r_ij
+        self.lin_e12 = Linear(num_gaussians, num_filters - (num_filters // 2))  # d_ij
+
+        if self.second_layer_MLP:
+            self.lin_e2 = Linear(num_filters, num_filters)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        self.emb.reset_parameters()
+        if self.use_mlp_phys:
+            nn.init.xavier_uniform_(self.phys_lin.weight)
+        if self.use_tag:
+            self.tag_embedding.reset_parameters()
+        if self.use_pg:
+            self.period_embedding.reset_parameters()
+            self.group_embedding.reset_parameters()
+        nn.init.xavier_uniform_(self.lin.weight)
+        self.lin.bias.data.fill_(0)
+        nn.init.xavier_uniform_(self.lin_e1.weight)
+        self.lin_e1.bias.data.fill_(0)
+        if self.second_layer_MLP:
+            nn.init.xavier_uniform_(self.lin_2.weight)
+            self.lin_2.bias.data.fill_(0)
+            nn.init.xavier_uniform_(self.lin_e2.weight)
+            self.lin_e2.bias.data.fill_(0)
+
+    def forward(self, z, rel_pos, edge_attr, tag=None, subnodes=None):
+        """Forward pass of the Embedding block.
+        Called in FAENet to generate initial atom and edge representations.
+
+        Args:
+            z (tensor): atomic numbers. (num_atoms, )
+            rel_pos (tensor): relative atomic positions. (num_edges, 3)
+            edge_attr (tensor): RBF of pairwise distances. (num_edges, num_gaussians)
+            tag (tensor, optional): atom information specific to OCP. Defaults to None.
+
+        Returns:
+            (tensor, tensor): atom embeddings, edge embeddings
+        """
+
+        # --- Edge embedding --
+        rel_pos = self.lin_e1(rel_pos)  # r_ij
+        edge_attr = self.lin_e12(edge_attr)  # d_ij
+        e = torch.cat((rel_pos, edge_attr), dim=1)
+        e = self.act(e)  # can comment out
+
+        if self.second_layer_MLP:
+            # e = self.lin_e2(e)
+            e = self.act(self.lin_e2(e))
+
+        # --- Node embedding --
+
+        # Create atom embeddings based on its characteristic number
+        h = self.emb(z)
+
+        if self.phys_emb.device != h.device:
+            self.phys_emb = self.phys_emb.to(h.device)
+
+        # Concat tag embedding
+        if self.use_tag:
+            h_tag = self.tag_embedding(tag)
+            h = torch.cat((h, h_tag), dim=1)
+
+        # Concat physics embeddings
+        if self.phys_emb.n_properties > 0:
+            h_phys = self.phys_emb.properties[z]
+            if self.use_mlp_phys:
+                h_phys = self.phys_lin(h_phys)
+            h = torch.cat((h, h_phys), dim=1)
+
+        # Concat period & group embedding
+        if self.use_pg:
+            h_period = self.period_embedding(self.phys_emb.period[z])
+            h_group = self.group_embedding(self.phys_emb.group[z])
+            h = torch.cat((h, h_period, h_group), dim=1)
+
+        # MLP
+        h = self.act(self.lin(h))
+        if self.second_layer_MLP:
+            h = self.act(self.lin_2(h))
+
+        return h, e
+
+
+class InteractionBlock(MessagePassing):
+    """Updates atom representations through custom message passing."""
+
+    def __init__(
+        self,
+        hidden_channels,
+        num_filters,
+        act,
+        mp_type,
+        complex_mp,
+        graph_norm,
+    ):
+        super().__init__()
+        self.act = act
+        self.mp_type = mp_type
+        self.hidden_channels = hidden_channels
+        self.complex_mp = complex_mp
+        self.graph_norm = graph_norm
+        if graph_norm:
+            self.graph_norm = GraphNorm(
+                hidden_channels if "updown" not in self.mp_type else num_filters,
+            )
+
+        if self.mp_type == "simple":
+            self.lin_h = nn.Linear(hidden_channels, hidden_channels)
+
+        elif self.mp_type == "updownscale":
+            self.lin_geom = nn.Linear(num_filters, num_filters)
+            self.lin_down = nn.Linear(hidden_channels, num_filters)
+            self.lin_up = nn.Linear(num_filters, hidden_channels)
+
+        elif self.mp_type == "updownscale_base":
+            self.lin_geom = nn.Linear(num_filters + 2 * hidden_channels, num_filters)
+            self.lin_down = nn.Linear(hidden_channels, num_filters)
+            self.lin_up = nn.Linear(num_filters, hidden_channels)
+
+        elif self.mp_type == "updown_local_env":
+            self.lin_down = nn.Linear(hidden_channels, num_filters)
+            self.lin_geom = nn.Linear(num_filters, num_filters)
+            self.lin_up = nn.Linear(2 * num_filters, hidden_channels)
+
+        else:  # base
+            self.lin_geom = nn.Linear(
+                num_filters + 2 * hidden_channels,
+                hidden_channels,
+            )
+            self.lin_h = nn.Linear(hidden_channels, hidden_channels)
+
+        if self.complex_mp:
+            self.other_mlp = nn.Linear(hidden_channels, hidden_channels)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.mp_type != "simple":
+            nn.init.xavier_uniform_(self.lin_geom.weight)
+            self.lin_geom.bias.data.fill_(0)
+        if self.complex_mp:
+            nn.init.xavier_uniform_(self.other_mlp.weight)
+            self.other_mlp.bias.data.fill_(0)
+        if self.mp_type in {"updownscale", "updownscale_base", "updown_local_env"}:
+            nn.init.xavier_uniform_(self.lin_up.weight)
+            self.lin_up.bias.data.fill_(0)
+            nn.init.xavier_uniform_(self.lin_down.weight)
+            self.lin_down.bias.data.fill_(0)
+        else:
+            nn.init.xavier_uniform_(self.lin_h.weight)
+            self.lin_h.bias.data.fill_(0)
+
+    def forward(self, h, edge_index, e):
+        """Forward pass of the Interaction block.
+        Called in FAENet forward pass to update atom representations.
+
+        Args:
+            h (tensor): atom embedddings. (num_atoms, hidden_channels)
+            edge_index (tensor): adjacency matrix. (2, num_edges)
+            e (tensor): edge embeddings. (num_edges, num_filters)
+
+        Returns:
+            (tensor): updated atom embeddings
+        """
+        # Define edge embedding
+        if self.mp_type in {"base", "updownscale_base"}:
+            e = torch.cat([e, h[edge_index[0]], h[edge_index[1]]], dim=1)
+
+        if self.mp_type in {
+            "updownscale",
+            "base",
+            "updownscale_base",
+        }:
+            e = self.act(self.lin_geom(e))
+
+        # --- Message Passing block --
+
+        if self.mp_type == "updownscale" or self.mp_type == "updownscale_base":
+            h = self.act(self.lin_down(h))  # downscale node rep.
+            h = self.propagate(edge_index, x=h, W=e)  # propagate
+            if self.graph_norm:
+                h = self.act(self.graph_norm(h))
+            h = self.act(self.lin_up(h))  # upscale node rep.
+
+        elif self.mp_type == "updown_local_env":
+            h = self.act(self.lin_down(h))
+            chi = self.propagate(edge_index, x=h, W=e, local_env=True)
+            e = self.lin_geom(e)
+            h = self.propagate(edge_index, x=h, W=e)  # propagate
+            if self.graph_norm:
+                h = self.act(self.graph_norm(h))
+            h = torch.cat((h, chi), dim=1)
+            h = self.lin_up(h)
+
+        elif self.mp_type in {"base", "simple"}:
+            h = self.propagate(edge_index, x=h, W=e)  # propagate
+            if self.graph_norm:
+                h = self.act(self.graph_norm(h))
+            h = self.act(self.lin_h(h))
+
+        else:
+            raise ValueError("mp_type provided does not exist")
+
+        if self.complex_mp:
+            h = self.act(self.other_mlp(h))
+
+        return h
+
+    def message(self, x_j, W, local_env=None):
+        if local_env is not None:
+            return W
+        else:
+            return x_j * W
+
+
+class OutputBlock(nn.Module):
+    """Compute task-specific predictions from final atom representations."""
+
+    def __init__(self, energy_head, hidden_channels, act, out_dim=1):
+        super().__init__()
+        self.energy_head = energy_head
+        self.act = act
+
+        self.lin1 = Linear(hidden_channels, hidden_channels // 2)
+        self.lin2 = Linear(hidden_channels // 2, out_dim)
+
+        if self.energy_head == "weighted-av-final-embeds":
+            self.w_lin = Linear(hidden_channels, 1)
+
+    def reset_parameters(self):
+        nn.init.xavier_uniform_(self.lin1.weight)
+        self.lin1.bias.data.fill_(0)
+        nn.init.xavier_uniform_(self.lin2.weight)
+        self.lin2.bias.data.fill_(0)
+        if self.energy_head == "weighted-av-final-embeds":
+            nn.init.xavier_uniform_(self.w_lin.weight)
+            self.w_lin.bias.data.fill_(0)
+
+    def forward(self, h, edge_index, edge_weight, batch, alpha):
+        """Forward pass of the Output block.
+        Called in FAENet to make prediction from final atom representations.
+
+        Args:
+            h (tensor): atom representations. (num_atoms, hidden_channels)
+            edge_index (tensor): adjacency matrix. (2, num_edges)
+            edge_weight (tensor): edge weights. (num_edges, )
+            batch (tensor): batch indices. (num_atoms, )
+            alpha (tensor): atom attention weights for late energy head. (num_atoms, )
+
+        Returns:
+            (tensor): graph-level representation (e.g. energy prediction)
+        """
+        if self.energy_head == "weighted-av-final-embeds":
+            alpha = self.w_lin(h)
+
+        # MLP
+        h = self.lin1(h)
+        h = self.act(h)
+        h = self.lin2(h)
+
+        if self.energy_head in {
+            "weighted-av-initial-embeds",
+            "weighted-av-final-embeds",
+        }:
+            h = h * alpha
+
+        # Global pooling
+        out = torch.scatter(h, batch, dim=0, reduce="add")
+
+        return out
 
 
 class LambdaLayer(nn.Module):

--- a/matsciml/models/pyg/faenet/layers.py
+++ b/matsciml/models/pyg/faenet/layers.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
-from typing import Dict
-from typing import Optional
-from typing import Union
-
 import pandas as pd
 import torch
 import torch.nn as nn
@@ -13,20 +8,11 @@ from mendeleev.fetch import fetch_table
 from torch import nn
 from torch.nn import Embedding
 from torch.nn import Linear
-from torch_geometric.nn import LayerNorm
 from torch_geometric.nn import MessagePassing
 from torch_geometric.nn.norm import GraphNorm
-from torch_geometric.nn.pool import global_add_pool
-from torch_geometric.typing import Size
 from torch_scatter import scatter
 
-from matsciml.common.types import AbstractGraph
-from matsciml.common.types import BatchDict
-from matsciml.common.types import DataDict
-from matsciml.models.base import AbstractPyGModel
 from matsciml.models.pyg.faenet.helper import *
-from matsciml.models.pyg.faenet.layers import *
-
 
 class PhysEmbedding(nn.Module):
     """

--- a/matsciml/models/pyg/faenet/layers.py
+++ b/matsciml/models/pyg/faenet/layers.py
@@ -245,9 +245,9 @@ class EmbeddingBlock(nn.Module):
         z: torch.Tensor,
         rel_pos: torch.Tensor,
         edge_attr: torch.Tensor,
-        tag: Union[torch.Tensor, None] = None,
+        tag: torch.Tensor | None = None,
         subnodes=None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass of the Embedding block.
         Called in FAENet to generate initial atom and edge representations.
 
@@ -434,9 +434,6 @@ class InteractionBlock(MessagePassing):
     def message(
         self, x_j: torch.Tensor, W: torch.Tensor, local_env=None,
     ) -> torch.Tensor:
-        import pdb
-
-        pdb.set_trace()
         if local_env is not None:
             return W
         else:

--- a/matsciml/models/pyg/faenet/layers.py
+++ b/matsciml/models/pyg/faenet/layers.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import pandas as pd
+import torch
+import torch.nn as nn
+from mendeleev.fetch import fetch_ionization_energies, fetch_table
+
+
+class PhysEmbedding(nn.Module):
+    """
+    Create physics-aware embeddings for each atom based their properties.
+
+    Args:
+        props (bool, optional): Create an embedding of physical
+            properties. (default: :obj:`True`)
+        props_grad (bool, optional): Learn a physics-aware embedding
+            instead of keeping it fixed. (default: :obj:`False`)
+        pg (bool, optional): Learn two embeddings based on period and
+            group information respectively. (default: :obj:`False`)
+        short (bool, optional): Remove all columns containing NaN values.
+            (default: :obj:`False`)
+    """
+
+    def __init__(self, props=True, props_grad=False, pg=False, short=False) -> None:
+        super().__init__()
+
+        self.properties_list = [
+            "atomic_radius",
+            "atomic_volume",
+            "density",
+            "dipole_polarizability",
+            "electron_affinity",
+            "en_allen",
+            "vdw_radius",
+            "metallic_radius",
+            "metallic_radius_c12",
+            "covalent_radius_pyykko_double",
+            "covalent_radius_pyykko_triple",
+            "covalent_radius_pyykko",
+            "IE1",
+            "IE2",
+        ]
+        self.group_size = 0
+        self.period_size = 0
+        self.n_properties = 0
+
+        self.props = props
+        self.props_grad = props_grad
+        self.pg = pg
+        self.short = short
+
+        group = None
+        period = None
+
+        # Load table with all properties of all periodic table elements
+        df = fetch_table("elements")
+        df = df.set_index("atomic_number")
+
+        # Add ionization energy
+        ies = fetch_ionization_energies(degree=[1, 2])
+        df = pd.concat([df, ies], axis=1)
+
+        # Fetch group and period data
+        if pg:
+            df.group_id = df.group_id.fillna(value=19.0)
+            self.group_size = df.group_id.unique().shape[0]
+            group = torch.cat(
+                [
+                    torch.ones(1, dtype=torch.long),
+                    torch.tensor(df.group_id.loc[:100].values, dtype=torch.long),
+                ],
+            )
+
+            self.period_size = df.period.loc[:100].unique().shape[0]
+            period = torch.cat(
+                [
+                    torch.ones(1, dtype=torch.long),
+                    torch.tensor(df.period.loc[:100].values, dtype=torch.long),
+                ],
+            )
+
+        self.register_buffer("group", group)
+        self.register_buffer("period", period)
+
+        # Create an embedding of physical properties
+        if props:
+            # Select only potentially relevant elements
+            df = df[self.properties_list]
+            df = df.loc[:85, :]
+
+            # Normalize
+            df = (df - df.mean()) / df.std()
+            # normalized_df=(df-df.min())/(df.max()-df.min())
+
+            # Process 'NaN' values and remove further non-essential columns
+            if self.short:
+                self.properties_list = df.columns[~df.isnull().any()].tolist()
+                df = df[self.properties_list]
+            else:
+                self.properties_list = df.columns[
+                    pd.isnull(df).sum() < int(1 / 2 * df.shape[0])
+                ].tolist()
+                df = df[self.properties_list]
+                col_missing_val = df.columns[df.isna().any()].tolist()
+                df[col_missing_val] = df[col_missing_val].fillna(
+                    value=df[col_missing_val].mean(),
+                )
+
+            self.n_properties = len(df.columns)
+            properties = torch.cat(
+                [
+                    torch.zeros(1, self.n_properties),
+                    torch.from_numpy(df.values).float(),
+                ],
+            )
+            if props_grad:
+                self.register_parameter("properties", nn.Parameter(properties))
+            else:
+                self.register_buffer("properties", properties)
+
+
+import torch.nn as nn
+
+
+class LambdaLayer(nn.Module):
+    def __init__(self, func):
+        super().__init__()
+        self.func = func
+
+    def forward(self, x):
+        return self.func(x)
+
+
+class ForceDecoder(nn.Module):
+    """
+    Predicts a force vector per atom from final atomic representations.
+
+    Args:
+        type (str): Type of force decoder to use
+        input_channels (int): Number of input channels
+        model_configs (dict): Dictionary of config parameters for the
+            decoder's model
+        act (callable): Activation function (NOT a module)
+
+    Raises:
+        ValueError: Unknown type of decoder
+
+    Returns:
+        (torch.Tensor): Predicted force vector per atom
+    """
+
+    def __init__(self, type, input_channels, model_configs, act):
+        super().__init__()
+        self.type = type
+        self.act = act
+        assert type in model_configs, f"Unknown type of force decoder: `{type}`"
+        self.model_config = model_configs[type]
+        if self.model_config.get("norm", "batch1d") == "batch1d":
+            self.norm = lambda n: nn.BatchNorm1d(n)
+        elif self.model_config["norm"] == "layer":
+            self.norm = lambda n: nn.LayerNorm(n)
+        elif self.model_config["norm"] in ["", None]:
+            self.norm = lambda n: nn.Identity()
+        else:
+            raise ValueError(f"Unknown norm type: {self.model_config['norm']}")
+        # Define the different force decoder models
+        if self.type == "simple":
+            assert "hidden_channels" in self.model_config
+            self.model = nn.Sequential(
+                nn.Linear(
+                    input_channels,
+                    self.model_config["hidden_channels"],
+                ),
+                LambdaLayer(act),
+                nn.Linear(self.model_config["hidden_channels"], 3),
+            )
+        elif self.type == "mlp":  # from forcenet
+            assert "hidden_channels" in self.model_config
+            self.model = nn.Sequential(
+                nn.Linear(
+                    input_channels,
+                    self.model_config["hidden_channels"],
+                ),
+                self.norm(self.model_config["hidden_channels"]),
+                LambdaLayer(act),
+                nn.Linear(self.model_config["hidden_channels"], 3),
+            )
+        elif self.type == "res":
+            assert "hidden_channels" in self.model_config
+            self.mlp_1 = nn.Sequential(
+                nn.Linear(
+                    input_channels,
+                    input_channels,
+                ),
+                self.norm(input_channels),
+                LambdaLayer(act),
+            )
+            self.mlp_2 = nn.Sequential(
+                nn.Linear(
+                    input_channels,
+                    input_channels,
+                ),
+                self.norm(input_channels),
+                LambdaLayer(act),
+            )
+            self.mlp_3 = nn.Sequential(
+                nn.Linear(
+                    input_channels,
+                    self.model_config["hidden_channels"],
+                ),
+                self.norm(self.model_config["hidden_channels"]),
+                LambdaLayer(act),
+                nn.Linear(self.model_config["hidden_channels"], 3),
+            )
+        elif self.type == "res_updown":
+            assert "hidden_channels" in self.model_config
+            self.mlp_1 = nn.Sequential(
+                nn.Linear(
+                    input_channels,
+                    self.model_config["hidden_channels"],
+                ),
+                self.norm(self.model_config["hidden_channels"]),
+                LambdaLayer(act),
+            )
+            self.mlp_2 = nn.Sequential(
+                nn.Linear(
+                    self.model_config["hidden_channels"],
+                    self.model_config["hidden_channels"],
+                ),
+                self.norm(self.model_config["hidden_channels"]),
+                LambdaLayer(act),
+            )
+            self.mlp_3 = nn.Sequential(
+                nn.Linear(
+                    self.model_config["hidden_channels"],
+                    input_channels,
+                ),
+                self.norm(input_channels),
+                LambdaLayer(act),
+            )
+            self.mlp_4 = nn.Sequential(
+                nn.Linear(
+                    input_channels,
+                    self.model_config["hidden_channels"],
+                ),
+                self.norm(self.model_config["hidden_channels"]),
+                LambdaLayer(act),
+                nn.Linear(self.model_config["hidden_channels"], 3),
+            )
+        else:
+            raise ValueError(f"Unknown force decoder type: `{self.type}`")
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        for layer in self.children():
+            if hasattr(layer, "reset_parameters"):
+                layer.reset_parameters()
+            else:
+                if hasattr(layer, "weight"):
+                    nn.init.xavier_uniform_(layer.weight)
+                if hasattr(layer, "bias"):
+                    layer.bias.data.fill_(0)
+
+    def forward(self, h):
+        if self.type == "res":
+            return self.mlp_3(self.mlp_2(self.mlp_1(h)) + h)
+        elif self.type == "res_updown":
+            return self.mlp_4(self.mlp_3(self.mlp_2(self.mlp_1(h))) + h)
+        return self.model(h)

--- a/matsciml/models/pyg/faenet/layers.py
+++ b/matsciml/models/pyg/faenet/layers.py
@@ -188,15 +188,17 @@ class EmbeddingBlock(nn.Module):
             self.period_embedding = Embedding(
                 self.phys_emb.period_size,
                 pg_hidden_channels,
+                padding_idx=0,
             )
             self.group_embedding = Embedding(
                 self.phys_emb.group_size,
                 pg_hidden_channels,
+                padding_idx=0,
             )
 
         # Tag embedding
         if tag_hidden_channels:
-            self.tag_embedding = Embedding(3, tag_hidden_channels)
+            self.tag_embedding = Embedding(3, tag_hidden_channels, padding_idx=0)
 
         # Main embedding
         self.emb = Embedding(
@@ -205,6 +207,7 @@ class EmbeddingBlock(nn.Module):
             - tag_hidden_channels
             - phys_hidden_channels
             - 2 * pg_hidden_channels,
+            padding_idx=0,
         )
 
         # MLP
@@ -287,9 +290,7 @@ class EmbeddingBlock(nn.Module):
         # Concat period & group embedding
         if self.use_pg:
             h_period = self.period_embedding(self.phys_emb.period[z])
-            # z = tensor([55, 63, 68, 47, 41,  6, 28,  6, 12, 51, 30, 47, 67,  7, 24, 26])
-            # CG: if this isnt added, how can 0 of embedding be used? also 19 goes out of range
-            h_group = self.group_embedding(self.phys_emb.group[z]-1)
+            h_group = self.group_embedding(self.phys_emb.group[z])
             h = torch.cat((h, h_period, h_group), dim=1)
 
         # MLP

--- a/matsciml/models/pyg/faenet/layers.py
+++ b/matsciml/models/pyg/faenet/layers.py
@@ -13,6 +13,7 @@ from torch_geometric.nn import LayerNorm, MessagePassing
 from torch_geometric.nn.norm import GraphNorm
 from torch_geometric.nn.pool import global_add_pool
 from torch_geometric.typing import Size
+from torch_scatter import scatter
 
 from matsciml.common.types import AbstractGraph, BatchDict, DataDict
 from matsciml.models.base import AbstractPyGModel
@@ -255,8 +256,9 @@ class EmbeddingBlock(nn.Module):
         # Create atom embeddings based on its characteristic number
         h = self.emb(z)
 
-        if self.phys_emb.device != h.device:
-            self.phys_emb = self.phys_emb.to(h.device)
+        # import pdb; pdb.set_trace()
+        # if self.phys_emb.device != h.device:
+        #     self.phys_emb = self.phys_emb.to(h.device)
 
         # Concat tag embedding
         if self.use_tag:
@@ -468,7 +470,7 @@ class OutputBlock(nn.Module):
             h = h * alpha
 
         # Global pooling
-        out = torch.scatter(h, batch, dim=0, reduce="add")
+        out = scatter(h, batch, dim=0, reduce="add")
 
         return out
 

--- a/matsciml/models/tests/test_tasks.py
+++ b/matsciml/models/tests/test_tasks.py
@@ -1,15 +1,17 @@
+from __future__ import annotations
+
 import pytorch_lightning as pl
 
-from matsciml.models.base import ForceRegressionTask
-from matsciml.models import PLEGNNBackbone
 from matsciml.datasets.materials_project import MaterialsProjectDataset
 from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models import PLEGNNBackbone
+from matsciml.models.base import ForceRegressionTask, GradFreeForceRegressionTask
 
 pl.seed_everything(2156161)
 
 
 def test_regression_devset():
-    dset = MaterialsProjectDataset.from_devset()
+    dset = MaterialsProjectDataset.from_devset()  # noqa: F841
 
 
 def test_force_regression():
@@ -49,3 +51,42 @@ def test_force_regression():
     # make sure losses are tracked
     for key in ["energy", "force"]:
         assert f"train_{key}" in trainer.logged_metrics
+
+
+def test_gradfree_force_regression():
+    devset = MatSciMLDataModule.from_devset("S2EFDataset")
+    model_args = {
+        "embed_in_dim": 128,
+        "embed_hidden_dim": 32,
+        "embed_out_dim": 128,
+        "embed_depth": 5,
+        "embed_feat_dims": [128, 128, 128],
+        "embed_message_dims": [128, 128, 128],
+        "embed_position_dims": [64, 64],
+        "embed_edge_attributes_dim": 0,
+        "embed_activation": "relu",
+        "embed_residual": True,
+        "embed_normalize": True,
+        "embed_tanh": True,
+        "embed_activate_last": False,
+        "embed_k_linears": 1,
+        "embed_use_attention": False,
+        "embed_attention_norm": "sigmoid",
+        "readout": "sum",
+        "node_projection_depth": 3,
+        "node_projection_hidden_dim": 128,
+        "node_projection_activation": "relu",
+        "prediction_out_dim": 1,
+        "prediction_depth": 3,
+        "prediction_hidden_dim": 128,
+        "prediction_activation": "relu",
+        "encoder_only": True,
+    }
+    task = GradFreeForceRegressionTask(
+        encoder_class=PLEGNNBackbone,
+        encoder_kwargs=model_args,
+    )
+    trainer = pl.Trainer(max_steps=5, logger=False, enable_checkpointing=False)
+    trainer.fit(task, datamodule=devset)
+    # make sure losses are tracked
+    assert "train_force" in trainer.logged_metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
   "schema>=0.7.5",
   "ase>=3.22.1",
   "matgl==0.8.5",
-  "einops==0.7.0"
+  "einops==0.7.0",
+  "mendeleev==0.14.0",
 ]
 description = "PyTorch Lightning and Deep Graph Library enabled materials science deep learning pipeline"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This PR adds the FAENet architecture, and frame averaging transform, which may be used with other architectures. Additionally, a transform for calculating a material's unit cell from lattice parameters is added, which is needed to generate extra keys to use FAENet. 

Original FAENet implementation: https://github.com/vict0rsch/faenet  