### PR TITLE
Model output refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ depending on the type of data representation being used and backend: `AbstractPo
 and edges) for consistency, and (2) to abstract out common functions, particularly how to "read" data from the minibatches.
 As an example, DGL and PyG have different interfaces, and by inheriting from the right parent class, ensures that the correct
 features are mapped to the right arguments, etc. If your abstraction permits, the `_forward` method should be the only method
-you need to override:
+you need to override, which returns the system/graph and point/node-level embeddings in a standardized data structure:
 
 ```python
     def _forward(
@@ -39,7 +39,7 @@ you need to override:
         edge_feats: Optional[torch.Tensor] = None,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         """
         Sets args/kwargs for the expected components of a graph-based
         model. At the bare minimum, we expect some kind of abstract
@@ -64,8 +64,8 @@ you need to override:
 
         Returns
         -------
-        torch.Tensor
-            Model output; either embedding or projected output
+        matsciml.common.types.Embeddings
+            Data structure containing system/graph and point/node-level embeddings.
         """
 ```
 

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -1,9 +1,11 @@
-from typing import Dict, Union
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Union
 
 import torch
 
 from matsciml.common import package_registry
-
 
 # for point clouds
 representations = [torch.Tensor]
@@ -27,7 +29,64 @@ DataType = Union[ModelingTypes]
 AbstractGraph = Union[GraphTypes]
 
 # for a dictionary look up of data
-DataDict = Dict[str, Union[float, DataType]]
+DataDict = dict[str, Union[float, DataType]]
 
 # for a dictionary of batched data
-BatchDict = Dict[str, Union[float, DataType, DataDict]]
+BatchDict = dict[str, Union[float, DataType, DataDict]]
+
+
+@dataclass
+class Embeddings:
+    """
+    Data structure that packs together embeddings from a model.
+    """
+
+    system_embedding: torch.Tensor | None = None
+    point_embedding: torch.Tensor | None = None
+    reduction: str | Callable | None = None
+    reduction_kwargs: dict[str, str | float] = {}
+
+    @property
+    def num_points(self) -> int:
+        if not isinstance(self.point_embedding, torch.Tensor):
+            raise ValueError("No point-level embeddings stored!")
+        return self.point_embedding.size(0)
+
+    @property
+    def batch_size(self) -> int:
+        if not isinstance(self.system_embedding, torch.Tensor):
+            raise ValueError(
+                "No system-level embeddings stored, can't determine batch size!",
+            )
+        return self.system_embedding.size(0)
+
+    def reduce_point_embeddings(
+        self,
+        reduction: str | Callable | None = None,
+        **reduction_kwargs,
+    ) -> torch.Tensor:
+        """
+        Perform a reduction/readout of the point-level embeddings to obtain
+        system/graph-level embeddings.
+
+        This function provides a regular interface for obtaining system-level
+        embeddings by either passing a function that functions via:
+
+        ``system_level = reduce(point_level)``
+
+        or by passing a ``str`` name of a function from ``torch`` such as ``mean``.
+        """
+        assert isinstance(
+            self.point_embedding,
+            torch.Tensor,
+        ), "No point-level embeddings stored to reduce."
+        if not reduction:
+            reduction = self.reduction
+        if isinstance(reduction, str):
+            reduction = getattr(torch, reduction)
+        if not reduction:
+            raise ValueError("No method for reduction passed.")
+        self.reduction_kwargs.update(reduction_kwargs)
+        system_embeddings = reduction(self.point_embedding, **self.reduction_kwargs)
+        self.system_embedding = system_embeddings
+        return system_embeddings

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Union
 
 import torch
@@ -44,7 +44,7 @@ class Embeddings:
     system_embedding: torch.Tensor | None = None
     point_embedding: torch.Tensor | None = None
     reduction: str | Callable | None = None
-    reduction_kwargs: dict[str, str | float] = {}
+    reduction_kwargs: dict[str, str | float] = field(default_factory=dict)
 
     @property
     def num_points(self) -> int:

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -787,7 +787,7 @@ class BaseTaskModule(pl.LightningModule):
         outputs = self.process_embedding(embedding)
         return outputs
 
-    def process_embedding(self, embeddings: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def process_embedding(self, embeddings: Embeddings) -> Dict[str, torch.Tensor]:
         """
         Given a set of embeddings, output predictions for each head.
 
@@ -803,7 +803,7 @@ class BaseTaskModule(pl.LightningModule):
         """
         results = {}
         for key, head in self.output_heads.items():
-            results[key] = head(embeddings)
+            results[key] = head(embeddings.system_embedding)
         return results
 
     def _get_targets(
@@ -1310,10 +1310,10 @@ class ForceRegressionTask(BaseTaskModule):
         return outputs
 
     def process_embedding(
-        self, embeddings: torch.Tensor, pos: torch.Tensor
+        self, embeddings: Embeddings, pos: torch.Tensor
     ) -> Dict[str, torch.Tensor]:
         outputs = {}
-        energy = self.output_heads["energy"](embeddings)
+        energy = self.output_heads["energy"](embeddings.system_embedding)
         # now use autograd for force calculation
         force = (
             -1

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -264,8 +264,8 @@ class AbstractTask(ABC, pl.LightningModule):
 
         Returns
         -------
-        torch.Tensor
-            Output of the model; can be embeddings or projected values
+        Embeddings
+            Data structure containing system/graph and point/node level embeddings.
         """
         ...
 
@@ -284,11 +284,16 @@ class AbstractTask(ABC, pl.LightningModule):
 
         Returns
         -------
-        torch.Tensor
-            Output of the model; can be embeddings or projected values
+        Embeddings
+            Data structure containing system/graph and point/node level embeddings.
         """
         input_data = self.read_batch(batch)
         outputs = self._forward(**input_data)
+        # raise an error to help spot models that have not yet been refactored
+        if not isinstance(outputs, Embeddings):
+            raise ValueError(
+                "Encoder did not return `Embeddings` data structure: please refactor your model!"
+            )
         return outputs
 
 

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -26,7 +26,7 @@ from torch.optim import lr_scheduler
 
 from matsciml.modules.normalizer import Normalizer
 from matsciml.models.common import OutputHead
-from matsciml.common.types import DataDict, BatchDict, AbstractGraph
+from matsciml.common.types import DataDict, BatchDict, AbstractGraph, Embeddings
 from matsciml.common.registry import registry
 from matsciml.common import package_registry
 
@@ -257,7 +257,7 @@ class AbstractTask(ABC, pl.LightningModule):
         ...
 
     @abstractmethod
-    def _forward(self, *args, **kwargs) -> torch.Tensor:
+    def _forward(self, *args, **kwargs) -> Embeddings:
         """
         Implements the actual logic of the architecture. Given a set
         of input features, produce outputs/predictions from the model.
@@ -269,7 +269,7 @@ class AbstractTask(ABC, pl.LightningModule):
         """
         ...
 
-    def forward(self, batch: BatchDict) -> torch.Tensor:
+    def forward(self, batch: BatchDict) -> Embeddings:
         """
         Given a batch structure, extract out data and pass it into the
         neural network architecture. This implements the 'forward' method
@@ -361,7 +361,7 @@ class AbstractPointCloudModel(AbstractTask):
         mask: Optional[torch.Tensor] = None,
         sizes: Optional[List[int]] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         """
         Sets expected patterns for args for point cloud based modeling, whereby
         the bare minimum expected data are 'pos' and 'pc_features' akin to graph
@@ -497,7 +497,7 @@ class AbstractGraphModel(AbstractTask):
         edge_feats: Optional[torch.Tensor] = None,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         """
         Sets args/kwargs for the expected components of a graph-based
         model. At the bare minimum, we expect some kind of abstract

--- a/matsciml/models/dgl/egnn/egnn.py
+++ b/matsciml/models/dgl/egnn/egnn.py
@@ -7,8 +7,8 @@ import dgl
 import torch
 import torch.nn as nn
 from dgl.nn.pytorch.glob import AvgPooling, MaxPooling, SumPooling, WeightAndSum
-from matsciml.common.types import BatchDict, DataDict
 
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 from matsciml.models.base import AbstractDGLModel
 from matsciml.models.dgl.egnn.egnn_model import EGNN, MLP
 
@@ -185,7 +185,7 @@ class PLEGNNBackbone(AbstractDGLModel):
         edge_feats: Optional[torch.Tensor] = None,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Implement the forward method, which computes the energy of
         a molecular graph.
@@ -210,12 +210,11 @@ class PLEGNNBackbone(AbstractDGLModel):
 
         Returns
         -------
-        torch.Tensor
-            Graph embeddings, or output value if not 'encoder_only'
+        Embeddings
+            Data structure containing node and graph level embeddings.
+            Node embeddings correspond to after the node projection layer.
         """
         n_z, _ = self.embed(graph, node_feats, pos)
         n_z = self.node_projection(n_z)
         g_z = self.readout(graph, n_z)
-        if self.encoder_only:
-            return g_z
-        return self.prediction(g_z)
+        return Embeddings(g_z, n_z)

--- a/matsciml/models/dgl/gaanet/gaanet.py
+++ b/matsciml/models/dgl/gaanet/gaanet.py
@@ -12,6 +12,7 @@ import dgl
 
 from .gaanet_model import MLP, MomentumNorm, LayerNorm, TiedMultivectorAttention
 import geometric_algebra_attention.pytorch as gala
+from matsciml.common.types import Embeddings
 
 
 class GalaPotential(AbstractPointCloudModel):
@@ -250,7 +251,7 @@ class GalaPotential(AbstractPointCloudModel):
         mask: Optional[torch.Tensor] = None,
         sizes: Optional[List[int]] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Map input data onto the Gala architecture.
 
@@ -292,10 +293,8 @@ class GalaPotential(AbstractPointCloudModel):
 
         Returns
         -------
-        torch.Tensor
-            If ``encoder_only``, emits a 2D tensor of shape ``[B, hidden_dim]``.
-            Otherwise, emits a 2D tensor of shape ``[B, 1]`` corresponding to
-            the system energy of each point cloud.
+        Embeddings
+            Data structure containing point cloud embeddings.
         """
         positions = torch.div(pc_pos, 1)
 
@@ -347,4 +346,6 @@ class GalaPotential(AbstractPointCloudModel):
         # are actually padding nodes
         if isinstance(mask, torch.Tensor) and sizes:
             last = self.mask_model_output(last, mask, sizes, self.hparams.extensive)
-        return last
+        # TODO map point level embeddings as well
+        embeddings = Embeddings(last)
+        return embeddings

--- a/matsciml/models/dgl/megnet/megnet.py
+++ b/matsciml/models/dgl/megnet/megnet.py
@@ -14,8 +14,8 @@ import torch
 from torch import nn
 from dgl.nn import Set2Set
 from torch.nn import Dropout, Identity, Module, ModuleList, Softplus
-from matsciml.common.types import BatchDict, DataDict
 
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 from matsciml.models.dgl.megnet import MLP, MEGNetBlock, EdgeSet2Set
 from matsciml.models.base import AbstractDGLModel
 
@@ -179,7 +179,7 @@ class MEGNet(AbstractDGLModel):
         graph_feats: torch.Tensor,
         pos: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Implement the forward method, which computes the energy of
         a molecular graph.
@@ -204,8 +204,8 @@ class MEGNet(AbstractDGLModel):
 
         Returns
         -------
-        torch.Tensor
-            Graph embeddings, or output value if not 'encoder_only'
+        Embeddings
+            Data structure containing graph and node level embeddings.
         """
         edge_feats = self.edge_encoder(self.edge_embed(edge_feats))
         node_feats = self.node_encoder(node_feats)
@@ -222,11 +222,5 @@ class MEGNet(AbstractDGLModel):
 
         if self.dropout:
             vec = self.dropout(vec)  # pylint: disable=E1102
-        if not self.encoder_only:
-            output = self.output_proj(vec)
-            if self.is_classification:
-                output = torch.sigmoid(output)
-        else:
-            output = vec
-
-        return output
+        embeddings = Embeddings(vec, node_vec)
+        return embeddings

--- a/matsciml/models/dgl/mpnn.py
+++ b/matsciml/models/dgl/mpnn.py
@@ -9,8 +9,8 @@ import dgl
 import torch
 from torch import nn
 from dgl.nn.pytorch import glob
-from matsciml.common.types import BatchDict, DataDict
 
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 from matsciml.models.base import AbstractDGLModel
 
 
@@ -114,7 +114,7 @@ class MPNN(AbstractDGLModel):
         edge_feats: torch.Tensor,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Implement the forward method, which computes the energy of
         a molecular graph.
@@ -139,12 +139,12 @@ class MPNN(AbstractDGLModel):
 
         Returns
         -------
-        torch.Tensor
-            Graph embeddings, or output value if not 'encoder_only'
+        Embeddings
+            Data structure with graph and node level embeddings packed.
+            Node embeddings are from the last message passing layer.
         """
         node_feats = self.join_position_embeddings(pos, node_feats)
         n_z = self.model(graph, node_feats, edge_feats)
         g_z = self.readout(graph, n_z)
-        if self.encoder_only:
-            return g_z
-        return self.output(g_z)
+        embeddings = Embeddings(g_z, n_z)
+        return embeddings

--- a/matsciml/models/dgl/schnet_dgl.py
+++ b/matsciml/models/dgl/schnet_dgl.py
@@ -11,7 +11,7 @@ from torch import nn
 from dgl.nn.pytorch import glob
 
 from matsciml.models.base import AbstractDGLModel
-from matsciml.common.types import BatchDict, DataDict
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 
 
 class SchNet(AbstractDGLModel):
@@ -133,7 +133,7 @@ class SchNet(AbstractDGLModel):
         pos: Optional[torch.Tensor] = None,
         graph_feats: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         r"""
         Implement the forward method, which computes the energy of
         a molecular graph.
@@ -158,11 +158,9 @@ class SchNet(AbstractDGLModel):
 
         Returns
         -------
-        torch.Tensor
-            Graph embeddings, or output value if not 'encoder_only'
+        Embeddings
+            Data structure holding graph and node level embeddings.
         """
         n_z = self.model(graph, node_feats, edge_feats)
         g_z = self.readout(graph, n_z)
-        if self.encoder_only:
-            return g_z
-        return self.output(g_z)
+        return Embeddings(g_z, n_z)

--- a/matsciml/models/pyg/egnn.py
+++ b/matsciml/models/pyg/egnn.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import torch
 from einops import reduce
-from matsciml.common.types import AbstractGraph
+from matsciml.common.types import AbstractGraph, Embeddings
 from matsciml.models.base import AbstractPyGModel
 from torch import nn
 from torch_geometric.nn import LayerNorm, MessagePassing
@@ -232,7 +232,7 @@ class EGNN(AbstractPyGModel):
         pos: torch.Tensor,
         edge_feats: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> Embeddings:
         # embed coordinates, then lookup embeddings for atoms and bonds
         coords = self.coord_embedding(pos)
         # loop over each graph layer
@@ -240,4 +240,5 @@ class EGNN(AbstractPyGModel):
             node_feats, coords = layer(node_feats, coords, edge_feats, graph.edge_index)
         # use size-extensive pooling
         pooled_data = global_add_pool(node_feats, graph.batch)
-        return self.output(pooled_data)
+        embeddings = Embeddings(pooled_data, node_feats)
+        return embeddings


### PR DESCRIPTION
This PR adds a bit of flexibility into task development by having a standardized data structure for what models return.

We introduce the `matsciml.common.types.Embeddings` dataclass, which holds `system_embeddings` and `point_embeddings` optional attributes, which house (as the name suggests) system/graph and point/node level embeddings from a model.

Prior to this, models would only return the system/graph-level embedding, which are then used by the task output heads for projection/prediction. In some cases, tasks will would want to operate on the point/node-level embeddings, and so this refactor facilitates that.

Most common models have been refactored to emit this `Embeddings` structure, and I've checked that they still run in the same way as they did before. In `AbstractTask`, which is what most model implementations should be inheriting from, the `forward` method will also check to make sure the output is an `Embeddings` instance to help flag down things that haven't been ported over. 