### PR TITLE
Pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,4 @@ repos:
         language_version: python3
         types: [python]
         require_serial: true
+        args: [--skip, "B101", --recursive]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
           flake8-use-fstring,
           flake8-pyproject,
         ]
+        args: [--max-line-length=88, --ignore=S101]
 -   repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,15 +37,15 @@ repos:
           flake8-pyproject,
         ]
 -   repo: https://github.com/psf/black
-    rev: 22.3.1
+    rev: 23.7.0
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python
 -   repo: https://github.com/psf/black
-    rev: 22.3.1
+    rev: 23.7.0
     hooks:
       - id: black-jupyter
-        language_version: python3.9
+        language_version: python
 -   repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,12 @@ repos:
     rev: v0.3.1
     hooks:
     -   id: absolufy-imports
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+      - id: bandit
+        name: bandit
+        language: python
+        language_version: python3
+        types: [python]
+        require_serial: true


### PR DESCRIPTION
This PR fixes and updates the `pre-commit` specification:

- `language_version` key for `black` is changed from `python3.9` to `python`, which resolves venv issues when it is not found.
- `black` is bumped to `23.7.0`
- `bandit` is a new part of the workflow, which automates scanning for unsafe code practices