### PR TITLE
Preserving symmetry representations in outputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,4 @@ repos:
         language_version: python3
         types: [python]
         require_serial: true
+        args: [--skip, "B101", --recursive]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
           flake8-use-fstring,
           flake8-pyproject,
         ]
+        args: [--max-line-length=88, --ignore=S101]
 -   repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,15 +37,15 @@ repos:
           flake8-pyproject,
         ]
 -   repo: https://github.com/psf/black
-    rev: 22.3.1
+    rev: 23.7.0
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python
 -   repo: https://github.com/psf/black
-    rev: 22.3.1
+    rev: 23.7.0
     hooks:
       - id: black-jupyter
-        language_version: python3.9
+        language_version: python
 -   repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,12 @@ repos:
     rev: v0.3.1
     hooks:
     -   id: absolufy-imports
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+      - id: bandit
+        name: bandit
+        language: python
+        language_version: python3
+        types: [python]
+        require_serial: true

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -143,7 +143,7 @@ class IrrepOutputBlock(nn.Module):
         | nn.Module
         | type[nn.Module]
         | None = None,
-        norm: nn.Module | type[nn.Module] | Callable | str | None = None,
+        norm: e3layers.BatchNorm | nn.Module | bool = True,
         residual: bool = True,
         **kwargs,
     ) -> None:
@@ -167,13 +167,12 @@ class IrrepOutputBlock(nn.Module):
             activation = activation()
         if not isinstance(activation, list):
             activation = [activation]
+        if isinstance(norm, bool):
+            if norm:
+                norm = e3layers.BatchNorm(output_dim)
+            else:
+                norm = nn.Identity()
         activation = e3layers.Activation(irreps_in=output_dim, acts=activation)
-        if norm is None:
-            norm = nn.Identity
-        if isinstance(norm, str):
-            norm = get_class_from_name(norm)
-        if isinstance(norm, type):
-            norm = norm()
         self.layers = nn.Sequential(linear, deepcopy(activation), deepcopy(norm))
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -165,7 +165,9 @@ class IrrepOutputBlock(nn.Module):
             activation = get_class_from_name(activation)
         if isinstance(activation, type):
             activation = activation()
-        activation = e3layers.Activation(irreps_in=output_dim, acts=[activation])
+        if not isinstance(activation, list):
+            activation = [activation]
+        activation = e3layers.Activation(irreps_in=output_dim, acts=activation)
         if norm is None:
             norm = nn.Identity
         if isinstance(norm, str):

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from importlib import import_module
 from inspect import getfullargspec
 from typing import Any, Callable
-from sys import modules
 
 import torch
 from e3nn import nn as e3layers

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -131,6 +131,7 @@ class OutputBlock(nn.Module):
         return self.layers[0].weight.size(-1)
 
 
+@registry.register_model("IrrepOutputBlock")
 class IrrepOutputBlock(nn.Module):
     def __init__(
         self,

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -182,7 +182,7 @@ class IrrepOutputBlock(nn.Module):
             if isinstance(act, str):
                 act = get_class_from_name(act)
             # if we haven't instantiated the activation, do it now
-            if isinstance(act, type):
+            if isinstance(act, type) and act is not None:
                 act = act()
             activation[index] = act
         # make sure we have enough activation functions

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -165,6 +165,7 @@ class IrrepOutputBlock(nn.Module):
             activation = get_class_from_name(activation)
         if isinstance(activation, type):
             activation = activation()
+        activation = e3layers.Activation(irreps_in=output_dim, acts=[activation])
         if norm is None:
             norm = nn.Identity
         if isinstance(norm, str):

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -143,6 +143,27 @@ class IrrepOutputBlock(nn.Module):
         residual: bool = True,
         **kwargs,
     ) -> None:
+        """
+        Initialize an `IrrepOutputBlock` MLP.
+
+        This output projection block is intended to preserve irreducible representations
+        that are created through equivariant neural networks.
+
+        Parameters
+        ----------
+        output_dim : str | o3.Irreps
+            Irreducible representations of the output projection
+        input_dim : str | o3.Irreps
+            Irreducible representations of the input representation
+        activation : Optional[list[str | e3.nn.Activation | None]], default None
+            A sequence of activation functions to apply to the output projection.
+        norm : Optional[e3.nn.BatchNorm | nn.Module | bool], default True
+            Applies normalization after non-linearity. Default value of ``True``
+            will automatically use `e3.nn.BatchNorm` with the correct representations.
+        residual : bool, default True
+            Flag to specify whether residual connections are used between
+            hidden layer.
+        """
         kwargs.setdefault("biases", True)
         super().__init__()
         self.residual = residual

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -247,8 +247,15 @@ class OutputHead(nn.Module):
         kwargs.setdefault("residual", True)
         kwargs.setdefault("bias", True)
         super().__init__()
+        if isinstance(block_type, str):
+            type_name = block_type
+            block_type = registry.get_model_class(block_type)
+            if not block_type:
+                raise NameError(
+                    f"Specified block type {type_name} does not exist in matsciml.models.common."
+                )
         blocks = [
-            OutputBlock(
+            block_type(
                 hidden_dim,
                 activation,
                 norm,

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from importlib import import_module
+from inspect import getfullargspec
 from typing import Any, Callable
 
 import torch
@@ -149,6 +150,10 @@ class IrrepOutputBlock(nn.Module):
             output_dim = o3.Irreps(output_dim)
         if not isinstance(input_dim, o3.Irreps):
             input_dim = o3.Irreps(input_dim)
+        # before mapping kwargs, filter out bad incorrect ones
+        linear_sig = getfullargspec(o3.Linear)
+        linear_args = set(linear_sig.args) | set(linear_sig.kwonlyargs)
+        kwargs = {key: value for key, value in kwargs.items() if key in linear_args}
         linear = o3.Linear(input_dim, output_dim, **kwargs)
         if activation is None:
             activation = nn.Identity

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -4,12 +4,14 @@ from copy import deepcopy
 from importlib import import_module
 from inspect import getfullargspec
 from typing import Any, Callable
+from sys import modules
 
 import torch
 from e3nn import nn as e3layers
 from e3nn import o3
 from torch import nn
 from torch.nn.parameter import Parameter
+from matsciml.common.registry import registry
 
 
 def get_class_from_name(class_path: str) -> type[Any]:
@@ -38,6 +40,7 @@ def get_class_from_name(class_path: str) -> type[Any]:
     return getattr(module, class_str)
 
 
+@registry.register_model("OutputBlock")
 class OutputBlock(nn.Module):
     """
     Building block for output heads. Simple MLP stack with

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -207,6 +207,7 @@ class OutputHead(nn.Module):
         norm: nn.Module | type[nn.Module] | Callable | str | None = None,
         act_last: nn.Module | type[nn.Module] | Callable | str | None = None,
         input_dim: int | None = None,
+        block_type: type[nn.Module] | str = OutputBlock,
         **kwargs,
     ) -> None:
         """

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -164,17 +164,21 @@ class IrrepOutputBlock(nn.Module):
             if isinstance(act, type):
                 act = act()
             activation[index] = act
+        # make sure we have enough activation functions
         if len(activation) != len(output_dim):
             raise ValueError(
                 "Number of activations passed not equal to number of representations; "
                 f"got {len(activation)}, expected {len(output_dim)}"
             )
+        # if we haven't converted the activation functions into the e3.nn wrapper,
+        # do so now
+        if not isinstance(activation, e3layers.Activation):
+            activation = e3layers.Activation(irreps_in=output_dim, acts=activation)
         if isinstance(norm, bool):
             if norm:
                 norm = e3layers.BatchNorm(output_dim)
             else:
                 norm = nn.Identity()
-        activation = e3layers.Activation(irreps_in=output_dim, acts=activation)
         self.layers = nn.Sequential(linear, deepcopy(activation), deepcopy(norm))
 
     def forward(self, data: torch.Tensor) -> torch.Tensor:

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -207,10 +207,7 @@ class OutputHead(nn.Module):
         norm: nn.Module | type[nn.Module] | Callable | str | None = None,
         act_last: nn.Module | type[nn.Module] | Callable | str | None = None,
         input_dim: int | None = None,
-        lazy: bool = True,
-        bias: bool = True,
-        dropout: float = 0.0,
-        residual: bool = True,
+        **kwargs,
     ) -> None:
         """
         Initialize an `OutputHead` architecture.
@@ -241,6 +238,10 @@ class OutputHead(nn.Module):
             Flag to specify whether residual connections are used between
             hidden layer.
         """
+        kwargs.setdefault("lazy", True)
+        kwargs.setdefault("dropout", 0.0)
+        kwargs.setdefault("residual", True)
+        kwargs.setdefault("bias", True)
         super().__init__()
         blocks = [
             OutputBlock(

--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -233,13 +233,13 @@ class OutputHead(nn.Module):
 
     def __init__(
         self,
-        output_dim: int,
-        hidden_dim: int,
+        output_dim: int | str,
+        hidden_dim: int | str,
         num_hidden: int = 1,
         activation: nn.Module | type[nn.Module] | Callable | str | None = None,
         norm: nn.Module | type[nn.Module] | Callable | str | None = None,
         act_last: nn.Module | type[nn.Module] | Callable | str | None = None,
-        input_dim: int | None = None,
+        input_dim: int | str | None = None,
         block_type: type[nn.Module] | str = OutputBlock,
         **kwargs,
     ) -> None:
@@ -248,15 +248,21 @@ class OutputHead(nn.Module):
 
         This model uses `LazyLinear` layers to create uninitialized MLPs,
         which means no input dimensionality is needed to be specified.
+        Kwargs are passed into the instantiation of ``block_type``.
 
         Parameters
         ----------
-        output_dim : int
-            Dimensionality of the output of this model.
-        hidden_dim : int
-            Dimensionality of the hidden layers within this stack.
+        output_dim : int | str
+            Dimensionality of the output of this model. String inputs are
+            specifically for ``IrrepOutputBlock``.
+        hidden_dim : int | str
+            Dimensionality of the hidden layers within this stack. String
+            inputs are specifically for ``IrrepOutputBlock``.
         num_hidden : int
             Number of hidden `OutputBlock`s to use.
+        input_dim : int | str | None, default None
+            Dimensionality of input data into the output head; typically would be the
+            embedding dimensionality. String inputs are specifically for ``IrrepOutputBlock``.
         activation : Optional[Union[nn.Module, Type[nn.Module], Callable, str]], default None
             If None, uses `nn.Identity()` as a placeholder. This nonlinearity is applied
             before normalization for every hidden layer within the stack.
@@ -271,6 +277,11 @@ class OutputHead(nn.Module):
         residual : bool, default True
             Flag to specify whether residual connections are used between
             hidden layer.
+        block_type : type[nn.Module] | str, default ``OutputBlock``
+            The type of block to constitute this output head. By default, the
+            naive ``OutputBlock`` just performs MLP projections, whereas ``IrrepOutputBlock``
+            will preserve irreducible representations in the output. If a String
+            is passed, the class will be retrieved from the registry.
         """
         kwargs.setdefault("lazy", True)
         kwargs.setdefault("dropout", 0.0)

--- a/matsciml/models/tests/test_output_heads.py
+++ b/matsciml/models/tests/test_output_heads.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from itertools import product
+
+import pytest
+import torch
+from e3nn import o3
+
+from matsciml.common.registry import registry
+from matsciml.models.common import IrrepOutputBlock, OutputBlock, OutputHead
+
+
+@pytest.mark.parametrize("classname", ("OutputBlock", "IrrepOutputBlock"))
+def test_block_in_registry(classname):
+    block_type = registry.get_model_class(classname)
+    if not block_type:
+        raise NameError(f"{classname} was not found in registry.")
+
+
+output_param_space = list(
+    product(
+        [None, True],
+        ["torch.nn.SiLU", "torch.nn.ReLU", "torch.nn.GELU"],
+        [False, True],
+        [2, 64, 256],
+        [2, 64, 256],
+    ),
+)
+
+
+@pytest.fixture(params=output_param_space)
+def output_block_fixture(request):
+    norm, activation, residual, output_dim, input_dim = request.param
+    if norm:
+        norm = torch.nn.BatchNorm1d(output_dim)
+    block = OutputBlock(
+        output_dim=output_dim,
+        input_dim=input_dim,
+        norm=norm,
+        activation=activation,
+        residual=residual,
+    )
+    rand_in = torch.rand(8, input_dim)
+    rand_out = torch.rand(8, output_dim)
+    return (block, rand_in, rand_out)
+
+
+@pytest.mark.dependency()
+def test_output_block(output_block_fixture):
+    block, rand_in, rand_out = output_block_fixture
+    residual_test = bool(block.residual * (rand_in.shape != rand_out.shape))
+    with torch.inference_mode():
+        if residual_test:
+            with pytest.raises(AssertionError):
+                pred = block(rand_in)
+        else:
+            pred = block(rand_in)
+            assert pred.shape == rand_out.shape
+
+
+irrep_param_space = list(
+    product(
+        [None, True],
+        ["torch.nn.SiLU", "torch.nn.ReLU"],
+        [False, True],
+        [2, 8, 16],
+        [2, 8, 16],
+    ),
+)
+
+
+@pytest.fixture(params=irrep_param_space)
+def irrep_block_fixture(request):
+    norm, activation, residual, output_dim, input_dim = request.param
+    input_irrep = o3.Irreps(f"{input_dim}x0e + {input_dim}x1e")
+    output_irrep = o3.Irreps(f"{output_dim}x0e + {output_dim}x1e")
+    rand_in = input_irrep.randn(4, -1)
+    rand_out = output_irrep.randn(4, -1)
+    block = IrrepOutputBlock(
+        output_dim=output_irrep,
+        input_dim=input_irrep,
+        norm=norm,
+        activation=[activation, None],
+        residual=residual,
+    )
+    block._output_irrep = output_irrep
+    block._input_irrep = input_irrep
+    return (block, rand_in, rand_out)
+
+
+@pytest.mark.dependency()
+def test_irrep_block(irrep_block_fixture):
+    block, rand_in, rand_out = irrep_block_fixture
+    residual_test = bool(block.residual * (block._output_irrep != block._input_irrep))
+    with torch.inference_mode():
+        if isinstance(block.layers[-1], torch.nn.BatchNorm1d):
+            assert rand_out.size(-1) == block.layers[-1].weight.size(-1)
+        if residual_test:
+            with pytest.raises(AssertionError):
+                pred = block(rand_in)
+        else:
+            pred = block(rand_in)
+            assert pred.shape == rand_out.shape
+
+
+@pytest.mark.parametrize(
+    "head_kwargs",
+    [
+        {
+            "output_dim": 16,
+            "hidden_dim": 64,
+            "input_dim": 8,
+            "activation": "torch.nn.SiLU",
+            "norm": None,
+            "residual": False,
+            "block_type": "OutputBlock",
+        },
+        {
+            "output_dim": o3.Irreps("10x0e + 10x1e"),
+            "input_dim": o3.Irreps("5x0e + 10x1e"),
+            "hidden_dim": o3.Irreps("20x0e + 20x1e"),
+            "activation": [torch.nn.SiLU(), None],
+            "norm": True,
+            "residual": False,
+            "block_type": "IrrepOutputBlock",
+        },
+    ],
+)
+@pytest.mark.dependency(depends=["test_output_block", "test_irrep_block"])
+def test_regular_output_head(head_kwargs):
+    head = OutputHead(**head_kwargs)
+    if head_kwargs["block_type"] == "IrrepOutputBlock":
+        rand_in = head_kwargs["input_dim"].randn(4, -1)
+        rand_out = head_kwargs["output_dim"].randn(4, -1)
+    else:
+        rand_in = torch.randn(4, head_kwargs["input_dim"])
+        rand_out = torch.randn(4, head_kwargs["output_dim"])
+    with torch.inference_mode():
+        pred = head(rand_in)
+        assert pred.shape == rand_out.shape

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "matgl==0.8.5",
   "einops==0.7.0",
   "mendeleev==0.14.0",
+  "e3nn==0.5.1"
 ]
 description = "PyTorch Lightning and Deep Graph Library enabled materials science deep learning pipeline"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This PR implements support for `e3nn` features in support of #72. The main change is addition of `IrrepOutputBlock` that utilizes `e3nn.o3.Linear` instead of the regular PyTorch `Linear` to preserve symmetry representations. The `OutputHead` class was refactored to support use of either `IrrepOutputBlock` or the regular `OutputBlock`.

A simple example for using this workflow is forthcoming, but in the meantime, the API remains pretty consistent between the two workflows via `output_kwargs` in task specifications:

```python
task = ScalarRegressionTask(
   ...,
   output_kwargs={
      "block_type": "IrrepOutputBlock",
      "input_dim": "10x0e + 20x1e", 
      "hidden_dim": "30x0e + 10x1e", 
      "output_dim": "0e",
      "activation": ["torch.nn.SiLU", None]
    }
)
```

Closes #70.