### PR TITLE
Trigger `RuntimeError` for when normalization is requested but not utilized

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -909,6 +909,11 @@ class BaseTaskModule(pl.LightningModule):
                 "Target normalization was intended but not used."
                 f"Please check your config - expected: {self.task_keys}"
             )
+        if len(used_norm) != len(self.normalizers):
+            raise RuntimeError(
+                "Normalization was performed, but number of keys do not match."
+                f"Expected {len(self.normalizers)} keys, but only used {len(used_norm)}."
+            )
         return {"loss": total_loss, "log": losses}
 
     def configure_optimizers(self) -> torch.optim.AdamW:

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -894,12 +894,21 @@ class BaseTaskModule(pl.LightningModule):
         targets = self._get_targets(batch)
         predictions = self(batch)
         losses = {}
+        used_norm = []
         for key in self.task_keys:
             target_val = targets[key]
             if self.uses_normalizers:
                 target_val = self.normalizers[key].norm(target_val)
+                used_norm.append(key)
             losses[key] = self.loss_func(predictions[key], target_val)
         total_loss: torch.Tensor = sum(losses.values())
+        # trigger warning for when we infer normalization intent but
+        # not actually executed
+        if len(used_norm) == 0 and self.uses_normalizers:
+            raise RuntimeError(
+                "Target normalization was intended but not used."
+                f"Please check your config - expected: {self.task_keys}"
+            )
         return {"loss": total_loss, "log": losses}
 
     def configure_optimizers(self) -> torch.optim.AdamW:


### PR DESCRIPTION
This PR adds checks and informative error messages centered around target normalization.

1. A check to `BaseTaskModule._compute_losses`, appending keys to a `used_norm` list as normalization is performed. When all the losses have been calculated, if `used_norm` is empty despite having requested normalization, we trigger a `RuntimeError` to stop training, and inform the user that no normalization was performed.
2. Another subsequent check to make sure that the number of keys used matches the number of keys specified by the user.

@melo-gonzo I've made it trigger an error, rather than a warning message, since it's probably too easy to ignore warnings and rather have it complete training.

Closes #75