### PR TITLE
OutputHead Key Correction

### DIFF
--- a/matsciml/models/common.py
+++ b/matsciml/models/common.py
@@ -322,6 +322,7 @@ class OutputHead(nn.Module):
             ],
         )
         # last layer does not use residual or normalization
+        kwargs["residual"] = False
         blocks.append(
             block_type(
                 output_dim=output_dim,


### PR DESCRIPTION
Simple bugfix to correct the `residual` keys in final output block creation. 

Closes #77