### PR TITLE
Fix issue https://github.com/IntelLabs/matsciml/issues/91

### DIFF
--- a/matsciml/datasets/transforms/frame_averaging.py
+++ b/matsciml/datasets/transforms/frame_averaging.py
@@ -10,8 +10,7 @@ from copy import deepcopy
 from itertools import product
 
 import torch
-import torch_geometric
-from torch_geometric.transforms import LinearTransformation
+
 
 from matsciml.common import package_registry
 from matsciml.datasets.transforms.base import AbstractDataTransform
@@ -21,7 +20,7 @@ if package_registry["dgl"]:
 
 if package_registry["pyg"]:
     import torch_geometric
-
+    from torch_geometric.transforms import LinearTransformation
 
 def compute_frames(
     eigenvec,


### PR DESCRIPTION
only import from torch_geometric in datasets.transformation.frame_averaging.py when package_registry check for pyg is satisfied 