### PR TITLE
Quick Lightning 2.0 Compatibility Update

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1411,7 +1411,7 @@ class MaceEnergyForceTask(BaseTaskModule):
         return status
 
     def on_validation_batch_start(
-        self, batch: any, batch_idx: int, dataloader_idx: int
+        self, batch: any, batch_idx: int, dataloader_idx: int = 0
     ):
         self.on_train_batch_start(batch, batch_idx)
 


### PR DESCRIPTION
Adding a default value for dataloader_idx so the MACE example script runs without hiccups.