### PR TITLE
Periodic properties transform

### DIFF
--- a/examples/datasets/periodic_properties_pipeline.py
+++ b/examples/datasets/periodic_properties_pipeline.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from matsciml.datasets import IS2REDataset, NomadDataset
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+
+"""
+This example shows how periodic boundary conditions can be wired
+into the graphs via the transform pipeline interface.
+
+We chain the `PeriodicPropertiesTransform`, which calculates the
+offsets and images using Pymatgen, which provides the edge definitions
+that are used by `PointCloudToGraphTransform`.
+"""
+
+dset = IS2REDataset.from_devset(
+    transforms=[
+        PeriodicPropertiesTransform(cutoff_radius=6.5),
+        PointCloudToGraphTransform(backend="dgl"),
+    ],
+)
+
+dset.__getitem__(25)

--- a/matsciml/datasets/transforms/__init__.py
+++ b/matsciml/datasets/transforms/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from matsciml.datasets.transforms.frame_averaging import FrameAveraging
+from matsciml.datasets.transforms.pbc import *
 from matsciml.datasets.transforms.props import *
 from matsciml.datasets.transforms.representations import *

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import torch
 from pymatgen.core import Lattice
 
-from matsciml.common.packages import package_registry
 from matsciml.common.types import DataDict
 from matsciml.datasets.transforms.base import AbstractDataTransform
 from matsciml.datasets.utils import (
@@ -11,62 +10,56 @@ from matsciml.datasets.utils import (
     make_pymatgen_periodic_structure,
 )
 
-if any([pkg in package_registry for pkg in ["pyg", "dgl"]]):
-    _has_graphs = True
-else:
-    _has_graphs = False
+__all__ = ["PeriodicPropertiesTransform"]
 
 
-if _has_graphs:
-    __all__ = ["PeriodicPropertiesTransform"]
+class PeriodicPropertiesTransform(AbstractDataTransform):
+    """
+    Rewires an already present graph to include periodic boundary conditions.
 
-    class PeriodicPropertiesTransform(AbstractDataTransform):
-        """
-        Rewires an already present graph to include periodic boundary conditions.
+    Since graphs are normally bounded within a unit cell, they may not capture
+    the necessary dependencies for atoms connected to neighboring cells. This
+    transform will compute the unit cell, tile it, and then rewire the graph
+    edges such that it can capture connectivity given a radial cutoff given
+    in Angstroms.
+    """
 
-        Since graphs are normally bounded within a unit cell, they may not capture
-        the necessary dependencies for atoms connected to neighboring cells. This
-        transform will compute the unit cell, tile it, and then rewire the graph
-        edges such that it can capture connectivity given a radial cutoff given
-        in Angstroms.
-        """
+    def __init__(self, cutoff_radius: float) -> None:
+        super().__init__()
+        self.cutoff_radius = cutoff_radius
 
-        def __init__(self, cutoff_radius: float) -> None:
-            super().__init__()
-            self.cutoff_radius = cutoff_radius
-
-        def __call__(self, data: DataDict) -> DataDict:
-            for key in ["atomic_numbers", "pos"]:
-                assert key in data, f"{key} missing from data sample!"
-            if "cell" in data:
-                # squeeze is used to make sure we remove empty dims
-                lattice = Lattice(data["cell"].squeeze())
+    def __call__(self, data: DataDict) -> DataDict:
+        for key in ["atomic_numbers", "pos"]:
+            assert key in data, f"{key} missing from data sample!"
+        if "cell" in data:
+            # squeeze is used to make sure we remove empty dims
+            lattice = Lattice(data["cell"].squeeze())
+        else:
+            # if we don't have a cell already, we go through the
+            # whole process
+            if "lattice_features" in data:
+                lattice_key = "lattice_features"
+            elif "lattice_params" in data:
+                lattice_key = "lattice_params"
             else:
-                # if we don't have a cell already, we go through the
-                # whole process
-                if "lattice_features" in data:
-                    lattice_key = "lattice_features"
-                elif "lattice_params" in data:
-                    lattice_key = "lattice_params"
-                else:
-                    raise KeyError(
-                        "Data sample is missing lattice parameters. "
-                        "Ensure `lattice_features` or `lattice_params` is available"
-                        " in the data.",
-                    )
-                lattice_params: torch.Tensor = data[lattice_key]
-                if isinstance(lattice_params, dict):
-                    lattice_params = lattice_params["lattice_params"]
-                abc, angles = lattice_params[:3], lattice_params[3:]
-                angles = torch.FloatTensor(
-                    tuple(angle * (180.0 / torch.pi) for angle in angles),
+                raise KeyError(
+                    "Data sample is missing lattice parameters. "
+                    "Ensure `lattice_features` or `lattice_params` is available"
+                    " in the data.",
                 )
-                lattice = Lattice.from_parameters(*abc, *angles)
-            structure = make_pymatgen_periodic_structure(
-                data["atomic_numbers"],
-                data["pos"],
-                lattice=lattice,
+            lattice_params: torch.Tensor = data[lattice_key]
+            if isinstance(lattice_params, dict):
+                lattice_params = lattice_params["lattice_params"]
+            abc, angles = lattice_params[:3], lattice_params[3:]
+            angles = torch.FloatTensor(
+                tuple(angle * (180.0 / torch.pi) for angle in angles),
             )
-            graph_props = calculate_periodic_shifts(structure, self.cutoff_radius)
-            data.update(graph_props)
-            return data
+            lattice = Lattice.from_parameters(*abc, *angles)
+        structure = make_pymatgen_periodic_structure(
+            data["atomic_numbers"],
+            data["pos"],
+            lattice=lattice,
+        )
+        graph_props = calculate_periodic_shifts(structure, self.cutoff_radius)
+        data.update(graph_props)
+        return data

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -30,7 +30,7 @@ if _has_graphs:
         in Angstroms.
         """
 
-        def __init__(self, cutoff_radius: float, graph_backend: str = "dgl") -> None:
+        def __init__(self, cutoff_radius: float) -> None:
             super().__init__()
             self.cutoff_radius = cutoff_radius
 

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -18,6 +18,7 @@ else:
 
 
 if _has_graphs:
+    __all__ = ["PeriodicPropertiesTransform"]
 
     class PeriodicPropertiesTransform(AbstractDataTransform):
         """

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -65,4 +65,5 @@ if _has_graphs:
                 lattice=lattice,
             )
             graph_props = calculate_periodic_shifts(structure, self.cutoff_radius)
+            data.update(graph_props)
             return data

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -19,7 +19,7 @@ else:
 
 if _has_graphs:
 
-    class PeriodicGraphTransform(AbstractDataTransform):
+    class PeriodicPropertiesTransform(AbstractDataTransform):
         """
         Rewires an already present graph to include periodic boundary conditions.
 

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -54,6 +54,8 @@ if _has_graphs:
                         " in the data.",
                     )
                 lattice_params: torch.Tensor = data[lattice_key]
+                if isinstance(lattice_params, dict):
+                    lattice_params = lattice_params["lattice_params"]
                 abc, angles = lattice_params[:3], lattice_params[3:]
                 angles = torch.FloatTensor(
                     tuple(angle * (180.0 / torch.pi) for angle in angles),

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import torch
+from einops import rearrange
+from pymatgen.core import Lattice
+
+from matsciml.common.packages import package_registry
+from matsciml.common.types import DataDict
+from matsciml.datasets.transforms.base import AbstractDataTransform
+
+if any([pkg in package_registry for pkg in ["pyg", "dgl"]]):
+    _has_graphs = True
+else:
+    _has_graphs = False
+
+
+if _has_graphs:
+
+    class PeriodicGraphTransform(AbstractDataTransform):
+        """
+        Rewires an already present graph to include periodic boundary conditions.
+
+        Since graphs are normally bounded within a unit cell, they may not capture
+        the necessary dependencies for atoms connected to neighboring cells. This
+        transform will compute the unit cell, tile it, and then rewire the graph
+        edges such that it can capture connectivity given a radial cutoff given
+        in Angstroms.
+        """
+
+        def __init__(self, cutoff_radius: float) -> None:
+            super().__init__()
+            self.cutoff_radius = cutoff_radius
+
+        def __call__(self, data: DataDict) -> DataDict:
+            assert (
+                "graph" in data
+            ), "Missing graph in data sample; please prepend a graph transform."
+            if "lattice_features" in data:
+                lattice_key = "lattice_features"
+            elif "lattice_params" in data:
+                lattice_key = "lattice_params"
+            else:
+                raise KeyError(
+                    "Data sample is missing lattice parameters. "
+                    "Ensure `lattice_features` or `lattice_params` is available"
+                    " in the data.",
+                )
+            lattice_params: torch.Tensor = data[lattice_key]
+            abc, angles = lattice_params[:3], lattice_params[3:]
+            angles = torch.FloatTensor(
+                tuple(angle * (180.0 / torch.pi) for angle in angles),
+            )
+            lattice_obj = Lattice.from_parameters(*abc, *angles)
+            lattice_matrix = torch.Tensor(lattice_obj.matrix)
+            # add dimension for batching
+            data["cell"] = rearrange(lattice_matrix, "h w -> () h w")
+            return data

--- a/matsciml/datasets/transforms/representations/graphs.py
+++ b/matsciml/datasets/transforms/representations/graphs.py
@@ -205,9 +205,6 @@ class PointCloudToGraphTransform(RepresentationTransform):
             g.ndata["atomic_numbers"] = atom_numbers
             g.ndata["pos"] = coords
             # copying over periodic data if it exists
-            for key in ["images"]:
-                if key in data:
-                    g.ndata[key] = data[key]
             for key in ["offsets", "pbc_distances"]:
                 if key in data:
                     g.edata[key] = data[key]

--- a/matsciml/datasets/transforms/representations/graphs.py
+++ b/matsciml/datasets/transforms/representations/graphs.py
@@ -237,15 +237,19 @@ class PointCloudToGraphTransform(RepresentationTransform):
             """
             atom_numbers = self.get_atom_types(data)
             coords = data["pos"]
-            atom_numbers, coords = self._apply_mask(atom_numbers, coords, data)
-            if "distance_matrix" not in data:
-                dist_mat = self.node_distances(coords)
+            # check to see if we have pre-computed edges
+            if all([f"{key}_nodes" in data for key in ["src", "dst"]]) in data:
+                edge_index = torch.stack([data["src_nodes"], data["dst_nodes"]])
             else:
-                dist_mat = data.get("distance_matrix")
-            # convert ensure edges are in the right format for PyG
-            edge_index = torch.LongTensor(
-                self.edges_from_dist(dist_mat, self.cutoff_dist),
-            )
+                atom_numbers, coords = self._apply_mask(atom_numbers, coords, data)
+                if "distance_matrix" not in data:
+                    dist_mat = self.node_distances(coords)
+                else:
+                    dist_mat = data.get("distance_matrix")
+                # convert ensure edges are in the right format for PyG
+                edge_index = torch.LongTensor(
+                    self.edges_from_dist(dist_mat, self.cutoff_dist),
+                )
             # if not in the expected shape, transpose and reformat layout
             if edge_index.size(0) != 2 and edge_index.size(1) == 2:
                 edge_index = edge_index.T.contiguous()

--- a/matsciml/datasets/transforms/representations/graphs.py
+++ b/matsciml/datasets/transforms/representations/graphs.py
@@ -192,7 +192,7 @@ class PointCloudToGraphTransform(RepresentationTransform):
             num_nodes = len(atom_numbers)
             # use pre-computed edges with periodic boundary conditions
             if all([f"{key}_nodes" in data for key in ["src", "dst"]]):
-                adj_list = [data["src_nodes"], data["dst_nodes"]]
+                adj_list = (data["src_nodes"], data["dst_nodes"])
             else:
                 # skip edge calculation if the distance matrix
                 # exists already

--- a/matsciml/datasets/transforms/representations/graphs.py
+++ b/matsciml/datasets/transforms/representations/graphs.py
@@ -205,7 +205,7 @@ class PointCloudToGraphTransform(RepresentationTransform):
             g.ndata["atomic_numbers"] = atom_numbers
             g.ndata["pos"] = coords
             # copying over periodic data if it exists
-            for key in ["offsets", "pbc_distances"]:
+            for key in ["offsets", "pbc_distances", "images"]:
                 if key in data:
                     g.edata[key] = data[key]
             data["graph"] = g

--- a/matsciml/datasets/transforms/representations/graphs.py
+++ b/matsciml/datasets/transforms/representations/graphs.py
@@ -266,6 +266,15 @@ class PointCloudToGraphTransform(RepresentationTransform):
                 edge_index = edge_index.T.contiguous()
             g = PyGGraph(edge_index=edge_index, pos=coords)
             g.atomic_numbers = atom_numbers
+            # run through potential periodic data as well. The two
+            # are functionally the same, but separating them because
+            # we keep edge and node data separate
+            for key in ["images"]:
+                if key in data:
+                    setattr(g, key, data[key])
+            for key in ["offsets", "pbc_distances"]:
+                if key in data:
+                    setattr(g, key, data[key])
             data["graph"] = g
 
     def convert(self, data: DataDict) -> None:

--- a/matsciml/datasets/transforms/representations/graphs.py
+++ b/matsciml/datasets/transforms/representations/graphs.py
@@ -311,7 +311,7 @@ class PointCloudToGraphTransform(RepresentationTransform):
                 del data[key]
             except KeyError:
                 pass
-        if self.backend == "dgl":
+        if self.backend == "dgl" and "cell" not in data:
             # DGL graphs are inherently directed, so we need to add non-redundant
             # reverse edges to avoid issues with message passing
             data["graph"] = dgl.to_bidirected(data["graph"], copy_ndata=True)

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -694,7 +694,7 @@ def calculate_periodic_shifts(
             all_dst.append(site.index)
             all_images.append(site.image)
     # get the lattice definition for use later
-    cell = rearrange(structure.lattice.matrix(), "i j -> () i j")
+    cell = rearrange(structure.lattice.matrix, "i j -> () i j")
     cell = torch.from_numpy(cell).float()
     # get coordinates as well, for standardization
     frac_coords = torch.from_numpy(structure.frac_coords).float()

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -706,7 +706,7 @@ def calculate_periodic_shifts(
         "pos": frac_coords,
     }
     # now calculate offsets based on each image for a lattice
-    return_dict["offsets"] = einsum(images, cell, "v i, n i j -> v j")
+    return_dict["offsets"] = einsum(return_dict["images"], cell, "v i, n i j -> v j")
     src, dst = return_dict["src"], return_dict["dst"]
     return_dict["pbc_distances"] = (
         frac_coords[dst] - frac_coords[src] + return_dict["offsets"]

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -701,7 +701,7 @@ def calculate_periodic_shifts(
     return_dict = {
         "src": torch.LongTensor(all_src),
         "dst": torch.LongTensor(all_dst),
-        "images": torch.LongTensor(all_images),
+        "images": torch.FloatTensor(all_images),
         "cell": cell,
         "pos": frac_coords,
     }

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -702,7 +702,7 @@ def calculate_periodic_shifts(
             all_images.append(site.image)
     # get the lattice definition for use later
     cell = rearrange(structure.lattice.matrix, "i j -> () i j")
-    cell = torch.from_numpy(cell).float()
+    cell = torch.from_numpy(cell.copy()).float()
     # get coordinates as well, for standardization
     frac_coords = torch.from_numpy(structure.frac_coords).float()
     return_dict = {

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -714,7 +714,7 @@ def calculate_periodic_shifts(
     }
     # now calculate offsets based on each image for a lattice
     return_dict["offsets"] = einsum(return_dict["images"], cell, "v i, n i j -> v j")
-    src, dst = return_dict["src"], return_dict["dst"]
+    src, dst = return_dict["src_nodes"], return_dict["dst_nodes"]
     return_dict["pbc_distances"] = (
         frac_coords[dst] - frac_coords[src] + return_dict["offsets"]
     )

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -605,8 +605,9 @@ def element_types():
 def make_pymatgen_periodic_structure(
     atomic_numbers: torch.Tensor,
     coords: torch.Tensor,
-    lat_angles: torch.Tensor,
-    lat_abc: torch.Tensor,
+    lat_angles: torch.Tensor | None = None,
+    lat_abc: torch.Tensor | None = None,
+    lattice: Lattice | None = None,
 ) -> Structure:
     """
     Construct a Pymatgen structure from available information
@@ -638,7 +639,13 @@ def make_pymatgen_periodic_structure(
         is_frac = False
     else:
         is_frac = True
-    lattice = Lattice(*lat_abc, *lat_angles)
+    if not lattice:
+        if lat_angles is None or lat_abc is None:
+            raise ValueError(
+                "Unable to construct Lattice object without parameters:"
+                f" Angles: {lat_angles}, ABC: {lat_abc}",
+            )
+        lattice = Lattice(*lat_abc, *lat_angles)
     structure = Structure(
         lattice,
         atomic_numbers,

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -706,8 +706,8 @@ def calculate_periodic_shifts(
     # get coordinates as well, for standardization
     frac_coords = torch.from_numpy(structure.frac_coords).float()
     return_dict = {
-        "src": torch.LongTensor(all_src),
-        "dst": torch.LongTensor(all_dst),
+        "src_nodes": torch.LongTensor(all_src),
+        "dst_nodes": torch.LongTensor(all_dst),
         "images": torch.FloatTensor(all_images),
         "cell": cell,
         "pos": frac_coords,

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -672,6 +672,9 @@ def calculate_periodic_shifts(
     structure (for obvious reasons), and that we are using fractional coordinates
     in order to compute the distances and offsets.
 
+    Portions of this code were inspired by the `e3nn` documentation, which is
+    released under MIT license.
+
     Parameters
     ----------
     structure

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -718,7 +718,8 @@ def calculate_periodic_shifts(
     # now calculate offsets based on each image for a lattice
     return_dict["offsets"] = einsum(return_dict["images"], cell, "v i, n i j -> v j")
     src, dst = return_dict["src_nodes"], return_dict["dst_nodes"]
-    return_dict["pbc_distances"] = (
+    # this corresponds to distances between nodes based on unit cell images
+    return_dict["unit_offsets"] = (
         frac_coords[dst] - frac_coords[src] + return_dict["offsets"]
     )
     return return_dict


### PR DESCRIPTION
This PR includes a general transform that will compute edges and distances based on unit cell images. The main use case designed for this is to pipeline with `PointCloudToGraphTransform` to produce graphs that have been wired for periodic boundary conditions, but is designed to be modular (i.e. point clouds could use this too).

A demonstration of its usage is shown in `examples/datasets/periodic_properties_pipeline.py`.

I didn't include it in this PR, but in some ways it supersedes `UnitCellCalculator`. Needs some work to find out how to fully replace it.

The main modifications in `utils.py` are including two functions that A) create Pymatgen `Structure` objects, and B) use `Structure` to compute neighboring atoms while respecting periodic boundary conditions. The new `PeriodicPropertiesTransform` calls these functions, and the results are automatically picked up by the `PointCloudToGraphTransform`, which has been refactored to look for pre-computed edges.

I've tested it on devsets for IS2RE, NOMAD, Materials Project, and LiPS