### PR TITLE
Lint and run formatters on MACE codebase

### DIFF
--- a/matsciml/models/pyg/__init__.py
+++ b/matsciml/models/pyg/__init__.py
@@ -21,5 +21,5 @@ if _has_pyg:
     from matsciml.models.pyg.egnn import EGNN
     from matsciml.models.pyg.faenet import FAENet
     from matsciml.models.pyg.forcenet import ForceNet
-    from matsciml.models.pyg.mace.modules.models import MACE, ScaleShiftMACE
+    from matsciml.models.pyg.mace import MACE, ScaleShiftMACE
     from matsciml.models.pyg.schnet import SchNetWrap

--- a/matsciml/models/pyg/__init__.py
+++ b/matsciml/models/pyg/__init__.py
@@ -6,11 +6,11 @@ LICENSE file in the root directory of this source tree.
 """
 from __future__ import annotations
 
-try:
-    import torch_geometric
+from matsciml.common.packages import package_registry
 
+if "pyg" in package_registry:
     _has_pyg = True
-except ImportError:
+else:
     _has_pyg = False
 
 # load models if we have PyG installed
@@ -19,7 +19,7 @@ if _has_pyg:
     from matsciml.models.pyg.dimenet import DimeNetWrap
     from matsciml.models.pyg.dimenet_plus_plus import DimeNetPlusPlusWrap
     from matsciml.models.pyg.egnn import EGNN
-    from matsciml.models.pyg.mace.modules.models import MACE,ScaleShiftMACE
     from matsciml.models.pyg.faenet import FAENet
     from matsciml.models.pyg.forcenet import ForceNet
+    from matsciml.models.pyg.mace.modules.models import MACE, ScaleShiftMACE
     from matsciml.models.pyg.schnet import SchNetWrap

--- a/matsciml/models/pyg/mace/__init__.py
+++ b/matsciml/models/pyg/mace/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from matsciml.models.pyg.mace.modules.models import MACE, ScaleShiftMACE
+
+__all__ = [
+    "MACE",
+    "ScaleShiftMACE",
+]

--- a/matsciml/models/pyg/mace/data/__init__.py
+++ b/matsciml/models/pyg/mace/data/__init__.py
@@ -1,14 +1,16 @@
 ###########################################################################################
-# Implementation of MACE models and other models based E(3)-Equivariant MPNNs 
-#(https://github.com/ACEsuit/mace)
+# Implementation of MACE models and other models based E(3)-Equivariant MPNNs
+# (https://github.com/ACEsuit/mace)
 # Original Authors: Ilyes Batatia, Gregor Simm
 # Integrated into matsciml by Vaibhav Bihani, Sajid Mannan
 # This program is distributed under the MIT License
 ###########################################################################################
 
-from .atomic_data import AtomicData
-from .neighborhood import get_neighborhood
-from .utils import (
+from __future__ import annotations
+
+from matsciml.models.pyg.mace.data.atomic_data import AtomicData
+from matsciml.models.pyg.mace.data.neighborhood import get_neighborhood
+from matsciml.models.pyg.mace.data.utils import (
     Configuration,
     Configurations,
     compute_average_E0s,

--- a/matsciml/models/pyg/mace/data/atomic_data.py
+++ b/matsciml/models/pyg/mace/data/atomic_data.py
@@ -4,20 +4,22 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
-from typing import Optional, Sequence
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Optional
 
 import torch.utils.data
 import torch_geometric
 
+from matsciml.models.pyg.mace.data.neighborhood import get_neighborhood
+from matsciml.models.pyg.mace.data.utils import Configuration
 from matsciml.models.pyg.mace.tools import (
     AtomicNumberTable,
     atomic_numbers_to_indices,
     to_one_hot,
     voigt_to_matrix,
 )
-
-from .neighborhood import get_neighborhood
-from .utils import Configuration
 
 
 class AtomicData(torch_geometric.data.Data):
@@ -50,18 +52,18 @@ class AtomicData(torch_geometric.data.Data):
         positions: torch.Tensor,  # [n_nodes, 3]
         shifts: torch.Tensor,  # [n_edges, 3],
         unit_shifts: torch.Tensor,  # [n_edges, 3]
-        cell: Optional[torch.Tensor],  # [3,3]
-        weight: Optional[torch.Tensor],  # [,]
-        energy_weight: Optional[torch.Tensor],  # [,]
-        forces_weight: Optional[torch.Tensor],  # [,]
-        stress_weight: Optional[torch.Tensor],  # [,]
-        virials_weight: Optional[torch.Tensor],  # [,]
-        forces: Optional[torch.Tensor],  # [n_nodes, 3]
-        energy: Optional[torch.Tensor],  # [, ]
-        stress: Optional[torch.Tensor],  # [1,3,3]
-        virials: Optional[torch.Tensor],  # [1,3,3]
-        dipole: Optional[torch.Tensor],  # [, 3]
-        charges: Optional[torch.Tensor],  # [n_nodes, ]
+        cell: torch.Tensor | None,  # [3,3]
+        weight: torch.Tensor | None,  # [,]
+        energy_weight: torch.Tensor | None,  # [,]
+        forces_weight: torch.Tensor | None,  # [,]
+        stress_weight: torch.Tensor | None,  # [,]
+        virials_weight: torch.Tensor | None,  # [,]
+        forces: torch.Tensor | None,  # [n_nodes, 3]
+        energy: torch.Tensor | None,  # [, ]
+        stress: torch.Tensor | None,  # [1,3,3]
+        virials: torch.Tensor | None,  # [1,3,3]
+        dipole: torch.Tensor | None,  # [, 3]
+        charges: torch.Tensor | None,  # [n_nodes, ]
     ):
         # Check shapes
         num_nodes = node_attrs.shape[0]
@@ -108,10 +110,16 @@ class AtomicData(torch_geometric.data.Data):
 
     @classmethod
     def from_config(
-        cls, config: Configuration, z_table: AtomicNumberTable, cutoff: float
-    ) -> "AtomicData":
+        cls,
+        config: Configuration,
+        z_table: AtomicNumberTable,
+        cutoff: float,
+    ) -> AtomicData:
         edge_index, shifts, unit_shifts = get_neighborhood(
-            positions=config.positions, cutoff=cutoff, pbc=config.pbc, cell=config.cell
+            positions=config.positions,
+            cutoff=cutoff,
+            pbc=config.pbc,
+            cell=config.cell,
         )
         indices = atomic_numbers_to_indices(config.atomic_numbers, z_table=z_table)
         one_hot = to_one_hot(
@@ -123,7 +131,8 @@ class AtomicData(torch_geometric.data.Data):
             torch.tensor(config.cell, dtype=torch.get_default_dtype())
             if config.cell is not None
             else torch.tensor(
-                3 * [0.0, 0.0, 0.0], dtype=torch.get_default_dtype()
+                3 * [0.0, 0.0, 0.0],
+                dtype=torch.get_default_dtype(),
             ).view(3, 3)
         )
 
@@ -169,7 +178,7 @@ class AtomicData(torch_geometric.data.Data):
         )
         stress = (
             voigt_to_matrix(
-                torch.tensor(config.stress, dtype=torch.get_default_dtype())
+                torch.tensor(config.stress, dtype=torch.get_default_dtype()),
             ).unsqueeze(0)
             if config.stress is not None
             else None

--- a/matsciml/models/pyg/mace/data/atomic_data.py
+++ b/matsciml/models/pyg/mace/data/atomic_data.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Optional
 
 import torch.utils.data
 import torch_geometric

--- a/matsciml/models/pyg/mace/data/neighborhood.py
+++ b/matsciml/models/pyg/mace/data/neighborhood.py
@@ -4,6 +4,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import ase.neighborlist
@@ -13,10 +15,10 @@ import numpy as np
 def get_neighborhood(
     positions: np.ndarray,  # [num_positions, 3]
     cutoff: float,
-    pbc: Optional[Tuple[bool, bool, bool]] = None,
-    cell: Optional[np.ndarray] = None,  # [3, 3]
+    pbc: tuple[bool, bool, bool] | None = None,
+    cell: np.ndarray | None = None,  # [3, 3]
     true_self_interaction=False,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     if pbc is None:
         pbc = (False, False, False)
 

--- a/matsciml/models/pyg/mace/data/neighborhood.py
+++ b/matsciml/models/pyg/mace/data/neighborhood.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
-
 import ase.neighborlist
 import numpy as np
 

--- a/matsciml/models/pyg/mace/data/utils.py
+++ b/matsciml/models/pyg/mace/data/utils.py
@@ -4,9 +4,12 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import ase.data
 import ase.io
@@ -31,29 +34,31 @@ DEFAULT_CONFIG_TYPE_WEIGHTS = {DEFAULT_CONFIG_TYPE: 1.0}
 class Configuration:
     atomic_numbers: np.ndarray
     positions: Positions  # Angstrom
-    energy: Optional[float] = None  # eV
-    forces: Optional[Forces] = None  # eV/Angstrom
-    stress: Optional[Stress] = None  # eV/Angstrom^3
-    virials: Optional[Virials] = None  # eV
-    dipole: Optional[Vector] = None  # Debye
-    charges: Optional[Charges] = None  # atomic unit
-    cell: Optional[Cell] = None
-    pbc: Optional[Pbc] = None
+    energy: float | None = None  # eV
+    forces: Forces | None = None  # eV/Angstrom
+    stress: Stress | None = None  # eV/Angstrom^3
+    virials: Virials | None = None  # eV
+    dipole: Vector | None = None  # Debye
+    charges: Charges | None = None  # atomic unit
+    cell: Cell | None = None
+    pbc: Pbc | None = None
 
     weight: float = 1.0  # weight of config in loss
     energy_weight: float = 1.0  # weight of config energy in loss
     forces_weight: float = 1.0  # weight of config forces in loss
     stress_weight: float = 1.0  # weight of config stress in loss
     virials_weight: float = 1.0  # weight of config virial in loss
-    config_type: Optional[str] = DEFAULT_CONFIG_TYPE  # config_type of config
+    config_type: str | None = DEFAULT_CONFIG_TYPE  # config_type of config
 
 
-Configurations = List[Configuration]
+Configurations = list[Configuration]
 
 
 def random_train_valid_split(
-    items: Sequence, valid_fraction: float, seed: int
-) -> Tuple[List, List]:
+    items: Sequence,
+    valid_fraction: float,
+    seed: int,
+) -> tuple[list, list]:
     assert 0.0 < valid_fraction < 1.0
 
     size = len(items)
@@ -70,14 +75,14 @@ def random_train_valid_split(
 
 
 def config_from_atoms_list(
-    atoms_list: List[ase.Atoms],
+    atoms_list: list[ase.Atoms],
     energy_key="energy",
     forces_key="forces",
     stress_key="stress",
     virials_key="virials",
     dipole_key="dipole",
     charges_key="charges",
-    config_type_weights: Dict[str, float] = None,
+    config_type_weights: dict[str, float] = None,
 ) -> Configurations:
     """Convert list of ase.Atoms into Configurations"""
     if config_type_weights is None:
@@ -95,7 +100,7 @@ def config_from_atoms_list(
                 dipole_key=dipole_key,
                 charges_key=charges_key,
                 config_type_weights=config_type_weights,
-            )
+            ),
         )
     return all_configs
 
@@ -108,7 +113,7 @@ def config_from_atoms(
     virials_key="virials",
     dipole_key="dipole",
     charges_key="charges",
-    config_type_weights: Dict[str, float] = None,
+    config_type_weights: dict[str, float] = None,
 ) -> Configuration:
     """Convert ase.Atoms to Configuration"""
     if config_type_weights is None:
@@ -122,13 +127,14 @@ def config_from_atoms(
     # Charges default to 0 instead of None if not found
     charges = atoms.arrays.get(charges_key, np.zeros(len(atoms)))  # atomic unit
     atomic_numbers = np.array(
-        [ase.data.atomic_numbers[symbol] for symbol in atoms.symbols]
+        [ase.data.atomic_numbers[symbol] for symbol in atoms.symbols],
     )
     pbc = tuple(atoms.get_pbc())
     cell = np.array(atoms.get_cell())
     config_type = atoms.info.get("config_type", "Default")
     weight = atoms.info.get("config_weight", 1.0) * config_type_weights.get(
-        config_type, 1.0
+        config_type,
+        1.0,
     )
     energy_weight = atoms.info.get("config_energy_weight", 1.0)
     forces_weight = atoms.info.get("config_forces_weight", 1.0)
@@ -171,7 +177,7 @@ def config_from_atoms(
 
 def test_config_types(
     test_configs: Configurations,
-) -> List[Tuple[Optional[str], List[Configuration]]]:
+) -> list[tuple[str | None, list[Configuration]]]:
     """Split test set based on config_type-s"""
     test_by_ct = []
     all_cts = []
@@ -187,7 +193,7 @@ def test_config_types(
 
 def load_from_xyz(
     file_path: str,
-    config_type_weights: Dict,
+    config_type_weights: dict,
     energy_key: str = "energy",
     forces_key: str = "forces",
     stress_key: str = "stress",
@@ -195,7 +201,7 @@ def load_from_xyz(
     dipole_key: str = "dipole",
     charges_key: str = "charges",
     extract_atomic_energies: bool = False,
-) -> Tuple[Dict[int, float], Configurations]:
+) -> tuple[dict[int, float], Configurations]:
     atoms_list = ase.io.read(file_path, index=":")
 
     if not isinstance(atoms_list, list):
@@ -205,7 +211,7 @@ def load_from_xyz(
     if extract_atomic_energies:
         atoms_without_iso_atoms = []
 
-        for idx, atoms in enumerate(atoms_list):# 1000
+        for idx, atoms in enumerate(atoms_list):  # 1000
             if len(atoms) == 1 and atoms.info["config_type"] == "IsolatedAtom":
                 if energy_key in atoms.info.keys():
                     atomic_energies_dict[atoms.get_atomic_numbers()[0]] = atoms.info[
@@ -214,7 +220,7 @@ def load_from_xyz(
                 else:
                     logging.warning(
                         f"Configuration '{idx}' is marked as 'IsolatedAtom' "
-                        "but does not contain an energy."
+                        "but does not contain an energy.",
                     )
             else:
                 atoms_without_iso_atoms.append(atoms)
@@ -238,8 +244,9 @@ def load_from_xyz(
 
 
 def compute_average_E0s(
-    collections_train: Configurations, z_table: AtomicNumberTable
-) -> Dict[int, float]:
+    collections_train: Configurations,
+    z_table: AtomicNumberTable,
+) -> dict[int, float]:
     """
     Function to compute the average interaction energy of each chemical element
     returns dictionary of E0s
@@ -259,7 +266,7 @@ def compute_average_E0s(
             atomic_energies_dict[z] = E0s[i]
     except np.linalg.LinAlgError:
         logging.warning(
-            "Failed to compute E0s using least squares regression, using the same for all atoms"
+            "Failed to compute E0s using least squares regression, using the same for all atoms",
         )
         atomic_energies_dict = {}
         for i, z in enumerate(z_table.zs):

--- a/matsciml/models/pyg/mace/data/utils.py
+++ b/matsciml/models/pyg/mace/data/utils.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
 
 import ase.data
 import ase.io

--- a/matsciml/models/pyg/mace/modules/__init__.py
+++ b/matsciml/models/pyg/mace/modules/__init__.py
@@ -1,17 +1,19 @@
 ###########################################################################################
 # Implementation of MACE models and other models based E(3)-Equivariant MPNNs
-#(https://github.com/ACEsuit/mace)
+# (https://github.com/ACEsuit/mace)
 # Original Authors: Ilyes Batatia, Gregor Simm
 # Integrated into matsciml by Vaibhav Bihani, Sajid Mannan
 # This program is distributed under the MIT License
 ###########################################################################################
 
 
+from __future__ import annotations
+
 from typing import Callable, Dict, Optional, Type
 
 import torch
 
-from .blocks import (
+from matsciml.models.pyg.mace.modules.blocks import (
     AgnosticNonlinearInteractionBlock,
     AgnosticResidualNonlinearInteractionBlock,
     AtomicEnergiesBlock,
@@ -28,9 +30,7 @@ from .blocks import (
     ResidualElementDependentInteractionBlock,
     ScaleShiftBlock,
 )
-
-
-from .models import (
+from matsciml.models.pyg.mace.modules.models import (
     MACE,
     AtomicDipolesMACE,
     BOTNet,
@@ -38,9 +38,9 @@ from .models import (
     ScaleShiftBOTNet,
     ScaleShiftMACE,
 )
-from .radial import BesselBasis, PolynomialCutoff
-from .symmetric_contraction import SymmetricContraction
-from .utils import (
+from matsciml.models.pyg.mace.modules.radial import BesselBasis, PolynomialCutoff
+from matsciml.models.pyg.mace.modules.symmetric_contraction import SymmetricContraction
+from matsciml.models.pyg.mace.modules.utils import (
     compute_avg_num_neighbors,
     compute_fixed_charge_dipole,
     compute_mean_rms_energy_forces,
@@ -48,7 +48,7 @@ from .utils import (
     compute_rms_dipoles,
 )
 
-interaction_classes: Dict[str, Type[InteractionBlock]] = {
+interaction_classes: dict[str, type[InteractionBlock]] = {
     "AgnosticNonlinearInteractionBlock": AgnosticNonlinearInteractionBlock,
     "ResidualElementDependentInteractionBlock": ResidualElementDependentInteractionBlock,
     "AgnosticResidualNonlinearInteractionBlock": AgnosticResidualNonlinearInteractionBlock,
@@ -56,13 +56,13 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "RealAgnosticInteractionBlock": RealAgnosticInteractionBlock,
 }
 
-scaling_classes: Dict[str, Callable] = {
+scaling_classes: dict[str, Callable] = {
     "std_scaling": compute_mean_std_atomic_inter_energy,
     "rms_forces_scaling": compute_mean_rms_energy_forces,
     "rms_dipoles_scaling": compute_rms_dipoles,
 }
 
-gate_dict: Dict[str, Optional[Callable]] = {
+gate_dict: dict[str, Callable | None] = {
     "abs": torch.abs,
     "tanh": torch.tanh,
     "silu": torch.nn.functional.silu,

--- a/matsciml/models/pyg/mace/modules/__init__.py
+++ b/matsciml/models/pyg/mace/modules/__init__.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Optional, Type
+from typing import Callable
 
 import torch
 

--- a/matsciml/models/pyg/mace/modules/blocks.py
+++ b/matsciml/models/pyg/mace/modules/blocks.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable
 
 import numpy as np
 import torch.nn.functional

--- a/matsciml/models/pyg/mace/modules/blocks.py
+++ b/matsciml/models/pyg/mace/modules/blocks.py
@@ -4,6 +4,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import Callable, Optional, Tuple, Union
 
@@ -12,15 +14,14 @@ import torch.nn.functional
 from e3nn import nn, o3
 from e3nn.util.jit import compile_mode
 
-from matsciml.models.pyg.mace.tools.scatter import scatter_sum
-
-from .irreps_tools import (
+from matsciml.models.pyg.mace.modules.irreps_tools import (
     linear_out_irreps,
     reshape_irreps,
     tp_out_irreps_with_instructions,
 )
-from .radial import BesselBasis, PolynomialCutoff
-from .symmetric_contraction import SymmetricContraction
+from matsciml.models.pyg.mace.modules.radial import BesselBasis, PolynomialCutoff
+from matsciml.models.pyg.mace.modules.symmetric_contraction import SymmetricContraction
+from matsciml.models.pyg.mace.tools.scatter import scatter_sum
 
 
 @compile_mode("script")
@@ -49,14 +50,18 @@ class LinearReadoutBlock(torch.nn.Module):
 @compile_mode("script")
 class NonLinearReadoutBlock(torch.nn.Module):
     def __init__(
-        self, irreps_in: o3.Irreps, MLP_irreps: o3.Irreps, gate: Optional[Callable]
+        self,
+        irreps_in: o3.Irreps,
+        MLP_irreps: o3.Irreps,
+        gate: Callable | None,
     ):
         super().__init__()
         self.hidden_irreps = MLP_irreps
         self.linear_1 = o3.Linear(irreps_in=irreps_in, irreps_out=self.hidden_irreps)
         self.non_linearity = nn.Activation(irreps_in=self.hidden_irreps, acts=[gate])
         self.linear_2 = o3.Linear(
-            irreps_in=self.hidden_irreps, irreps_out=o3.Irreps("0e")
+            irreps_in=self.hidden_irreps,
+            irreps_out=o3.Irreps("0e"),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # [n_nodes, irreps]  # [..., ]
@@ -94,10 +99,14 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
         else:
             self.irreps_out = o3.Irreps("1x0e + 1x1o")
         irreps_scalars = o3.Irreps(
-            [(mul, ir) for mul, ir in MLP_irreps if ir.l == 0 and ir in self.irreps_out]
+            [
+                (mul, ir)
+                for mul, ir in MLP_irreps
+                if ir.l == 0 and ir in self.irreps_out
+            ],
         )
         irreps_gated = o3.Irreps(
-            [(mul, ir) for mul, ir in MLP_irreps if ir.l > 0 and ir in self.irreps_out]
+            [(mul, ir) for mul, ir in MLP_irreps if ir.l > 0 and ir in self.irreps_out],
         )
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
         self.equivariant_nonlin = nn.Gate(
@@ -110,7 +119,8 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
         self.linear_1 = o3.Linear(irreps_in=irreps_in, irreps_out=self.irreps_nonlin)
         self.linear_2 = o3.Linear(
-            irreps_in=self.hidden_irreps, irreps_out=self.irreps_out
+            irreps_in=self.hidden_irreps,
+            irreps_out=self.irreps_out,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # [n_nodes, irreps]  # [..., ]
@@ -122,7 +132,7 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
 class AtomicEnergiesBlock(torch.nn.Module):
     atomic_energies: torch.Tensor
 
-    def __init__(self, atomic_energies: Union[np.ndarray, torch.Tensor]):
+    def __init__(self, atomic_energies: np.ndarray | torch.Tensor):
         super().__init__()
         assert len(atomic_energies.shape) == 1
 
@@ -132,7 +142,8 @@ class AtomicEnergiesBlock(torch.nn.Module):
         )  # [n_elements, ]
 
     def forward(
-        self, x: torch.Tensor  # one-hot of elements [..., n_elements]
+        self,
+        x: torch.Tensor,  # one-hot of elements [..., n_elements]
     ) -> torch.Tensor:  # [..., ]
         return torch.matmul(x, self.atomic_energies)
 
@@ -166,7 +177,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         target_irreps: o3.Irreps,
         correlation: int,
         use_sc: bool = True,
-        num_elements: Optional[int] = None,
+        num_elements: int | None = None,
     ) -> None:
         super().__init__()
 
@@ -188,7 +199,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
     def forward(
         self,
         node_feats: torch.Tensor,
-        sc: Optional[torch.Tensor],
+        sc: torch.Tensor | None,
         node_attrs: torch.Tensor,
     ) -> torch.Tensor:
         node_feats = self.symmetric_contractions(node_feats, node_attrs)
@@ -258,7 +269,10 @@ class TensorProductWeightsBlock(torch.nn.Module):
         edge_feats: torch.Tensor,
     ):
         return torch.einsum(
-            "be, ba, aek -> bk", edge_feats, sender_or_receiver_node_attrs, self.weights
+            "be, ba, aek -> bk",
+            edge_feats,
+            sender_or_receiver_node_attrs,
+            self.weights,
         )
 
     def __repr__(self):
@@ -279,7 +293,9 @@ class ResidualElementDependentInteractionBlock(InteractionBlock):
         )
         # TensorProduct
         irreps_mid, instructions = tp_out_irreps_with_instructions(
-            self.node_feats_irreps, self.edge_attrs_irreps, self.target_irreps
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
         )
         self.conv_tp = o3.TensorProduct(
             self.node_feats_irreps,
@@ -300,12 +316,17 @@ class ResidualElementDependentInteractionBlock(InteractionBlock):
         self.irreps_out = linear_out_irreps(irreps_mid, self.target_irreps)
         self.irreps_out = self.irreps_out.simplify()
         self.linear = o3.Linear(
-            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+            irreps_mid,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
         )
 
         # Selector TensorProduct
         self.skip_tp = o3.FullyConnectedTensorProduct(
-            self.node_feats_irreps, self.node_attrs_irreps, self.irreps_out
+            self.node_feats_irreps,
+            self.node_attrs_irreps,
+            self.irreps_out,
         )
 
     def forward(
@@ -323,10 +344,15 @@ class ResidualElementDependentInteractionBlock(InteractionBlock):
         node_feats = self.linear_up(node_feats)
         tp_weights = self.conv_tp_weights(node_attrs[sender], edge_feats)
         mji = self.conv_tp(
-            node_feats[sender], edge_attrs, tp_weights
+            node_feats[sender],
+            edge_attrs,
+            tp_weights,
         )  # [n_edges, irreps]
         message = scatter_sum(
-            src=mji, index=receiver, dim=0, dim_size=num_nodes
+            src=mji,
+            index=receiver,
+            dim=0,
+            dim_size=num_nodes,
         )  # [n_nodes, irreps]
         message = self.linear(message) / self.avg_num_neighbors
         return message + sc  # [n_nodes, irreps]
@@ -343,7 +369,9 @@ class AgnosticNonlinearInteractionBlock(InteractionBlock):
         )
         # TensorProduct
         irreps_mid, instructions = tp_out_irreps_with_instructions(
-            self.node_feats_irreps, self.edge_attrs_irreps, self.target_irreps
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
         )
         self.conv_tp = o3.TensorProduct(
             self.node_feats_irreps,
@@ -366,12 +394,17 @@ class AgnosticNonlinearInteractionBlock(InteractionBlock):
         self.irreps_out = linear_out_irreps(irreps_mid, self.target_irreps)
         self.irreps_out = self.irreps_out.simplify()
         self.linear = o3.Linear(
-            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+            irreps_mid,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
         )
 
         # Selector TensorProduct
         self.skip_tp = o3.FullyConnectedTensorProduct(
-            self.irreps_out, self.node_attrs_irreps, self.irreps_out
+            self.irreps_out,
+            self.node_attrs_irreps,
+            self.irreps_out,
         )
 
     def forward(
@@ -388,10 +421,15 @@ class AgnosticNonlinearInteractionBlock(InteractionBlock):
         tp_weights = self.conv_tp_weights(edge_feats)
         node_feats = self.linear_up(node_feats)
         mji = self.conv_tp(
-            node_feats[sender], edge_attrs, tp_weights
+            node_feats[sender],
+            edge_attrs,
+            tp_weights,
         )  # [n_edges, irreps]
         message = scatter_sum(
-            src=mji, index=receiver, dim=0, dim_size=num_nodes
+            src=mji,
+            index=receiver,
+            dim=0,
+            dim_size=num_nodes,
         )  # [n_nodes, irreps]
         message = self.linear(message) / self.avg_num_neighbors
         message = self.skip_tp(message, node_attrs)
@@ -410,7 +448,9 @@ class AgnosticResidualNonlinearInteractionBlock(InteractionBlock):
         )
         # TensorProduct
         irreps_mid, instructions = tp_out_irreps_with_instructions(
-            self.node_feats_irreps, self.edge_attrs_irreps, self.target_irreps
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
         )
         self.conv_tp = o3.TensorProduct(
             self.node_feats_irreps,
@@ -433,12 +473,17 @@ class AgnosticResidualNonlinearInteractionBlock(InteractionBlock):
         self.irreps_out = linear_out_irreps(irreps_mid, self.target_irreps)
         self.irreps_out = self.irreps_out.simplify()
         self.linear = o3.Linear(
-            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+            irreps_mid,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
         )
 
         # Selector TensorProduct
         self.skip_tp = o3.FullyConnectedTensorProduct(
-            self.node_feats_irreps, self.node_attrs_irreps, self.irreps_out
+            self.node_feats_irreps,
+            self.node_attrs_irreps,
+            self.irreps_out,
         )
 
     def forward(
@@ -456,10 +501,15 @@ class AgnosticResidualNonlinearInteractionBlock(InteractionBlock):
         node_feats = self.linear_up(node_feats)
         tp_weights = self.conv_tp_weights(edge_feats)
         mji = self.conv_tp(
-            node_feats[sender], edge_attrs, tp_weights
+            node_feats[sender],
+            edge_attrs,
+            tp_weights,
         )  # [n_edges, irreps]
         message = scatter_sum(
-            src=mji, index=receiver, dim=0, dim_size=num_nodes
+            src=mji,
+            index=receiver,
+            dim=0,
+            dim_size=num_nodes,
         )  # [n_nodes, irreps]
         message = self.linear(message) / self.avg_num_neighbors
         message = message + sc
@@ -502,12 +552,17 @@ class RealAgnosticInteractionBlock(InteractionBlock):
         irreps_mid = irreps_mid.simplify()
         self.irreps_out = self.target_irreps
         self.linear = o3.Linear(
-            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+            irreps_mid,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
         )
 
         # Selector TensorProduct
         self.skip_tp = o3.FullyConnectedTensorProduct(
-            self.irreps_out, self.node_attrs_irreps, self.irreps_out
+            self.irreps_out,
+            self.node_attrs_irreps,
+            self.irreps_out,
         )
         self.reshape = reshape_irreps(self.irreps_out)
 
@@ -518,17 +573,22 @@ class RealAgnosticInteractionBlock(InteractionBlock):
         edge_attrs: torch.Tensor,
         edge_feats: torch.Tensor,
         edge_index: torch.Tensor,
-    ) -> Tuple[torch.Tensor, None]:
+    ) -> tuple[torch.Tensor, None]:
         sender = edge_index[0]
         receiver = edge_index[1]
         num_nodes = node_feats.shape[0]
         node_feats = self.linear_up(node_feats)
         tp_weights = self.conv_tp_weights(edge_feats)
         mji = self.conv_tp(
-            node_feats[sender], edge_attrs, tp_weights
+            node_feats[sender],
+            edge_attrs,
+            tp_weights,
         )  # [n_edges, irreps]
         message = scatter_sum(
-            src=mji, index=receiver, dim=0, dim_size=num_nodes
+            src=mji,
+            index=receiver,
+            dim=0,
+            dim_size=num_nodes,
         )  # [n_nodes, irreps]
         message = self.linear(message) / self.avg_num_neighbors
         message = self.skip_tp(message, node_attrs)
@@ -574,12 +634,17 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
         irreps_mid = irreps_mid.simplify()
         self.irreps_out = self.target_irreps
         self.linear = o3.Linear(
-            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+            irreps_mid,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
         )
 
         # Selector TensorProduct
         self.skip_tp = o3.FullyConnectedTensorProduct(
-            self.node_feats_irreps, self.node_attrs_irreps, self.hidden_irreps
+            self.node_feats_irreps,
+            self.node_attrs_irreps,
+            self.hidden_irreps,
         )
         self.reshape = reshape_irreps(self.irreps_out)
 
@@ -590,7 +655,7 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
         edge_attrs: torch.Tensor,
         edge_feats: torch.Tensor,
         edge_index: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         sender = edge_index[0]
         receiver = edge_index[1]
         num_nodes = node_feats.shape[0]
@@ -598,10 +663,15 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
         node_feats = self.linear_up(node_feats)
         tp_weights = self.conv_tp_weights(edge_feats)
         mji = self.conv_tp(
-            node_feats[sender], edge_attrs, tp_weights
+            node_feats[sender],
+            edge_attrs,
+            tp_weights,
         )  # [n_edges, irreps]
         message = scatter_sum(
-            src=mji, index=receiver, dim=0, dim_size=num_nodes
+            src=mji,
+            index=receiver,
+            dim=0,
+            dim_size=num_nodes,
         )  # [n_nodes, irreps]
         message = self.linear(message) / self.avg_num_neighbors
         return (
@@ -615,10 +685,12 @@ class ScaleShiftBlock(torch.nn.Module):
     def __init__(self, scale: float, shift: float):
         super().__init__()
         self.register_buffer(
-            "scale", torch.tensor(scale, dtype=torch.get_default_dtype())
+            "scale",
+            torch.tensor(scale, dtype=torch.get_default_dtype()),
         )
         self.register_buffer(
-            "shift", torch.tensor(shift, dtype=torch.get_default_dtype())
+            "shift",
+            torch.tensor(shift, dtype=torch.get_default_dtype()),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/matsciml/models/pyg/mace/modules/irreps_tools.py
+++ b/matsciml/models/pyg/mace/modules/irreps_tools.py
@@ -4,6 +4,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 from typing import List, Tuple
 
 import torch
@@ -13,12 +15,14 @@ from e3nn.util.jit import compile_mode
 
 # Based on mir-group/nequip
 def tp_out_irreps_with_instructions(
-    irreps1: o3.Irreps, irreps2: o3.Irreps, target_irreps: o3.Irreps
-) -> Tuple[o3.Irreps, List]:
+    irreps1: o3.Irreps,
+    irreps2: o3.Irreps,
+    target_irreps: o3.Irreps,
+) -> tuple[o3.Irreps, list]:
     trainable = True
 
     # Collect possible irreps and their instructions
-    irreps_out_list: List[Tuple[int, o3.Irreps]] = []
+    irreps_out_list: list[tuple[int, o3.Irreps]] = []
     instructions = []
     for i, (mul, ir_in) in enumerate(irreps1):
         for j, (_, ir_edge) in enumerate(irreps2):

--- a/matsciml/models/pyg/mace/modules/irreps_tools.py
+++ b/matsciml/models/pyg/mace/modules/irreps_tools.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
-
 import torch
 from e3nn import o3
 from e3nn.util.jit import compile_mode

--- a/matsciml/models/pyg/mace/modules/models.py
+++ b/matsciml/models/pyg/mace/modules/models.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable
 
 import numpy as np
 import torch
@@ -15,9 +15,9 @@ import torch_geometric as pyg
 from e3nn import o3
 from e3nn.util.jit import compile_mode
 
-from matsciml.common.types import AbstractGraph, BatchDict, DataDict, Embeddings
+from matsciml.common.types import BatchDict, DataDict, Embeddings
 from matsciml.models.base import AbstractPyGModel
-from matsciml.models.pyg.mace import data, modules, tools
+from matsciml.models.pyg.mace import tools
 from matsciml.models.pyg.mace.data import AtomicData, get_neighborhood
 from matsciml.models.pyg.mace.modules.blocks import (
     AtomicEnergiesBlock,
@@ -38,12 +38,7 @@ from matsciml.models.pyg.mace.modules.utils import (
     get_outputs,
     get_symmetric_displacement,
 )
-from matsciml.models.pyg.mace.tools import (
-    AtomicNumberTable,
-    atomic_numbers_to_indices,
-    to_one_hot,
-    voigt_to_matrix,
-)
+from matsciml.models.pyg.mace.tools import atomic_numbers_to_indices, to_one_hot
 from matsciml.models.pyg.mace.tools.scatter import scatter_sum
 
 

--- a/matsciml/models/pyg/mace/modules/models.py
+++ b/matsciml/models/pyg/mace/modules/models.py
@@ -5,6 +5,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 from typing import Any, Callable, Dict, List, Optional, Type
 
 import numpy as np
@@ -13,25 +15,11 @@ import torch_geometric as pyg
 from e3nn import o3
 from e3nn.util.jit import compile_mode
 
-from matsciml.models.pyg.mace.data import AtomicData , get_neighborhood
-from matsciml.models.pyg.mace.tools.scatter import scatter_sum
-
-from matsciml.models.pyg.mace import data, modules, tools
-
-from matsciml.models.pyg.mace.tools import (
-    AtomicNumberTable,
-    atomic_numbers_to_indices,
-    to_one_hot,
-    voigt_to_matrix,
-)
-
-from matsciml.common.types import DataDict, BatchDict , Embeddings
-
-
-from matsciml.common.types import AbstractGraph
+from matsciml.common.types import AbstractGraph, BatchDict, DataDict, Embeddings
 from matsciml.models.base import AbstractPyGModel
-
-from .blocks import (
+from matsciml.models.pyg.mace import data, modules, tools
+from matsciml.models.pyg.mace.data import AtomicData, get_neighborhood
+from matsciml.models.pyg.mace.modules.blocks import (
     AtomicEnergiesBlock,
     EquivariantProductBasisBlock,
     InteractionBlock,
@@ -43,13 +31,20 @@ from .blocks import (
     RadialEmbeddingBlock,
     ScaleShiftBlock,
 )
-from .utils import (
+from matsciml.models.pyg.mace.modules.utils import (
     compute_fixed_charge_dipole,
     compute_forces,
     get_edge_vectors_and_lengths,
     get_outputs,
     get_symmetric_displacement,
 )
+from matsciml.models.pyg.mace.tools import (
+    AtomicNumberTable,
+    atomic_numbers_to_indices,
+    to_one_hot,
+    voigt_to_matrix,
+)
+from matsciml.models.pyg.mace.tools.scatter import scatter_sum
 
 
 @compile_mode("script")
@@ -60,31 +55,34 @@ class MACE(AbstractPyGModel):
         num_bessel: int,
         num_polynomial_cutoff: int,
         max_ell: int,
-        interaction_cls: Type[InteractionBlock],
-        interaction_cls_first: Type[InteractionBlock],
+        interaction_cls: type[InteractionBlock],
+        interaction_cls_first: type[InteractionBlock],
         num_interactions: int,
         num_elements: int,
         hidden_irreps: o3.Irreps,
         MLP_irreps: o3.Irreps,
         atomic_energies: np.ndarray,
         avg_num_neighbors: float,
-        atomic_numbers: List[int],
+        atomic_numbers: list[int],
         correlation: int,
-        gate: Optional[Callable],
+        gate: Callable | None,
     ):
         super().__init__(atom_embedding_dim=16)
         self.register_buffer(
-            "atomic_numbers", torch.tensor(atomic_numbers, dtype=torch.int64)
+            "atomic_numbers",
+            torch.tensor(atomic_numbers, dtype=torch.int64),
         )
         self.register_buffer("r_max", torch.tensor(r_max, dtype=torch.float64))
         self.register_buffer(
-            "num_interactions", torch.tensor(num_interactions, dtype=torch.int64)
+            "num_interactions",
+            torch.tensor(num_interactions, dtype=torch.int64),
         )
         # Embedding
         node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
         node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
         self.node_embedding = LinearNodeEmbeddingBlock(
-            irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
+            irreps_in=node_attr_irreps,
+            irreps_out=node_feats_irreps,
         )
         self.radial_embedding = RadialEmbeddingBlock(
             r_max=r_max,
@@ -97,7 +95,9 @@ class MACE(AbstractPyGModel):
         num_features = hidden_irreps.count(o3.Irrep(0, 1))
         interaction_irreps = (sh_irreps * num_features).sort()[0].simplify()
         self.spherical_harmonics = o3.SphericalHarmonics(
-            sh_irreps, normalize=True, normalization="component"
+            sh_irreps,
+            normalize=True,
+            normalization="component",
         )
 
         # Interactions and readout
@@ -135,7 +135,7 @@ class MACE(AbstractPyGModel):
         for i in range(num_interactions - 1):
             if i == num_interactions - 2:
                 hidden_irreps_out = str(
-                    hidden_irreps[0]
+                    hidden_irreps[0],
                 )  # Select only scalars for last layer
             else:
                 hidden_irreps_out = hidden_irreps
@@ -159,20 +159,20 @@ class MACE(AbstractPyGModel):
             self.products.append(prod)
             if i == num_interactions - 2:
                 self.readouts.append(
-                    NonLinearReadoutBlock(hidden_irreps_out, MLP_irreps, gate)
+                    NonLinearReadoutBlock(hidden_irreps_out, MLP_irreps, gate),
                 )
             else:
                 self.readouts.append(LinearReadoutBlock(hidden_irreps))
 
     def _forward(
         self,
-        data: Dict[str, torch.Tensor],
+        data: dict[str, torch.Tensor],
         training: bool = False,
         compute_force: bool = True,
         compute_virials: bool = False,
         compute_stress: bool = False,
         compute_displacement: bool = False,
-    ) -> Dict[str, Optional[torch.Tensor]]:
+    ) -> dict[str, torch.Tensor | None]:
         # Setup
         data["positions"].requires_grad_(True)
         num_graphs = data["ptr"].numel() - 1
@@ -198,7 +198,10 @@ class MACE(AbstractPyGModel):
         # Atomic energies
         node_e0 = self.atomic_energies_fn(data["node_attrs"])
         e0 = scatter_sum(
-            src=node_e0, index=data["batch"], dim=-1, dim_size=num_graphs
+            src=node_e0,
+            index=data["batch"],
+            dim=-1,
+            dim_size=num_graphs,
         )  # [n_graphs,]
 
         # Embeddings
@@ -215,7 +218,9 @@ class MACE(AbstractPyGModel):
         energies = [e0]
         node_energies_list = [node_e0]
         for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
+            self.interactions,
+            self.products,
+            self.readouts,
         ):
             node_feats, sc = interaction(
                 node_attrs=data["node_attrs"],
@@ -231,7 +236,10 @@ class MACE(AbstractPyGModel):
             )
             node_energies = readout(node_feats).squeeze(-1)  # [n_nodes, ]
             energy = scatter_sum(
-                src=node_energies, index=data["batch"], dim=-1, dim_size=num_graphs
+                src=node_energies,
+                index=data["batch"],
+                dim=-1,
+                dim_size=num_graphs,
             )  # [n_graphs,]
             energies.append(energy)
             node_energies_list.append(node_energies)
@@ -263,38 +271,40 @@ class MACE(AbstractPyGModel):
             "displacement": displacement,
         }
 
+
 @compile_mode("script")
 class ScaleShiftMACE(MACE):
     def __init__(
         self,
         atomic_inter_scale: float,
         atomic_inter_shift: float,
-        training :bool = False,
+        training: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.scale_shift = ScaleShiftBlock(
-            scale=atomic_inter_scale, shift=atomic_inter_shift
+            scale=atomic_inter_scale,
+            shift=atomic_inter_shift,
         )
 
     def _forward(
         self,
-        data: Dict[str, torch.Tensor],
+        data: dict[str, torch.Tensor],
         compute_force: bool = True,
         compute_virials: bool = False,
         compute_stress: bool = False,
         compute_displacement: bool = False,
-    ) -> Dict[str, Optional[torch.Tensor]]:
+    ) -> dict[str, torch.Tensor | None]:
         # Setup
         data["positions"].requires_grad_(True)
-        
+
         num_graphs = data["ptr"].numel() - 1
         displacement = torch.zeros(
             (num_graphs, 3, 3),
             dtype=data["positions"].dtype,
             device=data["positions"].device,
         )
-        
+
         if compute_virials or compute_stress or compute_displacement:
             (
                 data["positions"],
@@ -312,7 +322,10 @@ class ScaleShiftMACE(MACE):
         # Atomic energies
         node_e0 = self.atomic_energies_fn(data["node_attrs"])
         e0 = scatter_sum(
-            src=node_e0, index=data["batch"], dim=-1, dim_size=num_graphs
+            src=node_e0,
+            index=data["batch"],
+            dim=-1,
+            dim_size=num_graphs,
         )  # [n_graphs,]
 
         # Embeddings
@@ -328,7 +341,9 @@ class ScaleShiftMACE(MACE):
         # Interactions
         node_es_list = []
         for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
+            self.interactions,
+            self.products,
+            self.readouts,
         ):
             node_feats, sc = interaction(
                 node_attrs=data["node_attrs"],
@@ -338,19 +353,25 @@ class ScaleShiftMACE(MACE):
                 edge_index=data["edge_index"],
             )
             node_feats = product(
-                node_feats=node_feats, sc=sc, node_attrs=data["node_attrs"]
+                node_feats=node_feats,
+                sc=sc,
+                node_attrs=data["node_attrs"],
             )
             node_es_list.append(readout(node_feats).squeeze(-1))  # {[n_nodes, ], }
 
         # Sum over interactions
         node_inter_es = torch.sum(
-            torch.stack(node_es_list, dim=0), dim=0
+            torch.stack(node_es_list, dim=0),
+            dim=0,
         )  # [n_nodes, ]
         node_inter_es = self.scale_shift(node_inter_es)
 
         # Sum over nodes in graph
         inter_e = scatter_sum(
-            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+            src=node_inter_es,
+            index=data["batch"],
+            dim=-1,
+            dim_size=num_graphs,
         )  # [n_graphs,]
 
         # Add E_0 and (scaled) interaction energy
@@ -374,12 +395,14 @@ class ScaleShiftMACE(MACE):
             # "virials": virials,
             # "stress": stress,
             "displacement": displacement,
-            "node_feats" :node_feats,
-            "edge_feats" :edge_feats
+            "node_feats": node_feats,
+            "edge_feats": edge_feats,
         }
 
-        return Embeddings({'energy':output["energy"].reshape(-1,1),'force':output["forces"]})
-    
+        return Embeddings(
+            {"energy": output["energy"].reshape(-1, 1), "force": output["forces"]},
+        )
+
     def read_batch(self, batch: BatchDict) -> DataDict:
         """
         Extract PyG structure and features to pass into the model.
@@ -392,7 +415,7 @@ class ScaleShiftMACE(MACE):
         batch : BatchDict
             Batch of data to process.
 
-        
+
         Returns
         -------
         DataDict
@@ -401,35 +424,36 @@ class ScaleShiftMACE(MACE):
         assert (
             "graph" in batch
         ), f"Model {self.__class__.__name__} expects graph structures, but 'graph' key was not found in batch."
-        graph = batch.get("graph")    
-        pbc=batch.get('pbc')    
-        data={'cell':batch.get('cell'),'energy':batch.get('energy')}
-        
+        graph = batch.get("graph")
+        pbc = batch.get("pbc")
+        data = {"cell": batch.get("cell"), "energy": batch.get("energy")}
+
         assert isinstance(
-            graph, (pyg.data.Data, pyg.data.Batch)
+            graph,
+            (pyg.data.Data, pyg.data.Batch),
         ), f"Model {self.__class__.__name__} expects PyG graphs, but data in 'graph' key is type {type(graph)}"
-        
-        for key in ["ptr","batch","edge_feats", "graph_feats"]:
+
+        for key in ["ptr", "batch", "edge_feats", "graph_feats"]:
             data[key] = getattr(graph, key, None)
-        
-        data["positions"]=getattr(graph, "pos")
-        data["forces"]=getattr(graph, "force",None)
+
+        data["positions"] = getattr(graph, "pos")
+        data["forces"] = getattr(graph, "force", None)
         # Charges default to 0 instead of None if not found
-        data["charges"] = getattr(batch,"charges", torch.zeros_like(data["batch"]))
-        
-        data["energy_weight"]=torch.ones((data["positions"].shape[0],))
-        data["forces_weight"]=torch.ones((data["positions"].shape[0],))
-                
-        data["stress"]=torch.ones((data["positions"].shape[0],3,3))
-        data["stress_weights"]=torch.ones((data["positions"].shape[0],))
-        
-        data["virials"]=torch.ones((data["positions"].shape[0],3,3))
-        data["virials_weights"]=torch.ones((data["positions"].shape[0],))
-        
-        data["weights"]=torch.ones((data["positions"].shape[0],))
+        data["charges"] = getattr(batch, "charges", torch.zeros_like(data["batch"]))
+
+        data["energy_weight"] = torch.ones((data["positions"].shape[0],))
+        data["forces_weight"] = torch.ones((data["positions"].shape[0],))
+
+        data["stress"] = torch.ones((data["positions"].shape[0], 3, 3))
+        data["stress_weights"] = torch.ones((data["positions"].shape[0],))
+
+        data["virials"] = torch.ones((data["positions"].shape[0], 3, 3))
+        data["virials_weights"] = torch.ones((data["positions"].shape[0],))
+
+        data["weights"] = torch.ones((data["positions"].shape[0],))
 
         atomic_numbers: torch.Tensor = getattr(graph, "atomic_numbers")
-        z_table=tools.get_atomic_number_table_from_zs(atomic_numbers.numpy())
+        z_table = tools.get_atomic_number_table_from_zs(atomic_numbers.numpy())
 
         indices = atomic_numbers_to_indices(atomic_numbers, z_table=z_table)
         data["node_attrs"] = to_one_hot(
@@ -437,24 +461,33 @@ class ScaleShiftMACE(MACE):
             num_classes=len(z_table),
         )
 
-        shifts=[]
-        edge_index=[]
-        unit_shifts=[]
-        b_sz=data["ptr"].numel()-1
-        pos_k=data["positions"].reshape(b_sz,-1,3)
-        cell_k=data["cell"].reshape(b_sz,3,3)
+        shifts = []
+        edge_index = []
+        unit_shifts = []
+        b_sz = data["ptr"].numel() - 1
+        pos_k = data["positions"].reshape(b_sz, -1, 3)
+        cell_k = data["cell"].reshape(b_sz, 3, 3)
         for k in range(b_sz):
-            pbc_tensor=pbc[k]==1
-            pbc_tuple=(pbc_tensor[0].item(),pbc_tensor[1].item(),pbc_tensor[2].item())
-            edge_index_k, shifts_k, unit_shifts_k= get_neighborhood(pos_k[k].numpy(),cutoff=self.r_max.item(),pbc=pbc_tuple, cell=cell_k[k])
-            shifts+=[torch.Tensor(shifts_k)]
-            edge_index+=[ (torch.Tensor(edge_index_k)+83*k).T.to(torch.int64)]
-            unit_shifts+=[torch.Tensor(unit_shifts_k)]
+            pbc_tensor = pbc[k] == 1
+            pbc_tuple = (
+                pbc_tensor[0].item(),
+                pbc_tensor[1].item(),
+                pbc_tensor[2].item(),
+            )
+            edge_index_k, shifts_k, unit_shifts_k = get_neighborhood(
+                pos_k[k].numpy(),
+                cutoff=self.r_max.item(),
+                pbc=pbc_tuple,
+                cell=cell_k[k],
+            )
+            shifts += [torch.Tensor(shifts_k)]
+            edge_index += [(torch.Tensor(edge_index_k) + 83 * k).T.to(torch.int64)]
+            unit_shifts += [torch.Tensor(unit_shifts_k)]
 
-        data["shifts"]=torch.concatenate(shifts)
-        data["unit_shifts"]=torch.concatenate(unit_shifts)
-        data["edge_index"]=torch.concatenate(edge_index).T
-        return {'data':data}
+        data["shifts"] = torch.concatenate(shifts)
+        data["unit_shifts"] = torch.concatenate(unit_shifts)
+        data["edge_index"] = torch.concatenate(edge_index).T
+        return {"data": data}
 
     def read_batch_size(self, batch: BatchDict) -> int:
         graph = batch["graph"]
@@ -471,23 +504,26 @@ class ScaleShiftMACE1(MACE):
     ):
         super().__init__(**kwargs)
         self.scale_shift = ScaleShiftBlock(
-            scale=atomic_inter_scale, shift=atomic_inter_shift
+            scale=atomic_inter_scale,
+            shift=atomic_inter_shift,
         )
 
     def _forward(
         self,
-        data: Dict[str, torch.Tensor],
+        data: dict[str, torch.Tensor],
         training: bool = False,
-    ) -> Dict[str, Optional[torch.Tensor]]:
+    ) -> dict[str, torch.Tensor | None]:
         # Setup
         data["positions"].requires_grad_(True)
         num_graphs = data["ptr"].numel() - 1
-       
 
         # Atomic energies
         node_e0 = self.atomic_energies_fn(data["node_attrs"])
         e0 = scatter_sum(
-            src=node_e0, index=data["batch"], dim=-1, dim_size=num_graphs
+            src=node_e0,
+            index=data["batch"],
+            dim=-1,
+            dim_size=num_graphs,
         )  # [n_graphs,]
 
         # Embeddings
@@ -502,9 +538,11 @@ class ScaleShiftMACE1(MACE):
 
         # Interactions
         node_es_list = []
-        node_feats_list=[]
+        node_feats_list = []
         for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
+            self.interactions,
+            self.products,
+            self.readouts,
         ):
             node_feats, sc = interaction(
                 node_attrs=data["node_attrs"],
@@ -514,27 +552,31 @@ class ScaleShiftMACE1(MACE):
                 edge_index=data["edge_index"],
             )
             node_feats = product(
-                node_feats=node_feats, sc=sc, node_attrs=data["node_attrs"]
+                node_feats=node_feats,
+                sc=sc,
+                node_attrs=data["node_attrs"],
             )
             node_feats_list.append(node_feats)
             node_es_list.append(readout(node_feats).squeeze(-1))  # {[n_nodes, ], }
 
         # Sum over interactions
         node_inter_es = torch.sum(
-            torch.stack(node_es_list, dim=0), dim=0
+            torch.stack(node_es_list, dim=0),
+            dim=0,
         )  # [n_nodes, ]
         node_inter_es = self.scale_shift(node_inter_es)
 
         # Sum over nodes in graph
         inter_e = scatter_sum(
-            src=node_inter_es, index=data["batch"], dim=-1, dim_size=num_graphs
+            src=node_inter_es,
+            index=data["batch"],
+            dim=-1,
+            dim_size=num_graphs,
         )  # [n_graphs,]
 
         # Add E_0 and (scaled) interaction energy
         total_energy = e0 + inter_e
         node_energy = node_e0 + node_inter_es
-
-    
 
         output = {
             "energy": total_energy,
@@ -543,14 +585,12 @@ class ScaleShiftMACE1(MACE):
             # "forces": forces,
             # "virials": virials,
             # "stress": stress,
-            "node_feats_list" :torch.stack(node_feats_list[:-1], dim=0),
-            "edge_feats" :edge_feats
+            "node_feats_list": torch.stack(node_feats_list[:-1], dim=0),
+            "edge_feats": edge_feats,
         }
-        
 
+        return Embeddings(None, output["node_feats_list"])
 
-        return Embeddings(None,output["node_feats_list"])
-    
     def read_batch(self, batch: BatchDict) -> DataDict:
         """
         Extract PyG structure and features to pass into the model.
@@ -563,7 +603,7 @@ class ScaleShiftMACE1(MACE):
         batch : BatchDict
             Batch of data to process.
 
-        
+
         Returns
         -------
         DataDict
@@ -572,35 +612,36 @@ class ScaleShiftMACE1(MACE):
         assert (
             "graph" in batch
         ), f"Model {self.__class__.__name__} expects graph structures, but 'graph' key was not found in batch."
-        graph = batch.get("graph")    
-        pbc=batch.get('pbc')    
-        data={'cell':batch.get('cell'),'energy':batch.get('energy')}
-        
+        graph = batch.get("graph")
+        pbc = batch.get("pbc")
+        data = {"cell": batch.get("cell"), "energy": batch.get("energy")}
+
         assert isinstance(
-            graph, (pyg.data.Data, pyg.data.Batch)
+            graph,
+            (pyg.data.Data, pyg.data.Batch),
         ), f"Model {self.__class__.__name__} expects PyG graphs, but data in 'graph' key is type {type(graph)}"
-        
-        for key in ["ptr","batch","edge_feats", "graph_feats"]:
+
+        for key in ["ptr", "batch", "edge_feats", "graph_feats"]:
             data[key] = getattr(graph, key, None)
-        
-        data["positions"]=getattr(graph, "pos")
-        data["forces"]=getattr(graph, "force",None)
+
+        data["positions"] = getattr(graph, "pos")
+        data["forces"] = getattr(graph, "force", None)
         # Charges default to 0 instead of None if not found
-        data["charges"] = getattr(batch,"charges", torch.zeros_like(data["batch"]))
-        
-        data["energy_weight"]=torch.ones((data["positions"].shape[0],))
-        data["forces_weight"]=torch.ones((data["positions"].shape[0],))
-                
-        data["stress"]=torch.ones((data["positions"].shape[0],3,3))
-        data["stress_weights"]=torch.ones((data["positions"].shape[0],))
-        
-        data["virials"]=torch.ones((data["positions"].shape[0],3,3))
-        data["virials_weights"]=torch.ones((data["positions"].shape[0],))
-        
-        data["weights"]=torch.ones((data["positions"].shape[0],))
+        data["charges"] = getattr(batch, "charges", torch.zeros_like(data["batch"]))
+
+        data["energy_weight"] = torch.ones((data["positions"].shape[0],))
+        data["forces_weight"] = torch.ones((data["positions"].shape[0],))
+
+        data["stress"] = torch.ones((data["positions"].shape[0], 3, 3))
+        data["stress_weights"] = torch.ones((data["positions"].shape[0],))
+
+        data["virials"] = torch.ones((data["positions"].shape[0], 3, 3))
+        data["virials_weights"] = torch.ones((data["positions"].shape[0],))
+
+        data["weights"] = torch.ones((data["positions"].shape[0],))
 
         atomic_numbers: torch.Tensor = getattr(graph, "atomic_numbers")
-        z_table=tools.get_atomic_number_table_from_zs(atomic_numbers.numpy())
+        z_table = tools.get_atomic_number_table_from_zs(atomic_numbers.numpy())
 
         indices = atomic_numbers_to_indices(atomic_numbers, z_table=z_table)
         data["node_attrs"] = to_one_hot(
@@ -608,30 +649,38 @@ class ScaleShiftMACE1(MACE):
             num_classes=len(z_table),
         )
 
-        shifts=[]
-        edge_index=[]
-        unit_shifts=[]
-        b_sz=data["ptr"].numel()-1
-        pos_k=data["positions"].reshape(b_sz,-1,3)
-        cell_k=data["cell"].reshape(b_sz,3,3)
+        shifts = []
+        edge_index = []
+        unit_shifts = []
+        b_sz = data["ptr"].numel() - 1
+        pos_k = data["positions"].reshape(b_sz, -1, 3)
+        cell_k = data["cell"].reshape(b_sz, 3, 3)
         for k in range(b_sz):
-            pbc_tensor=pbc[k]==1
-            pbc_tuple=(pbc_tensor[0].item(),pbc_tensor[1].item(),pbc_tensor[2].item())
-            edge_index_k, shifts_k, unit_shifts_k= get_neighborhood(pos_k[k].numpy(),cutoff=self.r_max.item(),pbc=pbc_tuple, cell=cell_k[k])
-            shifts+=[torch.Tensor(shifts_k)]
-            edge_index+=[ torch.Tensor(edge_index_k).T.to(torch.int64)]
-            unit_shifts+=[torch.Tensor(unit_shifts_k)]
+            pbc_tensor = pbc[k] == 1
+            pbc_tuple = (
+                pbc_tensor[0].item(),
+                pbc_tensor[1].item(),
+                pbc_tensor[2].item(),
+            )
+            edge_index_k, shifts_k, unit_shifts_k = get_neighborhood(
+                pos_k[k].numpy(),
+                cutoff=self.r_max.item(),
+                pbc=pbc_tuple,
+                cell=cell_k[k],
+            )
+            shifts += [torch.Tensor(shifts_k)]
+            edge_index += [torch.Tensor(edge_index_k).T.to(torch.int64)]
+            unit_shifts += [torch.Tensor(unit_shifts_k)]
 
-        data["shifts"]=torch.concatenate(shifts)
-        data["unit_shifts"]=torch.concatenate(unit_shifts)
-        data["edge_index"]=torch.concatenate(edge_index).T
-        
-        return {'data':data}
+        data["shifts"] = torch.concatenate(shifts)
+        data["unit_shifts"] = torch.concatenate(unit_shifts)
+        data["edge_index"] = torch.concatenate(edge_index).T
+
+        return {"data": data}
 
     def read_batch_size(self, batch: BatchDict) -> int:
         graph = batch["graph"]
         return graph.num_graphs
-
 
 
 class BOTNet(torch.nn.Module):
@@ -641,16 +690,16 @@ class BOTNet(torch.nn.Module):
         num_bessel: int,
         num_polynomial_cutoff: int,
         max_ell: int,
-        interaction_cls: Type[InteractionBlock],
-        interaction_cls_first: Type[InteractionBlock],
+        interaction_cls: type[InteractionBlock],
+        interaction_cls_first: type[InteractionBlock],
         num_interactions: int,
         num_elements: int,
         hidden_irreps: o3.Irreps,
         MLP_irreps: o3.Irreps,
         atomic_energies: np.ndarray,
-        gate: Optional[Callable],
+        gate: Callable | None,
         avg_num_neighbors: float,
-        atomic_numbers: List[int],
+        atomic_numbers: list[int],
     ):
         super().__init__()
         self.r_max = r_max
@@ -659,7 +708,8 @@ class BOTNet(torch.nn.Module):
         node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
         node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
         self.node_embedding = LinearNodeEmbeddingBlock(
-            irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
+            irreps_in=node_attr_irreps,
+            irreps_out=node_feats_irreps,
         )
         self.radial_embedding = RadialEmbeddingBlock(
             r_max=r_max,
@@ -670,7 +720,9 @@ class BOTNet(torch.nn.Module):
 
         sh_irreps = o3.Irreps.spherical_harmonics(max_ell)
         self.spherical_harmonics = o3.SphericalHarmonics(
-            sh_irreps, normalize=True, normalization="component"
+            sh_irreps,
+            normalize=True,
+            normalization="component",
         )
 
         # Interactions and readouts
@@ -702,25 +754,30 @@ class BOTNet(torch.nn.Module):
             self.interactions.append(inter)
             if i == num_interactions - 2:
                 self.readouts.append(
-                    NonLinearReadoutBlock(inter.irreps_out, MLP_irreps, gate)
+                    NonLinearReadoutBlock(inter.irreps_out, MLP_irreps, gate),
                 )
             else:
                 self.readouts.append(LinearReadoutBlock(inter.irreps_out))
 
-    def forward(self, data: AtomicData, training=False) -> Dict[str, Any]:
+    def forward(self, data: AtomicData, training=False) -> dict[str, Any]:
         # Setup
         data.positions.requires_grad = True
 
         # Atomic energies
         node_e0 = self.atomic_energies_fn(data.node_attrs)
         e0 = scatter_sum(
-            src=node_e0, index=data.batch, dim=-1, dim_size=data.num_graphs
+            src=node_e0,
+            index=data.batch,
+            dim=-1,
+            dim_size=data.num_graphs,
         )  # [n_graphs,]
 
         # Embeddings
         node_feats = self.node_embedding(data.node_attrs)
         vectors, lengths = get_edge_vectors_and_lengths(
-            positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
+            positions=data.positions,
+            edge_index=data.edge_index,
+            shifts=data.shifts,
         )
         edge_attrs = self.spherical_harmonics(vectors)
         edge_feats = self.radial_embedding(lengths)
@@ -737,7 +794,10 @@ class BOTNet(torch.nn.Module):
             )
             node_energies = readout(node_feats).squeeze(-1)  # [n_nodes, ]
             energy = scatter_sum(
-                src=node_energies, index=data.batch, dim=-1, dim_size=data.num_graphs
+                src=node_energies,
+                index=data.batch,
+                dim=-1,
+                dim_size=data.num_graphs,
             )  # [n_graphs,]
             energies.append(energy)
 
@@ -749,7 +809,9 @@ class BOTNet(torch.nn.Module):
             "energy": total_energy,
             "contributions": contributions,
             "forces": compute_forces(
-                energy=total_energy, positions=data.positions, training=training
+                energy=total_energy,
+                positions=data.positions,
+                training=training,
             ),
         }
 
@@ -765,23 +827,29 @@ class ScaleShiftBOTNet(BOTNet):
     ):
         super().__init__(**kwargs)
         self.scale_shift = ScaleShiftBlock(
-            scale=atomic_inter_scale, shift=atomic_inter_shift
+            scale=atomic_inter_scale,
+            shift=atomic_inter_shift,
         )
 
-    def forward(self, data: AtomicData, training=False) -> Dict[str, Any]:
+    def forward(self, data: AtomicData, training=False) -> dict[str, Any]:
         # Setup
         data.positions.requires_grad = True
 
         # Atomic energies
         node_e0 = self.atomic_energies_fn(data.node_attrs)
         e0 = scatter_sum(
-            src=node_e0, index=data.batch, dim=-1, dim_size=data.num_graphs
+            src=node_e0,
+            index=data.batch,
+            dim=-1,
+            dim_size=data.num_graphs,
         )  # [n_graphs,]
 
         # Embeddings
         node_feats = self.node_embedding(data.node_attrs)
         vectors, lengths = get_edge_vectors_and_lengths(
-            positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
+            positions=data.positions,
+            edge_index=data.edge_index,
+            shifts=data.shifts,
         )
         edge_attrs = self.spherical_harmonics(vectors)
         edge_feats = self.radial_embedding(lengths)
@@ -801,13 +869,17 @@ class ScaleShiftBOTNet(BOTNet):
 
         # Sum over interactions
         node_inter_es = torch.sum(
-            torch.stack(node_es_list, dim=0), dim=0
+            torch.stack(node_es_list, dim=0),
+            dim=0,
         )  # [n_nodes, ]
         node_inter_es = self.scale_shift(node_inter_es)
 
         # Sum over nodes in graph
         inter_e = scatter_sum(
-            src=node_inter_es, index=data.batch, dim=-1, dim_size=data.num_graphs
+            src=node_inter_es,
+            index=data.batch,
+            dim=-1,
+            dim_size=data.num_graphs,
         )  # [n_graphs,]
 
         # Add E_0 and (scaled) interaction energy
@@ -816,7 +888,9 @@ class ScaleShiftBOTNet(BOTNet):
         output = {
             "energy": total_e,
             "forces": compute_forces(
-                energy=inter_e, positions=data.positions, training=training
+                energy=inter_e,
+                positions=data.positions,
+                training=training,
             ),
         }
 
@@ -830,19 +904,18 @@ class AtomicDipolesMACE(torch.nn.Module):
         num_bessel: int,
         num_polynomial_cutoff: int,
         max_ell: int,
-        interaction_cls: Type[InteractionBlock],
-        interaction_cls_first: Type[InteractionBlock],
+        interaction_cls: type[InteractionBlock],
+        interaction_cls_first: type[InteractionBlock],
         num_interactions: int,
         num_elements: int,
         hidden_irreps: o3.Irreps,
         MLP_irreps: o3.Irreps,
         avg_num_neighbors: float,
-        atomic_numbers: List[int],
+        atomic_numbers: list[int],
         correlation: int,
-        gate: Optional[Callable],
-        atomic_energies: Optional[
-            None
-        ],  # Just here to make it compatible with energy models, MUST be None
+        gate: Callable | None,
+        atomic_energies: None
+        | (None),  # Just here to make it compatible with energy models, MUST be None
     ):
         super().__init__()
         assert atomic_energies is None
@@ -853,7 +926,8 @@ class AtomicDipolesMACE(torch.nn.Module):
         node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
         node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
         self.node_embedding = LinearNodeEmbeddingBlock(
-            irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
+            irreps_in=node_attr_irreps,
+            irreps_out=node_feats_irreps,
         )
         self.radial_embedding = RadialEmbeddingBlock(
             r_max=r_max,
@@ -866,7 +940,9 @@ class AtomicDipolesMACE(torch.nn.Module):
         num_features = hidden_irreps.count(o3.Irrep(0, 1))
         interaction_irreps = (sh_irreps * num_features).sort()[0].simplify()
         self.spherical_harmonics = o3.SphericalHarmonics(
-            sh_irreps, normalize=True, normalization="component"
+            sh_irreps,
+            normalize=True,
+            normalization="component",
         )
 
         # Interactions and readouts
@@ -905,7 +981,7 @@ class AtomicDipolesMACE(torch.nn.Module):
                     len(hidden_irreps) > 1
                 ), "To predict dipoles use at least l=1 hidden_irreps"
                 hidden_irreps_out = str(
-                    hidden_irreps[1]
+                    hidden_irreps[1],
                 )  # Select only l=1 vectors for last layer
             else:
                 hidden_irreps_out = hidden_irreps
@@ -930,12 +1006,15 @@ class AtomicDipolesMACE(torch.nn.Module):
             if i == num_interactions - 2:
                 self.readouts.append(
                     NonLinearDipoleReadoutBlock(
-                        hidden_irreps_out, MLP_irreps, gate, dipole_only=True
-                    )
+                        hidden_irreps_out,
+                        MLP_irreps,
+                        gate,
+                        dipole_only=True,
+                    ),
                 )
             else:
                 self.readouts.append(
-                    LinearDipoleReadoutBlock(hidden_irreps, dipole_only=True)
+                    LinearDipoleReadoutBlock(hidden_irreps, dipole_only=True),
                 )
 
     def forward(
@@ -945,7 +1024,7 @@ class AtomicDipolesMACE(torch.nn.Module):
         compute_force: bool = False,
         compute_virials: bool = False,
         compute_stress: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         assert compute_force is False
         assert compute_virials is False
         assert compute_stress is False
@@ -961,7 +1040,9 @@ class AtomicDipolesMACE(torch.nn.Module):
         # Embeddings
         node_feats = self.node_embedding(data.node_attrs)
         vectors, lengths = get_edge_vectors_and_lengths(
-            positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
+            positions=data.positions,
+            edge_index=data.edge_index,
+            shifts=data.shifts,
         )
         edge_attrs = self.spherical_harmonics(vectors)
         edge_feats = self.radial_embedding(lengths)
@@ -969,7 +1050,9 @@ class AtomicDipolesMACE(torch.nn.Module):
         # Interactions
         dipoles = []
         for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
+            self.interactions,
+            self.products,
+            self.readouts,
         ):
             node_feats, sc = interaction(
                 node_attrs=data.node_attrs,
@@ -979,14 +1062,17 @@ class AtomicDipolesMACE(torch.nn.Module):
                 edge_index=data.edge_index,
             )
             node_feats = product(
-                node_feats=node_feats, sc=sc, node_attrs=data.node_attrs
+                node_feats=node_feats,
+                sc=sc,
+                node_attrs=data.node_attrs,
             )
             node_dipoles = readout(node_feats).squeeze(-1)  # [n_nodes,3]
             dipoles.append(node_dipoles)
 
         # Compute the dipoles
         contributions_dipoles = torch.stack(
-            dipoles, dim=-1
+            dipoles,
+            dim=-1,
         )  # [n_nodes,3,n_contributions]
         atomic_dipoles = torch.sum(contributions_dipoles, dim=-1)  # [n_nodes,3]
         total_dipole = scatter_sum(
@@ -1018,17 +1104,17 @@ class EnergyDipolesMACE(torch.nn.Module):
         num_bessel: int,
         num_polynomial_cutoff: int,
         max_ell: int,
-        interaction_cls: Type[InteractionBlock],
-        interaction_cls_first: Type[InteractionBlock],
+        interaction_cls: type[InteractionBlock],
+        interaction_cls_first: type[InteractionBlock],
         num_interactions: int,
         num_elements: int,
         hidden_irreps: o3.Irreps,
         MLP_irreps: o3.Irreps,
         avg_num_neighbors: float,
-        atomic_numbers: List[int],
+        atomic_numbers: list[int],
         correlation: int,
-        gate: Optional[Callable],
-        atomic_energies: Optional[np.ndarray],
+        gate: Callable | None,
+        atomic_energies: np.ndarray | None,
     ):
         super().__init__()
         self.r_max = r_max
@@ -1037,7 +1123,8 @@ class EnergyDipolesMACE(torch.nn.Module):
         node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
         node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
         self.node_embedding = LinearNodeEmbeddingBlock(
-            irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
+            irreps_in=node_attr_irreps,
+            irreps_out=node_feats_irreps,
         )
         self.radial_embedding = RadialEmbeddingBlock(
             r_max=r_max,
@@ -1050,7 +1137,9 @@ class EnergyDipolesMACE(torch.nn.Module):
         num_features = hidden_irreps.count(o3.Irrep(0, 1))
         interaction_irreps = (sh_irreps * num_features).sort()[0].simplify()
         self.spherical_harmonics = o3.SphericalHarmonics(
-            sh_irreps, normalize=True, normalization="component"
+            sh_irreps,
+            normalize=True,
+            normalization="component",
         )
 
         # Interactions and readouts
@@ -1091,7 +1180,7 @@ class EnergyDipolesMACE(torch.nn.Module):
                     len(hidden_irreps) > 1
                 ), "To predict dipoles use at least l=1 hidden_irreps"
                 hidden_irreps_out = str(
-                    hidden_irreps[:2]
+                    hidden_irreps[:2],
                 )  # Select scalars and l=1 vectors for last layer
             else:
                 hidden_irreps_out = hidden_irreps
@@ -1116,12 +1205,15 @@ class EnergyDipolesMACE(torch.nn.Module):
             if i == num_interactions - 2:
                 self.readouts.append(
                     NonLinearDipoleReadoutBlock(
-                        hidden_irreps_out, MLP_irreps, gate, dipole_only=False
-                    )
+                        hidden_irreps_out,
+                        MLP_irreps,
+                        gate,
+                        dipole_only=False,
+                    ),
                 )
             else:
                 self.readouts.append(
-                    LinearDipoleReadoutBlock(hidden_irreps, dipole_only=False)
+                    LinearDipoleReadoutBlock(hidden_irreps, dipole_only=False),
                 )
 
     def forward(
@@ -1131,7 +1223,7 @@ class EnergyDipolesMACE(torch.nn.Module):
         compute_force: bool = True,
         compute_virials: bool = False,
         compute_stress: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         # dipoles and virials / stress not supported simultaneously
         assert compute_virials is False
         assert compute_stress is False
@@ -1147,13 +1239,18 @@ class EnergyDipolesMACE(torch.nn.Module):
         # Atomic energies
         node_e0 = self.atomic_energies_fn(data.node_attrs)
         e0 = scatter_sum(
-            src=node_e0, index=data.batch, dim=-1, dim_size=data.num_graphs
+            src=node_e0,
+            index=data.batch,
+            dim=-1,
+            dim_size=data.num_graphs,
         )  # [n_graphs,]
 
         # Embeddings
         node_feats = self.node_embedding(data.node_attrs)
         vectors, lengths = get_edge_vectors_and_lengths(
-            positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
+            positions=data.positions,
+            edge_index=data.edge_index,
+            shifts=data.shifts,
         )
         edge_attrs = self.spherical_harmonics(vectors)
         edge_feats = self.radial_embedding(lengths)
@@ -1162,7 +1259,9 @@ class EnergyDipolesMACE(torch.nn.Module):
         energies = [e0]
         dipoles = []
         for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
+            self.interactions,
+            self.products,
+            self.readouts,
         ):
             node_feats, sc = interaction(
                 node_attrs=data.node_attrs,
@@ -1172,13 +1271,18 @@ class EnergyDipolesMACE(torch.nn.Module):
                 edge_index=data.edge_index,
             )
             node_feats = product(
-                node_feats=node_feats, sc=sc, node_attrs=data.node_attrs
+                node_feats=node_feats,
+                sc=sc,
+                node_attrs=data.node_attrs,
             )
             node_out = readout(node_feats).squeeze(-1)  # [n_nodes, ]
             # node_energies = readout(node_feats).squeeze(-1)  # [n_nodes, ]
             node_energies = node_out[:, 0]
             energy = scatter_sum(
-                src=node_energies, index=data.batch, dim=-1, dim_size=data.num_graphs
+                src=node_energies,
+                index=data.batch,
+                dim=-1,
+                dim_size=data.num_graphs,
             )  # [n_graphs,]
             energies.append(energy)
             # node_dipoles = readout(node_feats).squeeze(-1)  # [n_nodes,3]
@@ -1189,7 +1293,8 @@ class EnergyDipolesMACE(torch.nn.Module):
         contributions = torch.stack(energies, dim=-1)
         total_energy = torch.sum(contributions, dim=-1)  # [n_graphs, ]
         contributions_dipoles = torch.stack(
-            dipoles, dim=-1
+            dipoles,
+            dim=-1,
         )  # [n_nodes,3,n_contributions]
         atomic_dipoles = torch.sum(contributions_dipoles, dim=-1)  # [n_nodes,3]
         total_dipole = scatter_sum(

--- a/matsciml/models/pyg/mace/modules/radial.py
+++ b/matsciml/models/pyg/mace/modules/radial.py
@@ -4,6 +4,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 import numpy as np
 import torch
 from e3nn.util.jit import compile_mode
@@ -35,7 +37,8 @@ class BesselBasis(torch.nn.Module):
             self.register_buffer("bessel_weights", bessel_weights)
 
         self.register_buffer(
-            "r_max", torch.tensor(r_max, dtype=torch.get_default_dtype())
+            "r_max",
+            torch.tensor(r_max, dtype=torch.get_default_dtype()),
         )
         self.register_buffer(
             "prefactor",
@@ -67,7 +70,8 @@ class PolynomialCutoff(torch.nn.Module):
         super().__init__()
         self.register_buffer("p", torch.tensor(p, dtype=torch.get_default_dtype()))
         self.register_buffer(
-            "r_max", torch.tensor(r_max, dtype=torch.get_default_dtype())
+            "r_max",
+            torch.tensor(r_max, dtype=torch.get_default_dtype()),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/matsciml/models/pyg/mace/modules/symmetric_contraction.py
+++ b/matsciml/models/pyg/mace/modules/symmetric_contraction.py
@@ -7,8 +7,6 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Union
-
 import opt_einsum_fx
 import torch
 import torch.fx

--- a/matsciml/models/pyg/mace/modules/symmetric_contraction.py
+++ b/matsciml/models/pyg/mace/modules/symmetric_contraction.py
@@ -5,6 +5,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 from typing import Dict, Optional, Union
 
 import opt_einsum_fx
@@ -26,12 +28,12 @@ class SymmetricContraction(CodeGenMixin, torch.nn.Module):
         self,
         irreps_in: o3.Irreps,
         irreps_out: o3.Irreps,
-        correlation: Union[int, Dict[str, int]],
+        correlation: int | dict[str, int],
         irrep_normalization: str = "component",
         path_normalization: str = "element",
-        internal_weights: Optional[bool] = None,
-        shared_weights: Optional[bool] = None,
-        num_elements: Optional[int] = None,
+        internal_weights: bool | None = None,
+        shared_weights: bool | None = None,
+        num_elements: int | None = None,
     ) -> None:
         super().__init__()
 
@@ -75,7 +77,7 @@ class SymmetricContraction(CodeGenMixin, torch.nn.Module):
                     internal_weights=self.internal_weights,
                     num_elements=num_elements,
                     weights=self.shared_weights,
-                )
+                ),
             )
 
     def forward(self, x: torch.Tensor, y: torch.Tensor):
@@ -91,8 +93,8 @@ class Contraction(torch.nn.Module):
         irrep_out: o3.Irreps,
         correlation: int,
         internal_weights: bool = True,
-        num_elements: Optional[int] = None,
-        weights: Optional[torch.Tensor] = None,
+        num_elements: int | None = None,
+        weights: torch.Tensor | None = None,
     ) -> None:
         super().__init__()
 
@@ -130,8 +132,12 @@ class Contraction(torch.nn.Module):
                 )
                 graph_module_main = torch.fx.symbolic_trace(
                     lambda x, y, w, z: torch.einsum(
-                        "".join(parse_subscript_main), x, y, w, z
-                    )
+                        "".join(parse_subscript_main),
+                        x,
+                        y,
+                        w,
+                        z,
+                    ),
                 )
 
                 # Optimizing the contractions
@@ -139,7 +145,7 @@ class Contraction(torch.nn.Module):
                     model=graph_module_main,
                     example_inputs=(
                         torch.randn(
-                            [num_equivariance] + [num_ell] * i + [num_params]
+                            [num_equivariance] + [num_ell] * i + [num_params],
                         ).squeeze(0),
                         torch.randn((num_elements, num_params, self.num_features)),
                         torch.randn((BATCH_EXAMPLE, self.num_features, num_ell)),
@@ -149,7 +155,7 @@ class Contraction(torch.nn.Module):
                 # Parameters for the product basis
                 w = torch.nn.Parameter(
                     torch.randn((num_elements, num_params, self.num_features))
-                    / num_params
+                    / num_params,
                 )
                 self.weights_max = w
             else:
@@ -169,11 +175,14 @@ class Contraction(torch.nn.Module):
                 # Symbolic tracing of contractions
                 graph_module_weighting = torch.fx.symbolic_trace(
                     lambda x, y, z: torch.einsum(
-                        "".join(parse_subscript_weighting), x, y, z
-                    )
+                        "".join(parse_subscript_weighting),
+                        x,
+                        y,
+                        z,
+                    ),
                 )
                 graph_module_features = torch.fx.symbolic_trace(
-                    lambda x, y: torch.einsum("".join(parse_subscript_features), x, y)
+                    lambda x, y: torch.einsum("".join(parse_subscript_features), x, y),
                 )
 
                 # Optimizing the contractions
@@ -181,7 +190,7 @@ class Contraction(torch.nn.Module):
                     model=graph_module_weighting,
                     example_inputs=(
                         torch.randn(
-                            [num_equivariance] + [num_ell] * i + [num_params]
+                            [num_equivariance] + [num_ell] * i + [num_params],
                         ).squeeze(0),
                         torch.randn((num_elements, num_params, self.num_features)),
                         torch.randn((BATCH_EXAMPLE, num_elements)),
@@ -192,7 +201,7 @@ class Contraction(torch.nn.Module):
                     example_inputs=(
                         torch.randn(
                             [BATCH_EXAMPLE, self.num_features, num_equivariance]
-                            + [num_ell] * i
+                            + [num_ell] * i,
                         ).squeeze(2),
                         torch.randn((BATCH_EXAMPLE, self.num_features, num_ell)),
                     ),
@@ -202,7 +211,7 @@ class Contraction(torch.nn.Module):
                 # Parameters for the product basis
                 w = torch.nn.Parameter(
                     torch.randn((num_elements, num_params, self.num_features))
-                    / num_params
+                    / num_params,
                 )
                 self.weights.append(w)
         if not internal_weights:
@@ -217,7 +226,7 @@ class Contraction(torch.nn.Module):
             y,
         )
         for i, (weight, contract_weights, contract_features) in enumerate(
-            zip(self.weights, self.contractions_weighting, self.contractions_features)
+            zip(self.weights, self.contractions_weighting, self.contractions_features),
         ):
             c_tensor = contract_weights(
                 self.U_tensors(self.correlation - i - 1),

--- a/matsciml/models/pyg/mace/modules/utils.py
+++ b/matsciml/models/pyg/mace/modules/utils.py
@@ -4,6 +4,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -12,16 +14,17 @@ import torch.nn
 import torch.utils.data
 from scipy.constants import c, e
 
+from matsciml.models.pyg.mace.modules.blocks import AtomicEnergiesBlock
 from matsciml.models.pyg.mace.tools import to_numpy
 from matsciml.models.pyg.mace.tools.scatter import scatter_sum
 
-from .blocks import AtomicEnergiesBlock
-
 
 def compute_forces(
-    energy: torch.Tensor, positions: torch.Tensor, training: bool = True
+    energy: torch.Tensor,
+    positions: torch.Tensor,
+    training: bool = True,
 ) -> torch.Tensor:
-    grad_outputs: List[Optional[torch.Tensor]] = [torch.ones_like(energy)]
+    grad_outputs: list[torch.Tensor | None] = [torch.ones_like(energy)]
     gradient = torch.autograd.grad(
         outputs=[energy],  # [n_graphs, ]
         inputs=[positions],  # [n_nodes, 3]
@@ -44,8 +47,8 @@ def compute_forces_virials(
     cell: torch.Tensor,
     training: bool = True,
     compute_stress: bool = False,
-) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
-    grad_outputs: List[Optional[torch.Tensor]] = [torch.ones_like(energy)]
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    grad_outputs: list[torch.Tensor | None] = [torch.ones_like(energy)]
     forces, virials = torch.autograd.grad(
         outputs=[energy],  # [n_graphs, ]
         inputs=[positions, displacement],  # [n_nodes, 3]
@@ -74,11 +77,11 @@ def compute_forces_virials(
 def get_symmetric_displacement(
     positions: torch.Tensor,
     unit_shifts: torch.Tensor,
-    cell: Optional[torch.Tensor],
+    cell: torch.Tensor | None,
     edge_index: torch.Tensor,
     num_graphs: int,
     batch: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if cell is None:
         cell = torch.zeros(
             num_graphs * 3,
@@ -97,7 +100,9 @@ def get_symmetric_displacement(
         displacement + displacement.transpose(-1, -2)
     )  # From https://github.com/mir-group/nequip
     positions = positions + torch.einsum(
-        "be,bec->bc", positions, symmetric_displacement[batch]
+        "be,bec->bc",
+        positions,
+        symmetric_displacement[batch],
     )
     cell = cell.view(-1, 3, 3)
     cell = cell + torch.matmul(cell, symmetric_displacement)
@@ -112,13 +117,13 @@ def get_symmetric_displacement(
 def get_outputs(
     energy: torch.Tensor,
     positions: torch.Tensor,
-    displacement: Optional[torch.Tensor],
+    displacement: torch.Tensor | None,
     cell: torch.Tensor,
     training: bool = False,
     compute_force: bool = True,
     compute_virials: bool = True,
     compute_stress: bool = True,
-) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
     if (compute_virials or compute_stress) and displacement is not None:
         # forces come for free
         forces, virials, stress = compute_forces_virials(
@@ -146,7 +151,7 @@ def get_edge_vectors_and_lengths(
     shifts: torch.Tensor,  # [n_edges, 3]
     normalize: bool = False,
     eps: float = 1e-9,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     sender = edge_index[0]
     receiver = edge_index[1]
     vectors = positions[receiver] - positions[sender] + shifts  # [n_edges, 3]
@@ -161,7 +166,7 @@ def get_edge_vectors_and_lengths(
 def compute_mean_std_atomic_inter_energy(
     data_loader: torch.utils.data.DataLoader,
     atomic_energies: np.ndarray,
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     atomic_energies_fn = AtomicEnergiesBlock(atomic_energies=atomic_energies)
 
     avg_atom_inter_es_list = []
@@ -169,11 +174,14 @@ def compute_mean_std_atomic_inter_energy(
     for batch in data_loader:
         node_e0 = atomic_energies_fn(batch.node_attrs)
         graph_e0s = scatter_sum(
-            src=node_e0, index=batch.batch, dim=-1, dim_size=batch.num_graphs
+            src=node_e0,
+            index=batch.batch,
+            dim=-1,
+            dim_size=batch.num_graphs,
         )
         graph_sizes = batch.ptr[1:] - batch.ptr[:-1]
         avg_atom_inter_es_list.append(
-            (batch.energy - graph_e0s) / graph_sizes
+            (batch.energy - graph_e0s) / graph_sizes,
         )  # {[n_graphs], }
 
     avg_atom_inter_es = torch.cat(avg_atom_inter_es_list)  # [total_n_graphs]
@@ -186,7 +194,7 @@ def compute_mean_std_atomic_inter_energy(
 def compute_mean_rms_energy_forces(
     data_loader: torch.utils.data.DataLoader,
     atomic_energies: np.ndarray,
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     atomic_energies_fn = AtomicEnergiesBlock(atomic_energies=atomic_energies)
 
     atom_energy_list = []
@@ -195,11 +203,14 @@ def compute_mean_rms_energy_forces(
     for batch in data_loader:
         node_e0 = atomic_energies_fn(batch.node_attrs)
         graph_e0s = scatter_sum(
-            src=node_e0, index=batch.batch, dim=-1, dim_size=batch.num_graphs
+            src=node_e0,
+            index=batch.batch,
+            dim=-1,
+            dim_size=batch.num_graphs,
         )
         graph_sizes = batch.ptr[1:] - batch.ptr[:-1]
         atom_energy_list.append(
-            (batch.energy - graph_e0s) / graph_sizes
+            (batch.energy - graph_e0s) / graph_sizes,
         )  # {[n_graphs], }
         forces_list.append(batch.forces)  # {[n_graphs*n_atoms,3], }
 
@@ -221,14 +232,14 @@ def compute_avg_num_neighbors(data_loader: torch.utils.data.DataLoader) -> float
         num_neighbors.append(counts)
 
     avg_num_neighbors = torch.mean(
-        torch.cat(num_neighbors, dim=0).type(torch.get_default_dtype())
+        torch.cat(num_neighbors, dim=0).type(torch.get_default_dtype()),
     )
     return to_numpy(avg_num_neighbors).item()
 
 
 def compute_rms_dipoles(
     data_loader: torch.utils.data.DataLoader,
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     dipoles_list = []
     for batch in data_loader:
         dipoles_list.append(batch.dipole)  # {[n_graphs,3], }
@@ -246,5 +257,8 @@ def compute_fixed_charge_dipole(
 ) -> torch.Tensor:
     mu = positions * charges.unsqueeze(-1) / (1e-11 / c / e)  # [N_atoms,3]
     return scatter_sum(
-        src=mu, index=batch.unsqueeze(-1), dim=0, dim_size=num_graphs
+        src=mu,
+        index=batch.unsqueeze(-1),
+        dim=0,
+        dim_size=num_graphs,
     )  # [N_graphs,3]

--- a/matsciml/models/pyg/mace/modules/utils.py
+++ b/matsciml/models/pyg/mace/modules/utils.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
-
 import numpy as np
 import torch
 import torch.nn

--- a/matsciml/models/pyg/mace/tools/__init__.py
+++ b/matsciml/models/pyg/mace/tools/__init__.py
@@ -7,10 +7,15 @@
 ###########################################################################################
 
 
+from __future__ import annotations
 
-from .cg import U_matrix_real
-from .checkpoint import CheckpointHandler, CheckpointIO, CheckpointState
-from .torch_tools import (
+from matsciml.models.pyg.mace.tools.cg import U_matrix_real
+from matsciml.models.pyg.mace.tools.checkpoint import (
+    CheckpointHandler,
+    CheckpointIO,
+    CheckpointState,
+)
+from matsciml.models.pyg.mace.tools.torch_tools import (
     TensorDict,
     cartesian_to_spherical,
     count_parameters,
@@ -23,7 +28,7 @@ from .torch_tools import (
     to_one_hot,
     voigt_to_matrix,
 )
-from .utils import (
+from matsciml.models.pyg.mace.tools.utils import (
     AtomicNumberTable,
     MetricsLogger,
     atomic_numbers_to_indices,

--- a/matsciml/models/pyg/mace/tools/cg.py
+++ b/matsciml/models/pyg/mace/tools/cg.py
@@ -4,6 +4,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 import collections
 from typing import List, Union
 
@@ -15,7 +17,7 @@ _INPUT = collections.namedtuple("_INPUT", "tensor, start, stop")
 
 
 def _wigner_nj(
-    irrepss: List[o3.Irreps],
+    irrepss: list[o3.Irreps],
     normalization: str = "component",
     filter_ir_mid=None,
     dtype=None,
@@ -58,7 +60,9 @@ def _wigner_nj(
 
                 C = torch.einsum("jk,ijl->ikl", C_left.flatten(1), C)
                 C = C.reshape(
-                    ir_out.dim, *(irreps.dim for irreps in irrepss_left), ir.dim
+                    ir_out.dim,
+                    *(irreps.dim for irreps in irrepss_left),
+                    ir.dim,
                 )
                 for u in range(mul):
                     E = torch.zeros(
@@ -80,15 +84,15 @@ def _wigner_nj(
                                 ),
                             ),
                             E,
-                        )
+                        ),
                     ]
             i += mul * ir.dim
     return sorted(ret, key=lambda x: x[0])
 
 
 def U_matrix_real(
-    irreps_in: Union[str, o3.Irreps],
-    irreps_out: Union[str, o3.Irreps],
+    irreps_in: str | o3.Irreps,
+    irreps_out: str | o3.Irreps,
     correlation: int,
     normalization: str = "component",
     filter_ir_mid=None,

--- a/matsciml/models/pyg/mace/tools/cg.py
+++ b/matsciml/models/pyg/mace/tools/cg.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import collections
-from typing import List, Union
 
 import torch
 from e3nn import o3

--- a/matsciml/models/pyg/mace/tools/checkpoint.py
+++ b/matsciml/models/pyg/mace/tools/checkpoint.py
@@ -4,6 +4,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 import dataclasses
 import logging
 import os
@@ -12,9 +14,9 @@ from typing import Dict, List, Optional, Tuple
 
 import torch
 
-from .torch_tools import TensorDict
+from matsciml.models.pyg.mace.tools.torch_tools import TensorDict
 
-Checkpoint = Dict[str, TensorDict]
+Checkpoint = dict[str, TensorDict]
 
 
 @dataclasses.dataclass
@@ -35,7 +37,9 @@ class CheckpointBuilder:
 
     @staticmethod
     def load_checkpoint(
-        state: CheckpointState, checkpoint: Checkpoint, strict: bool
+        state: CheckpointState,
+        checkpoint: Checkpoint,
+        strict: bool,
     ) -> None:
         state.model.load_state_dict(checkpoint["model"], strict=strict)  # type: ignore
         state.optimizer.load_state_dict(checkpoint["optimizer"])
@@ -52,12 +56,16 @@ class CheckpointPathInfo:
 
 class CheckpointIO:
     def __init__(
-        self, directory: str, tag: str, keep: bool = False, swa_start: int = None
+        self,
+        directory: str,
+        tag: str,
+        keep: bool = False,
+        swa_start: int = None,
     ) -> None:
         self.directory = directory
         self.tag = tag
         self.keep = keep
-        self.old_path: Optional[str] = None
+        self.old_path: str | None = None
         self.swa_start = swa_start
 
         self._epochs_string = "_epoch-"
@@ -81,7 +89,7 @@ class CheckpointIO:
             + self._filename_extension
         )
 
-    def _list_file_paths(self) -> List[str]:
+    def _list_file_paths(self) -> list[str]:
         if not os.path.isdir(self.directory):
             return []
         all_paths = [
@@ -89,13 +97,13 @@ class CheckpointIO:
         ]
         return [path for path in all_paths if os.path.isfile(path)]
 
-    def _parse_checkpoint_path(self, path: str) -> Optional[CheckpointPathInfo]:
+    def _parse_checkpoint_path(self, path: str) -> CheckpointPathInfo | None:
         filename = os.path.basename(path)
         regex = re.compile(
-            rf"^(?P<tag>.+){self._epochs_string}(?P<epochs>\d+)\.{self._filename_extension}$"
+            rf"^(?P<tag>.+){self._epochs_string}(?P<epochs>\d+)\.{self._filename_extension}$",
         )
         regex2 = re.compile(
-            rf"^(?P<tag>.+){self._epochs_string}(?P<epochs>\d+)_swa\.{self._filename_extension}$"
+            rf"^(?P<tag>.+){self._epochs_string}(?P<epochs>\d+)_swa\.{self._filename_extension}$",
         )
         match = regex.match(filename)
         match2 = regex2.match(filename)
@@ -113,7 +121,7 @@ class CheckpointIO:
             swa=swa,
         )
 
-    def _get_latest_checkpoint_path(self, swa) -> Optional[str]:
+    def _get_latest_checkpoint_path(self, swa) -> str | None:
         all_file_paths = self._list_file_paths()
         checkpoint_info_list = [
             self._parse_checkpoint_path(path) for path in all_file_paths
@@ -124,7 +132,7 @@ class CheckpointIO:
 
         if len(selected_checkpoint_info_list) == 0:
             logging.warning(
-                f"Cannot find checkpoint with tag '{self.tag}' in '{self.directory}'"
+                f"Cannot find checkpoint with tag '{self.tag}' in '{self.directory}'",
             )
             return None
 
@@ -138,16 +146,21 @@ class CheckpointIO:
                 selected_checkpoint_info_list_no_swa.append(ckp)
         if swa:
             latest_checkpoint_info = max(
-                selected_checkpoint_info_list_swa, key=lambda info: info.epochs
+                selected_checkpoint_info_list_swa,
+                key=lambda info: info.epochs,
             )
         else:
             latest_checkpoint_info = max(
-                selected_checkpoint_info_list_no_swa, key=lambda info: info.epochs
+                selected_checkpoint_info_list_no_swa,
+                key=lambda info: info.epochs,
             )
         return latest_checkpoint_info.path
 
     def save(
-        self, checkpoint: Checkpoint, epochs: int, keep_last: bool = False
+        self,
+        checkpoint: Checkpoint,
+        epochs: int,
+        keep_last: bool = False,
     ) -> None:
         if not self.keep and self.old_path and not keep_last:
             logging.debug(f"Deleting old checkpoint file: {self.old_path}")
@@ -161,8 +174,10 @@ class CheckpointIO:
         self.old_path = path
 
     def load_latest(
-        self, swa: Optional[bool] = False, device: Optional[torch.device] = None
-    ) -> Optional[Tuple[Checkpoint, int]]:
+        self,
+        swa: bool | None = False,
+        device: torch.device | None = None,
+    ) -> tuple[Checkpoint, int] | None:
         path = self._get_latest_checkpoint_path(swa=swa)
         if path is None:
             return None
@@ -170,8 +185,10 @@ class CheckpointIO:
         return self.load(path, device=device)
 
     def load(
-        self, path: str, device: Optional[torch.device] = None
-    ) -> Tuple[Checkpoint, int]:
+        self,
+        path: str,
+        device: torch.device | None = None,
+    ) -> tuple[Checkpoint, int]:
         checkpoint_info = self._parse_checkpoint_path(path)
 
         if checkpoint_info is None:
@@ -190,7 +207,10 @@ class CheckpointHandler:
         self.builder = CheckpointBuilder()
 
     def save(
-        self, state: CheckpointState, epochs: int, keep_last: bool = False
+        self,
+        state: CheckpointState,
+        epochs: int,
+        keep_last: bool = False,
     ) -> None:
         checkpoint = self.builder.create_checkpoint(state)
         self.io.save(checkpoint, epochs, keep_last)
@@ -198,10 +218,10 @@ class CheckpointHandler:
     def load_latest(
         self,
         state: CheckpointState,
-        swa: Optional[bool] = False,
-        device: Optional[torch.device] = None,
+        swa: bool | None = False,
+        device: torch.device | None = None,
         strict=False,
-    ) -> Optional[int]:
+    ) -> int | None:
         result = self.io.load_latest(swa=swa, device=device)
         if result is None:
             return None
@@ -215,7 +235,7 @@ class CheckpointHandler:
         state: CheckpointState,
         path: str,
         strict=False,
-        device: Optional[torch.device] = None,
+        device: torch.device | None = None,
     ) -> int:
         checkpoint, epochs = self.io.load(path, device=device)
         self.builder.load_checkpoint(state=state, checkpoint=checkpoint, strict=strict)

--- a/matsciml/models/pyg/mace/tools/checkpoint.py
+++ b/matsciml/models/pyg/mace/tools/checkpoint.py
@@ -10,7 +10,6 @@ import dataclasses
 import logging
 import os
 import re
-from typing import Dict, List, Optional, Tuple
 
 import torch
 

--- a/matsciml/models/pyg/mace/tools/scatter.py
+++ b/matsciml/models/pyg/mace/tools/scatter.py
@@ -14,6 +14,8 @@ that don't require installing PyTorch C++ extensions.
 See https://github.com/pytorch/pytorch/issues/63780.
 """
 
+from __future__ import annotations
+
 from typing import Optional
 
 import torch
@@ -36,8 +38,8 @@ def scatter_sum(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: Optional[torch.Tensor] = None,
-    dim_size: Optional[int] = None,
+    out: torch.Tensor | None = None,
+    dim_size: int | None = None,
     reduce: str = "sum",
 ) -> torch.Tensor:
     assert reduce == "sum"  # for now, TODO
@@ -61,8 +63,8 @@ def scatter_std(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: Optional[torch.Tensor] = None,
-    dim_size: Optional[int] = None,
+    out: torch.Tensor | None = None,
+    dim_size: int | None = None,
     unbiased: bool = True,
 ) -> torch.Tensor:
     if out is not None:
@@ -99,8 +101,8 @@ def scatter_mean(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: Optional[torch.Tensor] = None,
-    dim_size: Optional[int] = None,
+    out: torch.Tensor | None = None,
+    dim_size: int | None = None,
 ) -> torch.Tensor:
     out = scatter_sum(src, index, dim, out, dim_size)
     dim_size = out.size(dim)

--- a/matsciml/models/pyg/mace/tools/scatter.py
+++ b/matsciml/models/pyg/mace/tools/scatter.py
@@ -16,8 +16,6 @@ See https://github.com/pytorch/pytorch/issues/63780.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import torch
 
 

--- a/matsciml/models/pyg/mace/tools/torch_tools.py
+++ b/matsciml/models/pyg/mace/tools/torch_tools.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict
 
 import numpy as np
 import torch

--- a/matsciml/models/pyg/mace/tools/torch_tools.py
+++ b/matsciml/models/pyg/mace/tools/torch_tools.py
@@ -4,6 +4,8 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 import logging
 from typing import Dict
 
@@ -11,7 +13,7 @@ import numpy as np
 import torch
 from e3nn.io import CartesianTensor
 
-TensorDict = Dict[str, torch.Tensor]
+TensorDict = dict[str, torch.Tensor]
 
 
 def to_one_hot(indices: torch.Tensor, num_classes: int) -> torch.Tensor:
@@ -52,7 +54,7 @@ def init_device(device_str: str) -> torch.device:
     if device_str == "cuda":
         assert torch.cuda.is_available(), "No CUDA device available!"
         logging.info(
-            f"CUDA version: {torch.version.cuda}, CUDA device: {torch.cuda.current_device()}"
+            f"CUDA version: {torch.version.cuda}, CUDA device: {torch.cuda.current_device()}",
         )
         torch.cuda.init()
         return torch.device("cuda")
@@ -111,7 +113,8 @@ def voigt_to_matrix(t: torch.Tensor):
         return t
 
     return torch.tensor(
-        [[t[0], t[5], t[4]], [t[5], t[1], t[3]], [t[4], t[3], t[2]]], dtype=t.dtype
+        [[t[0], t[5], t[4]], [t[5], t[1], t[3]], [t[4], t[3], t[2]]],
+        dtype=t.dtype,
     )
 
 

--- a/matsciml/models/pyg/mace/tools/utils.py
+++ b/matsciml/models/pyg/mace/tools/utils.py
@@ -11,7 +11,7 @@ import logging
 import os
 import sys
 from collections.abc import Iterable, Sequence
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 import numpy as np
 import torch

--- a/matsciml/models/pyg/mace/tools/utils.py
+++ b/matsciml/models/pyg/mace/tools/utils.py
@@ -4,16 +4,19 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 import json
 import logging
 import os
 import sys
-from typing import Any, Dict, Iterable, Optional, Sequence, Union
+from collections.abc import Iterable, Sequence
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 import torch
 
-from .torch_tools import to_numpy
+from matsciml.models.pyg.mace.tools.torch_tools import to_numpy
 
 
 def compute_mae(delta: np.ndarray) -> float:
@@ -47,9 +50,9 @@ def get_tag(name: str, seed: int) -> str:
 
 
 def setup_logger(
-    level: Union[int, str] = logging.INFO,
-    tag: Optional[str] = None,
-    directory: Optional[str] = None,
+    level: int | str = logging.INFO,
+    tag: str | None = None,
+    directory: str | None = None,
 ):
     logger = logging.getLogger()
     logger.setLevel(level)
@@ -97,7 +100,8 @@ def get_atomic_number_table_from_zs(zs: Iterable[int]) -> AtomicNumberTable:
 
 
 def atomic_numbers_to_indices(
-    atomic_numbers: np.ndarray, z_table: AtomicNumberTable
+    atomic_numbers: np.ndarray,
+    z_table: AtomicNumberTable,
 ) -> np.ndarray:
     to_index_fn = np.vectorize(z_table.z_to_index)
     return to_index_fn(atomic_numbers)
@@ -112,12 +116,18 @@ def get_optimizer(
 ) -> torch.optim.Optimizer:
     if name == "adam":
         return torch.optim.Adam(
-            parameters, lr=learning_rate, amsgrad=amsgrad, weight_decay=weight_decay
+            parameters,
+            lr=learning_rate,
+            amsgrad=amsgrad,
+            weight_decay=weight_decay,
         )
 
     if name == "adamw":
         return torch.optim.AdamW(
-            parameters, lr=learning_rate, amsgrad=amsgrad, weight_decay=weight_decay
+            parameters,
+            lr=learning_rate,
+            amsgrad=amsgrad,
+            weight_decay=weight_decay,
         )
 
     raise RuntimeError(f"Unknown optimizer '{name}'")
@@ -142,7 +152,7 @@ class MetricsLogger:
         self.filename = tag + ".txt"
         self.path = os.path.join(self.directory, self.filename)
 
-    def log(self, d: Dict[str, Any]) -> None:
+    def log(self, d: dict[str, Any]) -> None:
         logging.debug(f"Saving info: {self.path}")
         os.makedirs(name=self.directory, exist_ok=True)
         with open(self.path, mode="a", encoding="utf-8") as f:


### PR DESCRIPTION
This PR closes #116. 

I have not tested for functionality since I know @melo-gonzo has been having some issues, but I've significantly limited the scope of the work to more or less purely code maintenance. A summary:

- `pre-commit` hooks (lint, `black`, and `pyupgrade`) on all submodules of `matsciml.models.pyg.mace`
- Adding `MACE` and `ScaleShiftMACE` to `matsciml.models.pyg` namespace in a consistent manner
- Removed unused imports and superceded type hints