### PR TITLE
Replacing union type hints with `Optional` in MACE

### DIFF
--- a/matsciml/models/pyg/mace/tools/scatter.py
+++ b/matsciml/models/pyg/mace/tools/scatter.py
@@ -16,6 +16,8 @@ See https://github.com/pytorch/pytorch/issues/63780.
 
 from __future__ import annotations
 
+from typing import Optional
+
 import torch
 
 
@@ -36,8 +38,8 @@ def scatter_sum(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: torch.Tensor | None = None,
-    dim_size: int | None = None,
+    out: Optional[torch.Tensor] = None,
+    dim_size: Optional[int] = None,
     reduce: str = "sum",
 ) -> torch.Tensor:
     assert reduce == "sum"  # for now, TODO
@@ -61,8 +63,8 @@ def scatter_std(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: torch.Tensor | None = None,
-    dim_size: int | None = None,
+    out: Optional[torch.Tensor] = None,
+    dim_size: Optional[int] = None,
     unbiased: bool = True,
 ) -> torch.Tensor:
     if out is not None:
@@ -99,8 +101,8 @@ def scatter_mean(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: torch.Tensor | None = None,
-    dim_size: int | None = None,
+    out: Optional[torch.Tensor] = None,
+    dim_size: Optional[int] = None,
 ) -> torch.Tensor:
     out = scatter_sum(src, index, dim, out, dim_size)
     dim_size = out.size(dim)


### PR DESCRIPTION
This PR closes #123 by reinstating `Optional` as type hints for MACE, as opposed to the Python 3.10 `|` unions that fail to be JIT compiled.

If and when we move to a PyTorch version  with JIT that supports Python 3.10 unions we can probably revert this change back, but until then this ensures the model will run.