### PR TITLE
Upgrade matgl to 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ logs
 *.traj
 experimental
 lightning_logs
+msl-1.1.0
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ logs
 *.traj
 experimental
 lightning_logs
-msl-1.1.0
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -21,14 +21,14 @@ task = ScalarRegressionTask(
         "element_types": element_types(),
     },
     output_kwargs={"lazy": False, "input_dim": 64, "hidden_dim": 64},
-    task_keys=["energy_init"],
+    task_keys=["energy_total"],
 )
 
 dm = MatSciMLDataModule.from_devset(
-    "OQMDDataset",
+    "NomadDataset",
     dset_kwargs={
         "transforms": [
-            PeriodicPropertiesTransform(cutoff_radius=10.0),
+            PeriodicPropertiesTransform(cutoff_radius=6.5),
             PointCloudToGraphTransform(backend="dgl"),
             MGLDataTransform(),
         ]

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -7,6 +7,13 @@ from matsciml.lightning.data_utils import MatSciMLDataModule
 from matsciml.models import M3GNet
 from matsciml.models.base import ScalarRegressionTask
 
+from matsciml.datasets.transforms import MGLDataTransform
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+
+
 # construct a scalar regression task with SchNet encoder
 task = ScalarRegressionTask(
     encoder_class=M3GNet,
@@ -14,11 +21,18 @@ task = ScalarRegressionTask(
         "element_types": element_types(),
     },
     output_kwargs={"lazy": False, "input_dim": 64, "hidden_dim": 64},
-    task_keys=["energy_total"],
+    task_keys=["energy_init"],
 )
 
 dm = MatSciMLDataModule.from_devset(
-    "M3GNomadDataset",
+    "OQMDDataset",
+    dset_kwargs={
+        "transforms": [
+            PeriodicPropertiesTransform(cutoff_radius=10.0),
+            PointCloudToGraphTransform(backend="dgl"),
+            MGLDataTransform(),
+        ]
+    },
     num_workers=0,
     batch_size=4,
 )

--- a/matsciml/datasets/materials_project/dataset.py
+++ b/matsciml/datasets/materials_project/dataset.py
@@ -7,16 +7,14 @@ from functools import cache, cached_property
 from importlib.util import find_spec
 from math import pi
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable
 
 import numpy as np
 import torch
 from emmet.core.symmetry import SymmetryData
-from matgl.ext.pymatgen import Structure2Graph
-from matgl.graph.data import M3GNetDataset
 from pymatgen.analysis import local_env
 from pymatgen.analysis.graphs import StructureGraph
-from pymatgen.core import Lattice, Structure
+from pymatgen.core import Structure
 from tqdm import tqdm
 
 from matsciml.common.registry import registry
@@ -24,7 +22,6 @@ from matsciml.common.types import BatchDict, DataDict
 from matsciml.datasets.base import PointCloudDataset
 from matsciml.datasets.utils import (
     concatenate_keys,
-    element_types,
     point_cloud_featurization,
 )
 
@@ -667,35 +664,3 @@ if _has_pyg:
                         [(lmdb_index, int(subindex)) for subindex in subindices],
                     )
             return indices
-
-
-@registry.register_dataset("M3GMaterialsProjectDataset")
-class M3GMaterialsProjectDataset(MaterialsProjectDataset):
-    def __init__(
-        self,
-        lmdb_root_path: str | Path,
-        threebody_cutoff: float = 4.0,
-        cutoff_dist: float = 20.0,
-        graph_labels: list[int | float] | None = None,
-        transforms: list[Callable[..., Any]] | None = None,
-    ):
-        super().__init__(lmdb_root_path, transforms)
-        self.threebody_cutoff = threebody_cutoff
-        self.graph_labels = graph_labels
-        self.cutoff_dist = cutoff_dist
-        self.clear_processed = True
-
-    def _parse_structure(
-        self,
-        data: dict[str, Any],
-        return_dict: dict[str, Any],
-    ) -> None:
-        super()._parse_structure(data, return_dict)
-        structure: None | Structure = data.get("structure", None)
-        self.structures = [structure]
-        self.converter = Structure2Graph(
-            element_types=element_types(),
-            cutoff=self.cutoff_dist,
-        )
-        graphs, lattices, lg, sa = M3GNetDataset.process(self)
-        return_dict["graph"] = graphs[0]

--- a/matsciml/datasets/nomad/dataset.py
+++ b/matsciml/datasets/nomad/dataset.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from math import pi
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import numpy as np
 import torch
-from matgl.ext.pymatgen import Structure2Graph
-from matgl.graph.data import M3GNetDataset
-from pymatgen.core import Lattice, Structure
 
 from matsciml.common.registry import registry
 from matsciml.common.types import BatchDict, DataDict
@@ -17,8 +13,6 @@ from matsciml.datasets.base import PointCloudDataset
 from matsciml.datasets.utils import (
     atomic_number_map,
     concatenate_keys,
-    element_types,
-    pad_point_cloud,
     point_cloud_featurization,
 )
 
@@ -212,48 +206,4 @@ class NomadDataset(PointCloudDataset):
         data = super().data_from_key(lmdb_index, subindex)
         return_dict = {}
         self._parse_data(data, return_dict=return_dict)
-        return return_dict
-
-
-@registry.register_dataset("M3GNomadDataset")
-class M3GNomadDataset(NomadDataset):
-    def __init__(
-        self,
-        lmdb_root_path: str | Path,
-        threebody_cutoff: float = 4.0,
-        cutoff_dist: float = 20.0,
-        graph_labels: list[int | float] | None = None,
-        transforms: list[Callable[..., Any]] | None = None,
-    ):
-        super().__init__(lmdb_root_path, transforms)
-        self.threebody_cutoff = threebody_cutoff
-        self.graph_labels = graph_labels
-        self.cutoff_dist = cutoff_dist
-        self.clear_processed = True
-
-    def data_from_key(self, lmdb_index: int, subindex: int) -> Any:
-        return_dict = super().data_from_key(lmdb_index, subindex)
-        a, b, c, alpha, beta, gamma = return_dict["lattice_params"]
-        num_to_element = dict(
-            zip(atomic_number_map().values(), atomic_number_map().keys()),
-        )
-        elements = [
-            num_to_element[int(idx.item())] for idx in return_dict["atomic_numbers"]
-        ]
-        lattice = Lattice.from_parameters(
-            a,
-            b,
-            c,
-            alpha * 180 / pi,
-            beta * 180 / pi,
-            gamma * 180 / pi,
-        )
-        structure = Structure(lattice, elements, return_dict["pos"])
-        self.structures = [structure]
-        self.converter = Structure2Graph(
-            element_types=element_types(),
-            cutoff=self.cutoff_dist,
-        )
-        graphs, lattices, lg, sa  = M3GNetDataset.process(self)
-        return_dict["graph"] = graphs[0]
         return return_dict

--- a/matsciml/datasets/transforms/__init__.py
+++ b/matsciml/datasets/transforms/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from matsciml.datasets.transforms.frame_averaging import FrameAveraging
 from matsciml.datasets.transforms.pbc import *
 from matsciml.datasets.transforms.props import *
 from matsciml.datasets.transforms.representations import *
+from matsciml.datasets.transforms.matgl_datasets import *

--- a/matsciml/datasets/transforms/matgl_datasets.py
+++ b/matsciml/datasets/transforms/matgl_datasets.py
@@ -14,6 +14,9 @@ class MGLDataTransform(AbstractDataTransform):
     """
 
     def __call__(self, data: DataDict) -> DataDict:
+        assert (
+            "offsets" in data
+        ), "Offsets missing from data sample! Make sure to include PeriodicPropertiesTransform in the datamodule."
         graph = data["graph"]
         graph.edata["pbc_offset"] = graph.edata["offsets"]
         graph.edata["pbc_offshift"] = torch.matmul(
@@ -23,5 +26,4 @@ class MGLDataTransform(AbstractDataTransform):
         bond_vec, bond_dist = compute_pair_vector_and_distance(graph)
         graph.edata["bond_vec"] = bond_vec
         graph.edata["bond_dist"] = bond_dist
-        data["graph"] = graph
         return data

--- a/matsciml/datasets/transforms/matgl_datasets.py
+++ b/matsciml/datasets/transforms/matgl_datasets.py
@@ -18,10 +18,8 @@ class MGLDataTransform(AbstractDataTransform):
             "offsets" in data
         ), "Offsets missing from data sample! Make sure to include PeriodicPropertiesTransform in the datamodule."
         graph = data["graph"]
-        graph.edata["pbc_offset"] = graph.edata["offsets"]
-        graph.edata["pbc_offshift"] = torch.matmul(
-            graph.edata["pbc_offset"], data["cell"][0]
-        )
+        graph.edata["pbc_offset"] = data["images"]
+        graph.edata["pbc_offshift"] = graph.edata["offsets"]
         graph.ndata["node_type"] = graph.ndata["atomic_numbers"].type(torch.int)
         bond_vec, bond_dist = compute_pair_vector_and_distance(graph)
         graph.edata["bond_vec"] = bond_vec

--- a/matsciml/models/dgl/tests/test_m3gnet.py
+++ b/matsciml/models/dgl/tests/test_m3gnet.py
@@ -1,0 +1,61 @@
+import pytest
+
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+    MGLDataTransform,
+)
+from matsciml.lightning import MatSciMLDataModule
+from matsciml.common.registry import registry
+from matsciml.models import M3GNet
+from matsciml.datasets.utils import element_types
+
+import torch
+
+
+# fixture for some nominal set of hyperparameters that can be used
+# across datasets
+@pytest.fixture
+def model_fixture() -> M3GNet:
+    model = M3GNet(element_types=element_types())
+    return model
+
+
+# here we filter out datasets from the registry that don't make sense
+ignore_dset = ["Multi", "PyG", "Cdvae"]
+filtered_list = list(
+    filter(
+        lambda x: all([target_str not in x for target_str in ignore_dset]),
+        registry.__entries__["datasets"].keys(),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "dset_class_name",
+    filtered_list,
+)
+def test_model_forward_nograd(dset_class_name: str, model_fixture: M3GNet):
+    transforms = [
+        PeriodicPropertiesTransform(cutoff_radius=6.0),
+        PointCloudToGraphTransform("dgl"),
+        MGLDataTransform(),
+    ]
+    dm = MatSciMLDataModule.from_devset(
+        dset_class_name,
+        batch_size=8,
+        dset_kwargs={"transforms": transforms},
+    )
+    # dummy initialization
+    dm.setup("fit")
+    loader = dm.train_dataloader()
+    batch = next(iter(loader))
+    # run the model without gradient tracking
+    with torch.no_grad():
+        embeddings = model_fixture(batch)
+    # returns embeddings, and runs numerical checks
+    for z in [embeddings.system_embedding, embeddings.point_embedding]:
+        assert torch.isreal(z).all()
+        assert ~torch.isnan(z).all()  # check there are no NaNs
+        assert torch.isfinite(z).all()
+        assert torch.all(torch.abs(z) <= 1000)  # ensure reasonable values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "pymatgen==2023.7.20",
   "schema>=0.7.5",
   "ase>=3.22.1",
-  "matgl==0.9.2",
+  "matgl==1.0.0",
   "einops==0.7.0",
   "mendeleev==0.14.0",
   "e3nn==0.5.1"


### PR DESCRIPTION
This PR upgrades the matgl package to 1.0.0. This includes many refactors on their end. In matsciml, the `M3G` datasets are removed, and replaced by a transform, `MGLDataTransform`, which adds the required keys to train m3gnet. Also added in a test for m3gnet specifically. 