### PR TITLE
Periodic graph transform fixes

### DIFF
--- a/matsciml/datasets/transforms/base.py
+++ b/matsciml/datasets/transforms/base.py
@@ -34,3 +34,6 @@ class AbstractDataTransform:
             Transformed item from an abstract dataset
         """
         raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}: {self.__dict__}"

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -29,7 +29,7 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
     a large cut off for the entire dataset.
     """
 
-    def __init__(self, cutoff_radius: float, adaptive_cutoff: bool) -> None:
+    def __init__(self, cutoff_radius: float, adaptive_cutoff: bool = False) -> None:
         super().__init__()
         self.cutoff_radius = cutoff_radius
         self.adaptive_cutoff = adaptive_cutoff

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -22,11 +22,17 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
     transform will compute the unit cell, tile it, and then rewire the graph
     edges such that it can capture connectivity given a radial cutoff given
     in Angstroms.
+
+    Cut off radius is specified in Angstroms. An additional flag, ``adaptive_cutoff``,
+    allows the cut off value to grow up to 100 angstroms in order to find neighbors.
+    This allows larger (typically unstable) structures to be modeled without applying
+    a large cut off for the entire dataset.
     """
 
-    def __init__(self, cutoff_radius: float) -> None:
+    def __init__(self, cutoff_radius: float, adaptive_cutoff: bool) -> None:
         super().__init__()
         self.cutoff_radius = cutoff_radius
+        self.adaptive_cutoff = adaptive_cutoff
 
     def __call__(self, data: DataDict) -> DataDict:
         for key in ["atomic_numbers", "pos"]:
@@ -60,6 +66,8 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
             data["pos"],
             lattice=lattice,
         )
-        graph_props = calculate_periodic_shifts(structure, self.cutoff_radius)
+        graph_props = calculate_periodic_shifts(
+            structure, self.cutoff_radius, self.adaptive_cutoff
+        )
         data.update(graph_props)
         return data

--- a/matsciml/datasets/transforms/representations/graphs.py
+++ b/matsciml/datasets/transforms/representations/graphs.py
@@ -242,7 +242,7 @@ class PointCloudToGraphTransform(RepresentationTransform):
             atom_numbers = self.get_atom_types(data)
             coords = data["pos"]
             # check to see if we have pre-computed edges
-            if all([f"{key}_nodes" in data for key in ["src", "dst"]]) in data:
+            if all([f"{key}_nodes" in data for key in ["src", "dst"]]):
                 edge_index = torch.stack([data["src_nodes"], data["dst_nodes"]])
             else:
                 atom_numbers, coords = self._apply_mask(atom_numbers, coords, data)

--- a/matsciml/datasets/transforms/representations/graphs.py
+++ b/matsciml/datasets/transforms/representations/graphs.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import List, Optional, Tuple, Union
 from warnings import warn
 
 import numpy as np
 import torch
 
 from matsciml.common import DataDict, package_registry
-from matsciml.common.types import AbstractGraph, DataDict, GraphTypes
+from matsciml.common.types import AbstractGraph, GraphTypes
 from matsciml.datasets.transforms.representations import RepresentationTransform
 from matsciml.datasets.utils import retrieve_pointcloud_node_types
 
@@ -24,7 +23,6 @@ if package_registry["dgl"]:
     from dgl import graph as dgl_graph
 
 if package_registry["pyg"]:
-    import torch_geometric
     from torch_geometric.data import Data as PyGGraph
 
 log = getLogger(__name__)
@@ -58,14 +56,12 @@ class PointCloudToGraphTransform(RepresentationTransform):
             GraphTypes,
         ), "Data structure already contains a graph: transform shouldn't be required."
         # check for keys needed to construct the graph
-        assert "pos" in data, f"No atomic positions 'pos' key present in data sample."
+        assert "pos" in data, "No atomic positions 'pos' key present in data sample."
         has_atom_key = False
         for key in ["atomic_numbers", "pc_features"]:
             if key in data:
                 has_atom_key = True
-        assert (
-            has_atom_key
-        ), f"Neither 'atomic_numbers' nor 'pc_features' keys were present in data sample."
+        assert has_atom_key, "Neither 'atomic_numbers' nor 'pc_features' keys were present in data sample."
         return super().prologue(data)
 
     @staticmethod
@@ -100,11 +96,11 @@ class PointCloudToGraphTransform(RepresentationTransform):
             (src_types, dst_types) = retrieve_pointcloud_node_types(data["pc_features"])
             assert src_types.size(0) == data["pos"].size(
                 0,
-            ), f"Number of source nodes != number of atom positions!"
+            ), "Number of source nodes != number of atom positions!"
             return src_types
         else:
             raise KeyError(
-                f"No suitable atom types to read from; expect either 'atomic_numbers' or 'pc_features' to read from a data sample.",
+                "No suitable atom types to read from; expect either 'atomic_numbers' or 'pc_features' to read from a data sample.",
             )
 
     @staticmethod

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -693,8 +693,13 @@ def calculate_periodic_shifts(
         include_index=True,
         include_image=True,
     )
-    if len(neighbors) == 0 and adaptive_cutoff:
-        while len(neighbors) == 0 and cutoff < 30.0:
+    def _all_sites_have_neighbors(neighbors):
+        return all([len(n) for n in neighbors])
+
+    # if there are sites without neighbors and user requested adaptive
+    # cut off, we'll keep trying
+    if not _all_sites_have_neighbors(neighbors) and adaptive_cutoff:
+        while not _all_sites_have_neighbors(neighbors) and cutoff < 30.0:
             # increment radial cutoff progressively
             cutoff += 0.5
             neighbors = structure.get_all_neighbors(
@@ -702,7 +707,7 @@ def calculate_periodic_shifts(
             )
     # placing a secondary check means that if the cut off goes to space
     # and we still don't find a neighbor, we have a problem with the structure
-    if len(neighbors) == 0:
+    if not _all_sites_have_neighbors(neighbors)
         raise ValueError(
             f"No neighbors detected for structure with cutoff {cutoff}; {structure}"
         )

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -694,6 +694,10 @@ def calculate_periodic_shifts(
         include_index=True,
         include_image=True,
     )
+    if len(neighbors) == 0:
+        raise ValueError(
+            f"No neighbors detected for structure with cutoff {cutoff}; {structure}"
+        )
     # process the neighbors now
     all_src, all_dst, all_images = [], [], []
     for src_idx, dst_sites in enumerate(neighbors):
@@ -701,6 +705,11 @@ def calculate_periodic_shifts(
             all_src.append(src_idx)
             all_dst.append(site.index)
             all_images.append(site.image)
+    if any([len(obj) == 0 for obj in [all_images, all_dst, all_images]]):
+        raise ValueError(
+            f"No images or edges to work off for cutoff {cutoff}."
+            f" Please inspect your structure and neighbors: {structure} {neighbors}"
+        )
     # get the lattice definition for use later
     cell = rearrange(structure.lattice.matrix, "i j -> () i j")
     cell = torch.from_numpy(cell.copy()).float()

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -693,17 +693,19 @@ def calculate_periodic_shifts(
         include_index=True,
         include_image=True,
     )
-    if len(neighbors) == 0 and not adaptive_cutoff:
-        raise ValueError(
-            f"No neighbors detected for structure with cutoff {cutoff}; {structure}"
-        )
-    elif len(neighbors) == 0 and adaptive_cutoff:
+    if len(neighbors) == 0 and adaptive_cutoff:
         while len(neighbors) == 0 and cutoff < 30.0:
             # increment radial cutoff progressively
             cutoff += 0.5
             neighbors = structure.get_all_neighbors(
                 cutoff, include_index=True, include_image=True
             )
+    # placing a secondary check means that if the cut off goes to space
+    # and we still don't find a neighbor, we have a problem with the structure
+    if len(neighbors) == 0:
+        raise ValueError(
+            f"No neighbors detected for structure with cutoff {cutoff}; {structure}"
+        )
     # process the neighbors now
     all_src, all_dst, all_images = [], [], []
     for src_idx, dst_sites in enumerate(neighbors):

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -693,6 +693,7 @@ def calculate_periodic_shifts(
         include_index=True,
         include_image=True,
     )
+
     def _all_sites_have_neighbors(neighbors):
         return all([len(n) for n in neighbors])
 
@@ -707,7 +708,7 @@ def calculate_periodic_shifts(
             )
     # placing a secondary check means that if the cut off goes to space
     # and we still don't find a neighbor, we have a problem with the structure
-    if not _all_sites_have_neighbors(neighbors)
+    if not _all_sites_have_neighbors(neighbors):
         raise ValueError(
             f"No neighbors detected for structure with cutoff {cutoff}; {structure}"
         )

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -5,14 +5,13 @@ from collections.abc import Generator
 from functools import lru_cache, partial
 from os import makedirs
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable
 
 import lmdb
 import torch
 from einops import einsum, rearrange
 from joblib import Parallel, delayed
 from pymatgen.core import Lattice, Structure
-from torch.nn.utils.rnn import pad_sequence
 from tqdm import tqdm
 
 from matsciml.common import package_registry
@@ -22,7 +21,6 @@ if package_registry["dgl"]:
     import dgl
 
 if package_registry["pyg"]:
-    import torch_geometric
     from torch_geometric.data import Batch as PyGBatch
     from torch_geometric.data import Data as PyGGraph
 
@@ -301,7 +299,7 @@ def get_lmdb_keys(
         keys = [key.decode("utf-8") for key in txn.cursor().iternext(values=False)]
     if ignore_keys and _lambda:
         raise ValueError(
-            f"Both `ignore_keys` and `_lambda` were passed; arguments are mutually exclusive.",
+            "Both `ignore_keys` and `_lambda` were passed; arguments are mutually exclusive.",
         )
     if ignore_keys:
         _lambda = lambda x: x not in ignore_keys
@@ -463,7 +461,7 @@ def parallel_lmdb_write(
         target_dir = Path(target_dir)
     # make the LMDB directory
     makedirs(target_dir, exist_ok=True)
-    assert target_dir.is_dir(), f"Target to write LMDB data to is not a directory."
+    assert target_dir.is_dir(), "Target to write LMDB data to is not a directory."
 
     def write_chunk(
         chunk: list[Any],
@@ -530,7 +528,7 @@ def parallel_lmdb_write(
     lmdb_indices = list(range(num_procs))
     assert all(
         [length != 0 for length in lengths],
-    ), f"Too many processes specified and not enough data to split over multiple LMDB files. Decrease `num_procs!`"
+    ), "Too many processes specified and not enough data to split over multiple LMDB files. Decrease `num_procs!`"
     p = Parallel(num_procs)(
         delayed(write_chunk)(chunk, target_dir, index, metadata)
         for chunk, index in zip(chunks, lmdb_indices)
@@ -559,7 +557,7 @@ def retrieve_pointcloud_node_types(pc_feats: torch.Tensor) -> tuple[torch.Tensor
     """
     assert (
         pc_feats.ndim == 3
-    ), f"Expected individual samples of point clouds, not batched."
+    ), "Expected individual samples of point clouds, not batched."
     src_types = pc_feats.sum(dim=1).argmax(-1)
     dst_types = pc_feats.sum(dim=0).argmax(-1)
     return (src_types, dst_types)

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -708,7 +708,7 @@ def calculate_periodic_shifts(
     if any([len(obj) == 0 for obj in [all_images, all_dst, all_images]]):
         raise ValueError(
             f"No images or edges to work off for cutoff {cutoff}."
-            f" Please inspect your structure and neighbors: {structure} {neighbors}"
+            f" Please inspect your structure and neighbors: {structure} {neighbors} {structure.cart_coords}"
         )
     # get the lattice definition for use later
     cell = rearrange(structure.lattice.matrix, "i j -> () i j")


### PR DESCRIPTION
This PR addresses fixes a number of issues pertaining to the periodic property transform workflow:

- An erroneous `in data` condition was interfering with the PyG graph transform under certain circumstances. It was working correctly for like 99% of cases, but in the case that the `all([...])` failed, it would not trigger the branch condition as intended.
- Some structures in Materials Project were failing to produce neighbors, as the structures were incredibly large and nearest atom neighbors were well beyond the 6 Angstrom cutoff. I've added some quasi-helpful exceptions into the mix, as well as added support for a `adaptive_cutoff` flag for the `PeriodicPropertiesTransform` (that gets passed into the subfunction), which will slightly modify the behavior of the neighborhood detection. When this flag is `True`, we will iteratively check for neighbors, incrementing the `cutoff` value by half an Angstrom until we get to a point where every site has a neighbor, or we exceed 30 Angstroms for `cutoff`. A final `neighbors` check will then see catch and throw an error if there are still no neighbors detected (there's something seriously wrong with your structure then).
- I realized that the logging pipeline did not actually capture the `transforms` well at least when using MLFlow as the logger. I modified the `__repr__` method of `AbstractTransform` to return transforms in a dictionary representation, which hopefully will give enough information to recreate the transform at a later time. It would be good to make sure this doesn't impact other loggers.