### PR TITLE
M3GNet Model Refactor

### DIFF
--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -17,7 +17,7 @@ from matsciml.datasets.transforms import (
 # construct a scalar regression task with SchNet encoder
 task = ScalarRegressionTask(
     encoder_class=M3GNet,
-    encoder_kwargs={"element_types": element_types(), "output_layers": "final"},
+    encoder_kwargs={"element_types": element_types(), "return_all_layer_output": True},
     output_kwargs={"lazy": False, "input_dim": 64, "hidden_dim": 64},
     task_keys=["energy_total"],
 )

--- a/examples/model_demos/m3gnet_dgl.py
+++ b/examples/model_demos/m3gnet_dgl.py
@@ -17,9 +17,7 @@ from matsciml.datasets.transforms import (
 # construct a scalar regression task with SchNet encoder
 task = ScalarRegressionTask(
     encoder_class=M3GNet,
-    encoder_kwargs={
-        "element_types": element_types(),
-    },
+    encoder_kwargs={"element_types": element_types(), "output_layers": "final"},
     output_kwargs={"lazy": False, "input_dim": 64, "hidden_dim": 64},
     task_keys=["energy_total"],
 )

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -29,6 +29,7 @@ class M3GNet(AbstractDGLModel):
         self.elemenet_types = element_types
         self.all_embeddings = return_all_layer_output
         self.model = matgl_m3gnet(element_types, *args, **kwargs)
+        self.atomic_embedding = self.model.embedding
 
     def _forward(
         self,

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -43,5 +43,6 @@ class M3GNet(AbstractDGLModel):
         outputs = self.model(
             graph, return_all_layer_output=self.all_embeddings, **kwargs
         )
-        # gc_3 is essentially the last graph layer before the readout
-        return Embeddings(outputs["readout"], outputs["gc_3"]["node_feat"])
+        # gc_{self.model.n_blocks} is essentially the last graph layer before the readout
+        last_layer = f"gc_{self.model.n_blocks}"
+        return Embeddings(outputs["readout"], outputs[last_layer]["node_feat"])

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -22,9 +22,12 @@ and to construct the Embedding's output object.
 
 @registry.register_model(M3GNet)
 class M3GNet(AbstractDGLModel):
-    def __init__(self, element_types, *args, **kwargs):
+    def __init__(
+        self, element_types: list[str], return_all_layer_output: bool, *args, **kwargs
+    ):
         super().__init__(atom_embedding_dim=len(element_types))
         self.elemenet_types = element_types
+        self.all_embeddings = return_all_layer_output
         self.model = matgl_m3gnet(element_types, *args, **kwargs)
 
     def _forward(
@@ -36,5 +39,8 @@ class M3GNet(AbstractDGLModel):
         pos: torch.Tensor | None = None,
         **kwargs,
     ) -> Embeddings:
-        outputs = self.model(graph, return_all_layer_output=True, **kwargs)
+        outputs = self.model(
+            graph, return_all_layer_output=self.all_embeddings, **kwargs
+        )
+        # gc_3 is essentially the last graph layer before the readout
         return Embeddings(outputs["readout"], outputs["gc_3"]["node_feat"])

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
-from typing import Union
 
 import dgl
 import torch
-from matgl.graph.compute import (
-    compute_theta_and_phi,
-    create_line_graph,
-    ensure_line_graph_compatibility,
-)
 from matgl.models import M3GNet
-from matgl.models._megnet import *
-from matgl.utils.cutoff import polynomial_cutoff
+
+from matsciml.common.types import BatchDict
 
 from matsciml.common.types import Embeddings
+
+"""
+M3GNet is integrated from matgl: https://github.com/materialsvirtuallab/matgl
+The forward pass needs to be overwritten to accommodate matsciml's expected inputs,
+and to construct the Embedding's output object.
+"""
 
 
 def forward(
     self,
-    g: dgl.DGLGraph,
+    batch: BatchDict,
     state_attr: torch.Tensor | None = None,
     l_g: dgl.DGLGraph | None = None,
 ):
@@ -32,49 +32,10 @@ def forward(
     Returns:
         output: Output property for a batch of graphs
     """
-    g = g["graph"]
-    node_types = g.ndata["node_type"]
-    expanded_dists = self.bond_expansion(g.edata["bond_dist"])
-    if l_g is None:
-        l_g = create_line_graph(g, self.threebody_cutoff)
-    else:
-        l_g = ensure_line_graph_compatibility(g, l_g, self.threebody_cutoff)
-    l_g.apply_edges(compute_theta_and_phi)
-    g.edata["rbf"] = expanded_dists
-    three_body_basis = self.basis_expansion(l_g)
-    three_body_cutoff = polynomial_cutoff(g.edata["bond_dist"], self.threebody_cutoff)
-    node_feat, edge_feat, state_feat = self.embedding(
-        node_types,
-        g.edata["rbf"],
-        state_attr,
-    )
-    for i in range(self.n_blocks):
-        edge_feat = self.three_body_interactions[i](
-            g,
-            l_g,
-            three_body_basis,
-            three_body_cutoff,
-            node_feat,
-            edge_feat,
-        )
-        edge_feat, node_feat, state_feat = self.graph_layers[i](
-            g,
-            edge_feat,
-            node_feat,
-            state_feat,
-        )
-    g.ndata["node_feat"] = node_feat
-    g.edata["edge_feat"] = edge_feat
-    if self.is_intensive:
-        node_vec = self.readout(g)
-        vec = torch.hstack([node_vec, state_feat]) if self.include_states else node_vec  # type: ignore
-        output = self.final_layer(vec)
-        if self.task_type == "classification":
-            output = self.sigmoid(output)
-    else:
-        g.ndata["atomic_properties"] = self.final_layer(g)
-        output = dgl.readout_nodes(g, "atomic_properties", op="sum")
-    return Embeddings(vec, node_vec)
+    graph = batch["graph"]
+    outputs = self.m3gnet_forward(graph, state_attr, l_g, return_all_layer_output=True)
+    # gc_3 is essentially the last graph layer before the readout
+    return Embeddings(outputs["readout"], outputs["gc_3"]["node_feat"])
 
 
 M3GNet.m3gnet_forward = M3GNet.forward

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import dgl
 import torch
-from matgl.models import M3GNet
-
 
 from matsciml.common.types import Embeddings
 
@@ -20,7 +18,7 @@ and to construct the Embedding's output object.
 """
 
 
-@registry.register_model(M3GNet)
+@registry.register_model("M3GNet")
 class M3GNet(AbstractDGLModel):
     def __init__(
         self, element_types: list[str], return_all_layer_output: bool, *args, **kwargs


### PR DESCRIPTION
With the update to matgl to include [intermediate outputs](https://github.com/materialsvirtuallab/matgl/pull/212) in m3gnet, the required embeddings for the matsciml Embeddings object are easy to grab, and the full forward pass does not need to be copied over. 