### PR TITLE
Adding FA Transform Back In

### DIFF
--- a/matsciml/datasets/transforms/__init__.py
+++ b/matsciml/datasets/transforms/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+# ruff: noqa: F403
+
 from matsciml.datasets.transforms.pbc import *
 from matsciml.datasets.transforms.props import *
 from matsciml.datasets.transforms.representations import *
 from matsciml.datasets.transforms.matgl_datasets import *
+from matsciml.datasets.transforms.frame_averaging import *

--- a/matsciml/datasets/transforms/frame_averaging.py
+++ b/matsciml/datasets/transforms/frame_averaging.py
@@ -17,12 +17,11 @@ from matsciml.datasets.transforms.base import AbstractDataTransform
 
 __all__ = ["FrameAveraging"]
 
-if package_registry["dgl"]:
-    pass
-
 if package_registry["pyg"]:
     import torch_geometric
     from torch_geometric.transforms import LinearTransformation
+else:
+    raise Exception("torch_geometric is required for Frame Averaging transform.")
 
 
 def compute_frames(

--- a/matsciml/datasets/transforms/frame_averaging.py
+++ b/matsciml/datasets/transforms/frame_averaging.py
@@ -15,12 +15,15 @@ import torch
 from matsciml.common import package_registry
 from matsciml.datasets.transforms.base import AbstractDataTransform
 
+__all__ = ["FrameAveraging"]
+
 if package_registry["dgl"]:
-    import dgl
+    pass
 
 if package_registry["pyg"]:
     import torch_geometric
     from torch_geometric.transforms import LinearTransformation
+
 
 def compute_frames(
     eigenvec,

--- a/matsciml/datasets/transforms/frame_averaging.py
+++ b/matsciml/datasets/transforms/frame_averaging.py
@@ -21,7 +21,9 @@ if package_registry["pyg"]:
     import torch_geometric
     from torch_geometric.transforms import LinearTransformation
 else:
-    raise Exception("torch_geometric is required for Frame Averaging transform.")
+    raise ModuleNotFoundError(
+        "Frame averaging transform is only currently implemented for PyG."
+    )
 
 
 def compute_frames(


### PR DESCRIPTION
Frame averaging transform was removed in [this](https://github.com/IntelLabs/matsciml/commit/34d2677c3c51357f1a35f1574dd36e22758f7142) commit by ruff. There doesn't seem to be a great solution to prevent ruff from removing unused imports, and also for allowing * imports. I added `# noqa: F403` to get around this for now. 