### PR TITLE
Adding `pre-commit` workflow to Github actions

### DIFF
--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -1,0 +1,18 @@
+name: Run pre-commit workflow
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        name: Install Python 3.10
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - run: pip install -U pip setuptools
+      - uses: pre-commit/action@v3.0.1
+        name: Configure and run pre-commit

--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -8,12 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: file_changes
-        name: Determine changed files in PR
-        uses: trilom/file-changes-action@v1.2.4
-        with:
-          prNumber: ${{ github.event.number }}
-          output: ' '
       - uses: actions/setup-python@v5
         name: Install Python 3.10
         with:
@@ -21,4 +15,6 @@ jobs:
           cache: 'pip'
       - run: pip install -U pip setuptools
       - uses: pre-commit/action@v3.0.1
-        name: Configure and run pre-commit
+        name: Configure and run pre-commit on changed files
+        with:
+          extra_args: --color=always --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -1,3 +1,5 @@
+# Snippets for how to only run on changed PR files can be found
+# here: https://github.com/pre-commit/action/issues/7#issuecomment-1251300704
 name: Run pre-commit workflow
 on:
   pull_request:
@@ -8,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         name: Install Python 3.10
         with:

--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -8,6 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - id: file_changes
+        name: Determine changed files in PR
+        uses: trilom/file-changes-action@v1.2.4
+        with:
+          prNumber: ${{ github.event.number }}
+          output: ' '
       - uses: actions/setup-python@v5
         name: Install Python 3.10
         with:


### PR DESCRIPTION
This PR adds a workflow to run `pre-commit` on the repository upon pull request to `main`.