### PR TITLE
Fix for unused atomic embedding table in M3Gnet

### DIFF
--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -27,7 +27,7 @@ class M3GNet(AbstractDGLModel):
         self.elemenet_types = element_types
         self.all_embeddings = return_all_layer_output
         self.model = matgl_m3gnet(element_types, *args, **kwargs)
-        self.atomic_embedding = self.model.embedding
+        self.atom_embedding = self.model.embedding.layer_node_embedding
 
     def _forward(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,6 @@ where = ["."]
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"]}
 version = {attr = "matsciml.__version__"}
+
+[tool.ruff.lint]
+ignore = ["F403", "F405"]


### PR DESCRIPTION
Thanks to @JonathanSchmidt1 for opening the issue!

This PR closes #137, which had an unintended bug where the M3GNet embedding table is not correctly mapped to the correct attribute name expected by `AbstractDGLModel`. Consequently, you end up with unused parameters that are picked up when DDP is used.

Per Jonathan's suggestion, this PR just changes the attribute mapping so that the atom table is correctly referenced and no unused parameters are present.