### PR TITLE
Add minimal end-to-end workflow

### DIFF
--- a/.github/workflows/run_pytest_endtoend.yml
+++ b/.github/workflows/run_pytest_endtoend.yml
@@ -11,7 +11,7 @@ on:
       - main
   workflow_dispatch:
 jobs:
-  models-pytest:
+  end-to-end-pytest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run_pytest_endtoend.yml
+++ b/.github/workflows/run_pytest_endtoend.yml
@@ -1,0 +1,32 @@
+name: Run end-to-end suites for full pipeline coverage
+on:
+  pull_request:
+    paths:
+      - 'matsciml/**'
+      - 'pyproject.toml'
+      - 'conda.yml'
+      - 'setup.py'
+  workflow_dispatch:
+jobs:
+  models-pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create micromamba env
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: '1.5.7-0'
+          environment-file: conda.yml
+          init-shell: >-
+            bash
+          cache-environment: true
+          post-cleanup: 'all'
+          generate-run-shell: true
+      - name: Install PyTest
+        run: |
+          pip install pytest pytest-dependency
+        shell: micromamba-shell {0}
+      - name: Run pytest in models
+        run: |
+          pytest -v -m "not lmdb and not slow and not remote_request" ./matsciml/tests
+        shell: micromamba-shell {0}

--- a/.github/workflows/run_pytest_endtoend.yml
+++ b/.github/workflows/run_pytest_endtoend.yml
@@ -6,6 +6,9 @@ on:
       - 'pyproject.toml'
       - 'conda.yml'
       - 'setup.py'
+  push:
+    branches:
+      - main
   workflow_dispatch:
 jobs:
   models-pytest:

--- a/matsciml/tests/test_pipeline.py
+++ b/matsciml/tests/test_pipeline.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytorch_lightning as pl
+
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+from matsciml.lightning import MatSciMLDataModule
+from matsciml.models import ScalarRegressionTask
+from matsciml.models.pyg import EGNN
+
+
+def test_egnn_end_to_end():
+    """
+    Test the end to end pipeline using a devset with EGNN.
+
+    The idea is that this basically mimics an example script to
+    try and maximize coverage across dataset to training, which
+    is particularly useful for checking new dependencies, etc.
+    """
+    dm = MatSciMLDataModule.from_devset(
+        "MaterialsProjectDataset",
+        dset_kwargs={
+            "transforms": [
+                PeriodicPropertiesTransform(6.0, adaptive_cutoff=True),
+                PointCloudToGraphTransform("pyg"),
+            ]
+        },
+        batch_size=8,
+    )
+
+    # this specifies a whole lot to make sure we have coverage
+    task = ScalarRegressionTask(
+        encoder_class=EGNN,
+        encoder_kwargs={
+            "hidden_dim": 48,
+            "output_dim": 32,
+            "num_conv": 2,
+            "num_atom_embedding": 200,
+        },
+        scheduler_kwargs={
+            "CosineAnnealingLR": {
+                "T_max": 5,
+                "eta_min": 1e-7,
+            }
+        },
+        lr=1e-3,
+        weight_decay=0.0,
+        output_kwargs={
+            "lazy": False,
+            "hidden_dim": 48,
+            "input_dim": 48,
+            "dropout": 0.2,
+            "num_hidden": 2,
+        },
+        task_keys=["band_gap"],
+    )
+
+    trainer = pl.Trainer(fast_dev_run=5)
+    trainer.fit(task, datamodule=dm)


### PR DESCRIPTION
This PR adds (for now) a simple EGNN end-to-end PyTest and accompanying Github actions workflow definition.

The premise for this is to have at least one example of an end-to-end run, which hopefully preserves functionality regardless of the changes being submitted are. 

I'm open to adding more tests, but this was the simplest one I could think of and is usually my "go to".