### PR TITLE
Upstream MACE implementation

### DIFF
--- a/examples/model_demos/mace_wrapper.py
+++ b/examples/model_demos/mace_wrapper.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytorch_lightning as pl
+from torch import nn
+from e3nn.o3 import Irreps
+from mace.modules.blocks import RealAgnosticInteractionBlock
+
+from matsciml.datasets.transforms import (
+    PointCloudToGraphTransform,
+    PeriodicPropertiesTransform,
+)
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models.base import ScalarRegressionTask
+from matsciml.models.pyg.mace import MACEWrapper
+
+
+"""
+This example script runs through a fast development run of the IS2RE devset
+in combination with a PyG implementation of EGNN.
+"""
+
+# construct IS2RE relaxed energy regression with PyG implementation of E(n)-GNN
+task = ScalarRegressionTask(
+    encoder_class=MACEWrapper,
+    encoder_kwargs={
+        "r_max": 6.0,
+        "num_bessel": 3,
+        "num_polynomial_cutoff": 3,
+        "max_ell": 2,
+        "interaction_cls": RealAgnosticInteractionBlock,
+        "interaction_cls_first": RealAgnosticInteractionBlock,
+        "num_interactions": 2,
+        "atom_embedding_dim": 64,
+        "MLP_irreps": Irreps("256x0e"),
+        "avg_num_neighbors": 10.0,
+        "correlation": 1,
+        "radial_type": "bessel",
+        "gate": nn.Identity(),
+    },
+    task_keys=["energy_relaxed"],
+)
+# matsciml devset for OCP are serialized with DGL - this transform goes between the two frameworks
+dm = MatSciMLDataModule.from_devset(
+    "IS2REDataset",
+    dset_kwargs={
+        "transforms": [
+            PeriodicPropertiesTransform(6.0, adaptive_cutoff=True),
+            PointCloudToGraphTransform(
+                "pyg",
+                node_keys=["pos", "atomic_numbers"],
+            ),
+        ],
+    },
+)
+
+# run a quick training loop
+trainer = pl.Trainer(fast_dev_run=10)
+trainer.fit(task, datamodule=dm)

--- a/matsciml/common/inspection.py
+++ b/matsciml/common/inspection.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: MIT License
+from __future__ import annotations
+
+from inspect import signature
+from typing import Callable, Type
+
+from torch import nn
+
+"""
+Simple utility functions for inspecting functions and objects.
+
+The idea is that this should provide reusable functions that
+are useful for mapping kwargs onto classes that belong outside
+of this library, where we might not know what is required or not.
+"""
+
+
+def get_args_without_defaults(func: Callable, exclude_self: bool = True) -> list[str]:
+    """
+    Inspect a function for required positional input arguments.
+
+    The function works by looping through arguments and checking
+    if defaults are available. The option ``exclude_self`` is also
+    available to specify whether or not to remove ``self`` entries
+    from the list, since this may correspond to class methods.
+
+    Parameters
+    ----------
+    func : Callable
+        A callable function with some input arguments.
+    exclude_self
+        If True, ignores ``self`` and ``cls`` from the returned
+        list.
+
+    Returns
+    -------
+    list[str]
+        List of argument names that are required by ``func``.
+    """
+    parameters = signature(func).parameters
+    matches = []
+    for arg_name, parameter in parameters.items():
+        if getattr(parameter, "default", None):
+            matches.append(arg_name)
+    # remove self from list if requested
+    if exclude_self:
+        matches = list(filter(lambda x: x not in ["self", "cls"], matches))
+    return matches
+
+
+def get_model_required_args(model: Type[nn.Module]) -> list[str]:
+    """
+    Inspect a child of PyTorch ``nn.Module`` for required arguments.
+
+    The idea behind this is to identify which parameters are needed to
+    instantiate a model, which is useful for determining how args/kwargs
+    should be unpacked into a model from an abstract interface.
+
+    Parameters
+    ----------
+    model : Type[nn.Module]
+        A model class to inspect
+
+    Returns
+    -------
+    list[str]
+        List of argument names that are required to instantiate ``model``
+    """
+    return get_args_without_defaults(model.__init__, exclude_self=True)

--- a/matsciml/common/inspection.py
+++ b/matsciml/common/inspection.py
@@ -49,6 +49,24 @@ def get_args_without_defaults(func: Callable, exclude_self: bool = True) -> list
     return matches
 
 
+def get_all_args(func: Callable) -> list[str]:
+    """
+    Get all the arguments of a function, include with defaults.
+
+    Parameters
+    ----------
+    func : Callable
+        Function to inspect arguments for.
+
+    Returns
+    -------
+    list[str]
+        List of argument names, positional and keyword.
+    """
+    parameters = signature(func).parameters
+    return list(parameters.keys())
+
+
 def get_model_required_args(model: Type[nn.Module]) -> list[str]:
     """
     Inspect a child of PyTorch ``nn.Module`` for required arguments.
@@ -68,3 +86,38 @@ def get_model_required_args(model: Type[nn.Module]) -> list[str]:
         List of argument names that are required to instantiate ``model``
     """
     return get_args_without_defaults(model.__init__, exclude_self=True)
+
+
+def get_model_all_args(model: Type[nn.Module]) -> list[str]:
+    """
+    Inspect a model for all of its initialization arguments, including
+    optional ones.
+
+    Parameters
+    ----------
+    model : Type[nn.Module]
+        Model class to inspect for arguments.
+
+    Returns
+    -------
+    list[str]
+        List of arguments used by the model instantiation.
+    """
+    return get_all_args(model.__init__)
+
+
+def get_model_forward_args(model: Type[nn.Module]) -> list[str]:
+    """
+    Inspect a model's ``forward`` method for argument names.
+
+    Parameters
+    ----------
+    model : Type[nn.Module]
+        Model to inspect.
+
+    Returns
+    -------
+    list[str]
+        List of argument names in a model's forward method.
+    """
+    return get_all_args(model.forward)

--- a/matsciml/models/pyg/mace/__init__.py
+++ b/matsciml/models/pyg/mace/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from matsciml.models.pyg.mace.modules.models import MACE, ScaleShiftMACE
+from matsciml.models.pyg.mace.wrapper.model import MACEWrapper
 
-__all__ = [
-    "MACE",
-    "ScaleShiftMACE",
-]
+__all__ = ["MACE", "ScaleShiftMACE", "MACEWrapper"]

--- a/matsciml/models/pyg/mace/original/model.py
+++ b/matsciml/models/pyg/mace/original/model.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from inspect import signature
+from typing import Any
+
+from e3nn.o3 import Irreps
+from mace.modules import MACE
+
+from matsciml.models.base import AbstractPyGModel
+from matsciml.common.registry import registry
+
+
+__mace_signature = signature(MACE)
+__mace_parameters = __mace_signature.parameters
+
+
+@registry.register_model("MACEWrapper")
+class MACEWrapper(AbstractPyGModel):
+    def __init__(
+        self,
+        atom_embedding_dim: int,
+        num_atom_embedding: int = 100,
+        embedding_kwargs: Any = None,
+        encoder_only: bool = True,
+        **mace_kwargs,
+    ) -> None:
+        super().__init__(atom_embedding_dim, num_atom_embedding, {}, encoder_only)
+        for key in mace_kwargs:
+            assert (
+                key in __mace_parameters
+            ), f"{key} was passed as a MACE kwarg but does not match expected arguments."
+        # remove the embedding table, as MACE uses e3nn layers
+        del self.atom_embedding
+        if "num_elements" in mace_kwargs:
+            raise KeyError(
+                "Please use `num_atom_embedding` instead of passing `num_elements`."
+            )
+        if "hidden_irreps" in mace_kwargs:
+            raise KeyError(
+                "Please use `atom_embedding_dim` instead of passing `hidden_irreps`."
+            )
+        atom_embedding_dim = Irreps(f"{atom_embedding_dim}x0e")
+        self.encoder = ...

--- a/matsciml/models/pyg/mace/original/model.py
+++ b/matsciml/models/pyg/mace/original/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from inspect import signature
+from logging import getLogger
 from typing import Any
 
 from e3nn.o3 import Irreps
@@ -14,6 +15,9 @@ __mace_signature = signature(MACE)
 __mace_parameters = __mace_signature.parameters
 
 
+logger = getLogger(__file__)
+
+
 @registry.register_model("MACEWrapper")
 class MACEWrapper(AbstractPyGModel):
     def __init__(
@@ -24,6 +28,8 @@ class MACEWrapper(AbstractPyGModel):
         encoder_only: bool = True,
         **mace_kwargs,
     ) -> None:
+        if embedding_kwargs is not None:
+            logger.warning("`embedding_kwargs` is not used for MACE models.")
         super().__init__(atom_embedding_dim, num_atom_embedding, {}, encoder_only)
         for key in mace_kwargs:
             assert (

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -5,6 +5,7 @@ from typing import Any
 from functools import cache
 
 import torch
+import numpy as np
 from e3nn.o3 import Irreps
 from mace.modules import MACE
 
@@ -54,6 +55,10 @@ class MACEWrapper(AbstractPyGModel):
         # pack stuff into the mace kwargs
         mace_kwargs["num_elements"] = num_atom_embedding
         mace_kwargs["hidden_irreps"] = atom_embedding_dim
+        mace_kwargs["atomic_numbers"] = list(range(1, num_atom_embedding))
+        if "atomic_energies" not in mace_kwargs:
+            logger.warning("No ``atomic_energies`` provided, defaulting to ones.")
+            mace_kwargs["atomic_energies"] = np.ones(num_atom_embedding)
         # check to make sure all that's required is
         for key in __mace_required_args:
             if key not in mace_kwargs:

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -20,6 +20,8 @@ __mace_all_args = get_model_all_args(MACE)
 
 logger = getLogger(__file__)
 
+__all__ = ["MACEWrapper"]
+
 
 @registry.register_model("MACEWrapper")
 class MACEWrapper(AbstractPyGModel):

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -15,10 +15,6 @@ from matsciml.common.registry import registry
 from matsciml.common.inspection import get_model_required_args, get_model_all_args
 
 
-__mace_required_args = get_model_required_args(MACE)
-__mace_all_args = get_model_all_args(MACE)
-
-
 logger = getLogger(__file__)
 
 __all__ = ["MACEWrapper"]
@@ -37,6 +33,9 @@ class MACEWrapper(AbstractPyGModel):
         if embedding_kwargs is not None:
             logger.warning("`embedding_kwargs` is not used for MACE models.")
         super().__init__(atom_embedding_dim, num_atom_embedding, {}, encoder_only)
+        # dynamically check to check which arguments are needed by MACE
+        __mace_required_args = get_model_required_args(MACE)
+        __mace_all_args = get_model_all_args(MACE)
         for key in mace_kwargs:
             assert (
                 key in __mace_all_args

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -92,7 +92,7 @@ class MACEWrapper(AbstractPyGModel):
         return self._atom_eye[atomic_numbers.long()]
 
     def read_batch(self, batch: BatchDict) -> DataDict:
-        data = super().read_batch(batch)
+        data = {}
         # expect a PyG graph already
         graph = batch["graph"]
         atomic_numbers = graph.atomic_numbers

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -49,4 +49,8 @@ class MACEWrapper(AbstractPyGModel):
         # pack stuff into the mace kwargs
         mace_kwargs["num_elements"] = num_atom_embedding
         mace_kwargs["hidden_irreps"] = atom_embedding_dim
+        # check to make sure all that's required is
+        for key in __mace_required_args:
+            if key not in mace_kwargs:
+                raise KeyError(f"{key} is required by MACE, but was not found in kwargs.")
         self.encoder = MACE(**mace_kwargs)

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -117,15 +117,14 @@ class MACEWrapper(AbstractPyGModel):
                     f"Expected periodic property {key} to be in batch."
                     " Please include ``PeriodicPropertiesTransform``."
                 )
+        assert hasattr(graph, "ptr"), "Graph is missing the `ptr` attribute!"
         # the name of these keys matches up with our `_forward`, and
         # later get remapped to MACE ones
         data.update(
             {
                 "graph": graph,
                 "pos": graph.pos,
-                "edge_index": graph.edge_index,
                 "node_feats": one_hot_atoms,
-                "ptr": graph.ptr,  # refers to pointers/node segments
                 "cell": batch["cell"],
                 "shifts": batch["offsets"],
             }
@@ -163,7 +162,7 @@ class MACEWrapper(AbstractPyGModel):
         mace_data = {
             "positions": pos,
             "node_attrs": node_feats,
-            "ptr": kwargs["ptr"],
+            "ptr": graph.ptr,
             "cell": kwargs["cell"],
             "shifts": kwargs["shifts"],
             "batch": graph.batch,

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -8,10 +8,11 @@ from mace.modules import MACE
 
 from matsciml.models.base import AbstractPyGModel
 from matsciml.common.registry import registry
-from matsciml.common.inspection import get_model_required_args
+from matsciml.common.inspection import get_model_required_args, get_model_all_args
 
 
 __mace_required_args = get_model_required_args(MACE)
+__mace_all_args = get_model_all_args(MACE)
 
 
 logger = getLogger(__file__)
@@ -32,7 +33,7 @@ class MACEWrapper(AbstractPyGModel):
         super().__init__(atom_embedding_dim, num_atom_embedding, {}, encoder_only)
         for key in mace_kwargs:
             assert (
-                key in __mace_parameters
+                key in __mace_all_args
             ), f"{key} was passed as a MACE kwarg but does not match expected arguments."
         # remove the embedding table, as MACE uses e3nn layers
         del self.atom_embedding

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from inspect import signature
 from logging import getLogger
 from typing import Any
 
@@ -9,10 +8,10 @@ from mace.modules import MACE
 
 from matsciml.models.base import AbstractPyGModel
 from matsciml.common.registry import registry
+from matsciml.common.inspection import get_model_required_args
 
 
-__mace_signature = signature(MACE)
-__mace_parameters = __mace_signature.parameters
+__mace_required_args = get_model_required_args(MACE)
 
 
 logger = getLogger(__file__)

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -108,6 +108,7 @@ class MACEWrapper(AbstractPyGModel):
         # later get remapped to MACE ones
         data.update(
             {
+                "graph": graph,
                 "pos": graph.pos,
                 "edge_index": graph.edge_index,
                 "node_feats": one_hot_atoms,

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -46,4 +46,7 @@ class MACEWrapper(AbstractPyGModel):
                 "Please use `atom_embedding_dim` instead of passing `hidden_irreps`."
             )
         atom_embedding_dim = Irreps(f"{atom_embedding_dim}x0e")
-        self.encoder = ...
+        # pack stuff into the mace kwargs
+        mace_kwargs["num_elements"] = num_atom_embedding
+        mace_kwargs["hidden_irreps"] = atom_embedding_dim
+        self.encoder = MACE(**mace_kwargs)

--- a/matsciml/models/pyg/mace/wrapper/tests/test_mace_wrapper.py
+++ b/matsciml/models/pyg/mace/wrapper/tests/test_mace_wrapper.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+from e3nn.o3 import Irreps
+from mace.modules.blocks import RealAgnosticInteractionBlock
+
+# this import is not used, but ensures that the registry is updated
+from matsciml import datasets  # noqa: F401
+from matsciml.common.registry import registry
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+from matsciml.lightning import MatSciMLDataModule
+from matsciml.models.pyg.mace import MACEWrapper
+
+
+@pytest.fixture
+def mace_architecture() -> MACEWrapper:
+    """
+    Fixture for a nominal mace architecture.
+
+    Some lightweight (but realistic) hyperparameters are
+    used to test data flowing through the model.
+
+    Returns
+    -------
+    mace
+        Concrete mace object
+    """
+    model_config = {
+        "r_max": 6.0,
+        "num_bessel": 3,
+        "num_polynomial_cutoff": 3,
+        "max_ell": 2,
+        "interaction_cls": RealAgnosticInteractionBlock,
+        "interaction_cls_first": RealAgnosticInteractionBlock,
+        "num_interactions": 2,
+        "atom_embedding_dim": 64,
+        "MLP_irreps": Irreps("256x0e"),
+        "avg_num_neighbors": 10.0,
+        "correlation": 1,
+        "radial_type": "bessel",
+        "gate": nn.Identity(),
+    }
+    model = MACEWrapper(**model_config)
+    return model
+
+
+# here we filter out datasets from the registry that don't make sense
+ignore_dset = ["Multi", "M3G", "PyG", "Cdvae"]
+filtered_list = list(
+    filter(
+        lambda x: all([target_str not in x for target_str in ignore_dset]),
+        registry.__entries__["datasets"].keys(),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "dset_class_name",
+    filtered_list,
+)
+def test_model_forward_nograd(dset_class_name: str, mace_architecture: MACEWrapper):
+    # these are necessary for the model to work as intended
+    """
+    This test checks model ``forward`` compatibility with datasets.
+
+    The test is parameterized to run on all datasets in the registry
+    that have *not* been filtered out; this list should be sparse,
+    as the idea is to maximize coverage and we can just ignore failing
+    combinations if they do not make sense and we can at least be
+    aware of them.
+
+    Parameters
+    ----------
+    dset_class_name : str
+        Name of the dataset class to retrieve
+    mace_architecture : EGNN
+        Concrete mace object with some parameters
+    """
+    transforms = [
+        PeriodicPropertiesTransform(cutoff_radius=6.0, adaptive_cutoff=True),
+        PointCloudToGraphTransform("pyg"),
+    ]
+    dm = MatSciMLDataModule.from_devset(
+        dset_class_name,
+        batch_size=4,
+        dset_kwargs={"transforms": transforms},
+    )
+    # dummy initialization
+    dm.setup("fit")
+    loader = dm.train_dataloader()
+    batch = next(iter(loader))
+    # run the model without gradient tracking
+    with torch.no_grad():
+        embeddings = mace_architecture(batch)
+    # returns embeddings, and runs numerical checks
+    for z in [embeddings.system_embedding, embeddings.point_embedding]:
+        assert torch.isreal(z).all()
+        assert ~torch.isnan(z).all()  # check there are no NaNs
+        assert torch.isfinite(z).all()
+        assert torch.all(torch.abs(z) <= 1000)  # ensure reasonable values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
   "matgl==1.0.0",
   "einops==0.7.0",
   "mendeleev==0.14.0",
-  "e3nn==0.5.1"
+  "e3nn",
+  "mace-torch==0.3.4"
 ]
 description = "PyTorch Lightning and Deep Graph Library enabled materials science deep learning pipeline"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This PR partially addresses #114 by providing a new `MACEWrapper` implementation that, as the name suggests, wraps the upstream MACE model.

Some of the key changes:

- `e3nn` dependency is relaxed, in order to let MACE dictate which version to install for now.
- `mace-torch` is added as a dependency
- A new module, `matsciml.common.inspection`, which provides utility functions for inspecting model arguments. This is used in the `MACEWrapper` workflow to determine which arguments are missing and/or unmapped and can be used in future model implementations
- It wasn't immediately obvious if there were graph-level outputs, and so I took the liberty of just using (by default) sum pooling on the node outputs. Not 100% sure if this makes sense from a modeling perspective, yet, however. 
- The wrapper is hard coded to not to calculate anything else: we don't deal with `stress`, `virials`, `displacement`, or `forces`. Force calculation should be handled by `ForceRegressionTask`.