### PR TITLE
CI environment fix and validation

### DIFF
--- a/.github/workflows/run_pytest_datasets.yml
+++ b/.github/workflows/run_pytest_datasets.yml
@@ -28,6 +28,10 @@ jobs:
         run: |
           pip install pytest pytest-dependency
         shell: micromamba-shell {0}
+      - name: Print out environment
+        run: |
+          micromamba env export
+        shell: micromamba-shell {0}
       - name: Run pytest in data
         run: |
           pytest -v -m "not lmdb and not slow and not remote_request" ./matsciml/datasets ./matsciml/lightning/

--- a/.github/workflows/run_pytest_datasets.yml
+++ b/.github/workflows/run_pytest_datasets.yml
@@ -20,6 +20,10 @@ jobs:
           cache-environment: true
           post-cleanup: 'all'
           generate-run-shell: true
+      - name: Install current version of matsciml
+        run: |
+          pip install .
+        shell: micromamba-shell {0}
       - name: Install PyTest
         run: |
           pip install pytest pytest-dependency

--- a/.github/workflows/run_pytest_datasets.yml
+++ b/.github/workflows/run_pytest_datasets.yml
@@ -30,7 +30,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |
-          micromamba env export
+          micromamba env export && pip freeze
         shell: micromamba-shell {0}
       - name: Run pytest in data
         run: |

--- a/.github/workflows/run_pytest_endtoend.yml
+++ b/.github/workflows/run_pytest_endtoend.yml
@@ -33,6 +33,10 @@ jobs:
         run: |
           pip install pytest pytest-dependency
         shell: micromamba-shell {0}
+      - name: Print out environment
+        run: |
+          micromamba env export
+        shell: micromamba-shell {0}
       - name: Run pytest in models
         run: |
           pytest -v -m "not lmdb and not slow and not remote_request" ./matsciml/tests

--- a/.github/workflows/run_pytest_endtoend.yml
+++ b/.github/workflows/run_pytest_endtoend.yml
@@ -35,7 +35,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |
-          micromamba env export
+          micromamba env export && pip freeze
         shell: micromamba-shell {0}
       - name: Run pytest in models
         run: |

--- a/.github/workflows/run_pytest_lightning.yml
+++ b/.github/workflows/run_pytest_lightning.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           pip install pytest pytest-dependency
         shell: micromamba-shell {0}
+      - name: Print out environment
+        run: |
+          micromamba env export
+        shell: micromamba-shell {0}
       - name: Run pytest in lightning submodule
         run: |
           pytest -v -m "not lmdb and not slow and not remote_request" ./matsciml/lightning

--- a/.github/workflows/run_pytest_lightning.yml
+++ b/.github/workflows/run_pytest_lightning.yml
@@ -29,7 +29,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |
-          micromamba env export
+          micromamba env export && pip freeze
         shell: micromamba-shell {0}
       - name: Run pytest in lightning submodule
         run: |

--- a/.github/workflows/run_pytest_models.yml
+++ b/.github/workflows/run_pytest_models.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           pip install pytest pytest-dependency
         shell: micromamba-shell {0}
+      - name: Print out environment
+        run: |
+          micromamba env export
+        shell: micromamba-shell {0}
       - name: Run pytest in models
         run: |
           pytest -v -m "not lmdb and not slow and not remote_request" ./matsciml/models

--- a/.github/workflows/run_pytest_models.yml
+++ b/.github/workflows/run_pytest_models.yml
@@ -19,6 +19,10 @@ jobs:
           cache-environment: true
           post-cleanup: 'all'
           generate-run-shell: true
+      - name: Install current version of matsciml
+        run: |
+          pip install .
+        shell: micromamba-shell {0}
       - name: Install PyTest
         run: |
           pip install pytest pytest-dependency

--- a/.github/workflows/run_pytest_models.yml
+++ b/.github/workflows/run_pytest_models.yml
@@ -29,7 +29,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |
-          micromamba env export
+          micromamba env export && pip freeze
         shell: micromamba-shell {0}
       - name: Run pytest in models
         run: |

--- a/.github/workflows/run_pytest_repo.yml
+++ b/.github/workflows/run_pytest_repo.yml
@@ -24,6 +24,10 @@ jobs:
         run: |
           pip install pytest pytest-dependency
         shell: micromamba-shell {0}
+      - name: Print out environment
+        run: |
+          micromamba env export
+        shell: micromamba-shell {0}
       - name: Run pytest in root directory
         run: |
           pytest -v -m "not lmdb and not slow and not remote_request"

--- a/.github/workflows/run_pytest_repo.yml
+++ b/.github/workflows/run_pytest_repo.yml
@@ -26,7 +26,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |
-          micromamba env export
+          micromamba env export && pip freeze
         shell: micromamba-shell {0}
       - name: Run pytest in root directory
         run: |

--- a/.github/workflows/run_pytest_repo.yml
+++ b/.github/workflows/run_pytest_repo.yml
@@ -16,6 +16,10 @@ jobs:
           cache-environment: true
           post-cleanup: 'all'
           generate-run-shell: true
+      - name: Install current version of matsciml
+        run: |
+          pip install .
+        shell: micromamba-shell {0}
       - name: Install PyTest
         run: |
           pip install pytest pytest-dependency


### PR DESCRIPTION
This PR closes #155.

The changes in this PR are:

- Added a `pip install` step to every PyTest workflow, which ensures the most up-to-date code is being used for the `pytest` runs.
- Added an environment printing step so that reviewers can double check that new package versions are being used for validating dependency bumps.