### PR TITLE
Bumping `ruff` to latest 0.3.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
   -   id: check-yaml
   -   id: debug-statements
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.2.1
+  rev: v0.3.5
   hooks:
     - id: ruff
       args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ all = [
   "matsciml[dev,symmetry,pyg]",
 ]
 dev = [
-  "ruff==0.3.3",
+  "ruff==0.3.5",
   "pre-commit",
   "pytest"
 ]


### PR DESCRIPTION
This PR replaces #171, by updating `ruff` in both the pre-commit workflow as well as the `pyproject.toml` development dependency list.