### PR TITLE
Downgrading `torch_geometric` to 2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
   "pytest"
 ]
 pyg = [
-  "torch_geometric==2.5.2",
+  "torch_geometric==2.4.0",
   "torch_scatter==2.1.2",
   "torch_sparse==0.6.18",
   "pybind11"


### PR DESCRIPTION
This PR temporarily downgrades `torch_geometric` to 2.4.0, due to a breaking change in the abstraction for `MessagePassing.propagate`.

This issue arose running the PyG implementation of EGNN, triggering exceptions about "too many things to unpack" when running `self.propagate`, which for EGNN, expects to return new node features and coordinates. I haven't been able to look at how and where to rectify this yet.