### PR TITLE
SAM force regression task fix

### DIFF
--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -22,7 +22,7 @@ from torch.optim import Optimizer
 
 from matsciml.common.packages import package_registry
 from matsciml.datasets.utils import concatenate_keys
-from matsciml.models.base import AbstractTask
+from matsciml.models.base import BaseTaskModule
 
 
 class LeaderboardWriter(BasePredictionWriter):
@@ -756,7 +756,7 @@ class SAM(Callback):
     def on_before_optimizer_step(
         self,
         trainer: Trainer,
-        task: AbstractTask,
+        task: BaseTaskModule,
         optimizer: Optimizer,
     ) -> None:
         with torch.no_grad():

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -694,21 +694,27 @@ class SAM(Callback):
 
         This implementation is adapted from https://github.com/davda54/sam.
 
-        Description:
-        SAM (Sharpness Aware Minimization) simultaneously minimizes loss value and loss sharpness
-        it seeks parameters that lie in neighborhoods having uniformly low loss improving model generalization
-        The training will run twice as slow because SAM needs two forward-backward passes to estimate the "sharpness-aware" gradient.
-        If you're using gradient clipping, make sure to change only the magnitude of gradients, not their direction.
+        SAM (Sharpness Aware Minimization) simultaneously minimizes loss
+        value and loss sharpness it seeks parameters that lie in neighborhoods
+        having uniformly low loss improving model generalization.
 
-        Parameters:
-        - rho (float): A hyperparameter determining the scale of regularization for sharpness-aware minimization.
-                      Defaults to 0.05.
-        - adaptive (bool): A boolean flag indicating whether to adaptively normalize weights.
-                           Defaults to False.
+        The training will run twice as slow because SAM needs two forward-backward
+        passes to estimate the "sharpness-aware" gradient.
 
+        If you're using gradient clipping, make sure to change only the magnitude
+        of gradients, not their direction.
 
-        Examples:
-        Add the writer as a callback to ``Trainer``
+        Parameters
+        ----------
+        rho : float
+            A hyperparameter determining the scale of regularization for
+            sharpness-aware minimization. Defaults to 0.05.
+        adaptive : bool
+            A boolean flag indicating whether to adaptively normalize weights.
+            Defaults to False.
+
+        Examples
+        --------
 
         >>> import pytorch_lightning as pl
         >>> from matsciml.lightning.callbacks import SAM

--- a/matsciml/lightning/tests/test_sam.py
+++ b/matsciml/lightning/tests/test_sam.py
@@ -253,9 +253,7 @@ def test_gradfree_force_regression():
         encoder_class=PLEGNNBackbone,
         encoder_kwargs=model_args,
     )
-    trainer = pl.Trainer(
-        max_steps=5, logger=False, enable_checkpointing=False, callbacks=[SAM()]
-    )
+    trainer = pl.Trainer(fast_dev_run=5, callbacks=[SAM()])
     trainer.fit(task, datamodule=devset)
     # make sure losses are tracked
     assert "train_force" in trainer.logged_metrics

--- a/matsciml/lightning/tests/test_sam.py
+++ b/matsciml/lightning/tests/test_sam.py
@@ -199,9 +199,7 @@ def test_force_regression_with_SAM():
 
     model = PLEGNNBackbone(**model_args)
     task = ForceRegressionTask(model)
-    trainer = pl.Trainer(
-        max_steps=5, logger=False, enable_checkpointing=False, callbacks=[SAM()]
-    )
+    trainer = pl.Trainer(fast_dev_run=5, callbacks=[SAM()])
     trainer.fit(task, datamodule=devset)
     # make sure losses are tracked
     for key in ["energy", "force"]:

--- a/matsciml/lightning/tests/test_sam.py
+++ b/matsciml/lightning/tests/test_sam.py
@@ -197,8 +197,7 @@ def test_force_regression_with_SAM():
         "encoder_only": True,
     }
 
-    model = PLEGNNBackbone(**model_args)
-    task = ForceRegressionTask(model)
+    task = ForceRegressionTask(encoder_class=PLEGNNBackbone, encoder_kwargs=model_args)
     trainer = pl.Trainer(fast_dev_run=5, callbacks=[SAM()])
     trainer.fit(task, datamodule=devset)
     # make sure losses are tracked

--- a/matsciml/lightning/tests/test_sam.py
+++ b/matsciml/lightning/tests/test_sam.py
@@ -365,5 +365,5 @@ def test_multitask_sam():
         ("IS2REDataset", is2re),
         ("S2EFDataset", s2ef),
     )
-    trainer = pl.Trainer(fast_dev_run=2)
+    trainer = pl.Trainer(fast_dev_run=10)
     trainer.fit(task, datamodule=dm)

--- a/matsciml/lightning/tests/test_sam.py
+++ b/matsciml/lightning/tests/test_sam.py
@@ -9,8 +9,8 @@ from matsciml.datasets.transforms import (
     UnitCellCalculator,
 )
 
-from matsciml.lightning import MatSciMLDataModule
-from matsciml.models import ScalarRegressionTask, BinaryClassificationTask
+from matsciml.lightning import MatSciMLDataModule, MultiDataModule
+from matsciml.datasets import MultiDataset, IS2REDataset, S2EFDataset
 from matsciml.models.pyg import EGNN
 from matsciml.lightning.callbacks import SAM
 from matsciml.models.pyg import FAENet
@@ -18,8 +18,14 @@ from torch import nn
 from e3nn.o3 import Irreps
 from mace.modules.blocks import RealAgnosticInteractionBlock
 from matsciml.models.pyg.mace import MACEWrapper
-from matsciml.models import PLEGNNBackbone
-from matsciml.models.base import ForceRegressionTask, GradFreeForceRegressionTask
+from matsciml.models.dgl import PLEGNNBackbone
+from matsciml.models.base import (
+    MultiTaskLitModule,
+    ForceRegressionTask,
+    GradFreeForceRegressionTask,
+    ScalarRegressionTask,
+    BinaryClassificationTask,
+)
 
 
 def test_egnn_end_to_end_with_SAM():
@@ -295,4 +301,69 @@ def test_egnn_binary_classification_with_SAM():
     )
 
     trainer = pl.Trainer(fast_dev_run=5, callbacks=[SAM()])
+    trainer.fit(task, datamodule=dm)
+
+
+def test_multitask_sam():
+    transforms = [
+        PeriodicPropertiesTransform(6.0, adaptive_cutoff=True),
+        PointCloudToGraphTransform(
+            "dgl",
+            cutoff_dist=6.0,
+            node_keys=["pos", "atomic_numbers"],
+        ),
+    ]
+    dm = MultiDataModule(
+        train_dataset=MultiDataset(
+            [
+                IS2REDataset.from_devset(transforms=transforms),
+                S2EFDataset.from_devset(transforms=transforms),
+            ],
+        ),
+        batch_size=8,
+    )
+    model_args = {
+        "embed_in_dim": 128,
+        "embed_hidden_dim": 32,
+        "embed_out_dim": 128,
+        "embed_depth": 5,
+        "embed_feat_dims": [128, 128, 128],
+        "embed_message_dims": [128, 128, 128],
+        "embed_position_dims": [64, 64],
+        "embed_edge_attributes_dim": 0,
+        "embed_activation": "relu",
+        "embed_residual": True,
+        "embed_normalize": True,
+        "embed_tanh": True,
+        "embed_activate_last": False,
+        "embed_k_linears": 1,
+        "embed_use_attention": False,
+        "embed_attention_norm": "sigmoid",
+        "readout": "sum",
+        "node_projection_depth": 3,
+        "node_projection_hidden_dim": 128,
+        "node_projection_activation": "relu",
+        "prediction_out_dim": 1,
+        "prediction_depth": 3,
+        "prediction_hidden_dim": 128,
+        "prediction_activation": "relu",
+        "encoder_only": True,
+    }
+
+    is2re = ScalarRegressionTask(
+        encoder_class=PLEGNNBackbone,
+        encoder_kwargs=model_args,
+        task_keys=["energy_init", "energy_relaxed"],
+    )
+    s2ef = ForceRegressionTask(
+        encoder_class=PLEGNNBackbone,
+        encoder_kwargs=model_args,
+        task_keys=["energy", "force"],
+    )
+
+    task = MultiTaskLitModule(
+        ("IS2REDataset", is2re),
+        ("S2EFDataset", s2ef),
+    )
+    trainer = pl.Trainer(fast_dev_run=2)
     trainer.fit(task, datamodule=dm)


### PR DESCRIPTION
This PR closes #181 by refactoring the use of `training_step` in the SAM callback, replacing it with `_compute_losses` and thereby removing the recursive relationship between task and callback.

Also made some minor stylistic changes.