### PR TITLE
Version pinning `monty`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
   "einops==0.7.0",
   "mendeleev==0.15.0",
   "e3nn",
-  "mace-torch==0.3.4"
+  "mace-torch==0.3.4",
+  "monty==2024.2.2"
 ]
 description = "PyTorch Lightning and Deep Graph Library enabled materials science deep learning pipeline"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This PR pins a functional version of `monty` that is compatible with the currently set versions of `pymatgen`, `mp_api`, etc.

The most recent update introduced breaking API changes that caused the environment to not work.