### PR TITLE
Noisy node positions pretraining task

### DIFF
--- a/examples/tasks/pretraining/denoising_nodes.py
+++ b/examples/tasks/pretraining/denoising_nodes.py
@@ -18,6 +18,12 @@ pretraining task, as described in:
 Pre-training via denoising for molecular property prediction
 
 by Zaidi _et al._, ICLR 2023; https://openreview.net/pdf?id=tYIMtogyee
+
+The permutation of transforms is not fully invariant, based on how
+it is currently implemented. This configuration is the recommended one,
+where positions are noised _after_ generating the periodic properties;
+this is to ensure that the periodic offsets are generated based on
+the noise-free positions.
 """
 
 # construct IS2RE relaxed energy regression with PyG implementation of E(n)-GNN
@@ -30,10 +36,10 @@ dm = MatSciMLDataModule.from_devset(
     "AlexandriaDataset",
     dset_kwargs={
         "transforms": [
+            PeriodicPropertiesTransform(6.0, True),
             NoisyPositions(
                 scale=1e-3
             ),  # this sets the scale of the Gaussian noise added
-            PeriodicPropertiesTransform(6.0, True),
             PointCloudToGraphTransform(
                 "pyg",
                 node_keys=[

--- a/examples/tasks/pretraining/denoising_nodes.py
+++ b/examples/tasks/pretraining/denoising_nodes.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytorch_lightning as pl
+
+from matsciml.datasets.transforms import (
+    PointCloudToGraphTransform,
+    PeriodicPropertiesTransform,
+    NoisyPositions,
+)
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models.base import NodeDenoisingTask
+from matsciml.models.pyg import EGNN
+
+"""
+This example script shows EGNN being used for a denoising
+pretraining task, as described in:
+
+Pre-training via denoising for molecular property prediction
+
+by Zaidi _et al._, ICLR 2023; https://openreview.net/pdf?id=tYIMtogyee
+"""
+
+# construct IS2RE relaxed energy regression with PyG implementation of E(n)-GNN
+task = NodeDenoisingTask(
+    encoder_class=EGNN,
+    encoder_kwargs={"hidden_dim": 128, "output_dim": 64},
+)
+# set up the data module
+dm = MatSciMLDataModule.from_devset(
+    "AlexandriaDataset",
+    dset_kwargs={
+        "transforms": [
+            NoisyPositions(
+                scale=1e-3
+            ),  # this sets the scale of the Gaussian noise added
+            PeriodicPropertiesTransform(6.0, True),
+            PointCloudToGraphTransform(
+                "pyg",
+                node_keys=[
+                    "pos",
+                    "noisy_pos",
+                    "atomic_numbers",
+                ],  # ensure noisy_pos is included for the task
+            ),
+        ],
+    },
+)
+
+# run a quick training loop
+trainer = pl.Trainer(fast_dev_run=10)
+trainer.fit(task, datamodule=dm)

--- a/matsciml/datasets/transforms/__init__.py
+++ b/matsciml/datasets/transforms/__init__.py
@@ -7,3 +7,4 @@ from matsciml.datasets.transforms.props import *
 from matsciml.datasets.transforms.representations import *
 from matsciml.datasets.transforms.matgl_datasets import *
 from matsciml.datasets.transforms.frame_averaging import *
+from matsciml.datasets.transforms.pretraining import *

--- a/matsciml/datasets/transforms/pretraining/__init__.py
+++ b/matsciml/datasets/transforms/pretraining/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+from matsciml.datasets.transforms.pretraining.noisy_positions import NoisyPositions
+
+
+__all__ = ["NoisyPositions"]

--- a/matsciml/datasets/transforms/pretraining/noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/noisy_positions.py
@@ -57,4 +57,10 @@ class NoisyPositions(AbstractDataTransform):
                 setattr(graph, "noisy_pos", noisy_pos)
         else:
             data["noisy_pos"] = noisy_pos
+        # set targets so that tasks know what to do
+        data["targets"]["denoise"] = pos
+        if "pretraining" in data["target_types"]:
+            data["target_types"]["pretraining"].append(pos)
+        else:
+            data["target_types"]["pretraining"] = [pos]
         return data

--- a/matsciml/datasets/transforms/pretraining/noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/noisy_positions.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import torch
+from dgl import DGLGraph
+
+from matsciml.common.types import DataDict
+from matsciml.datasets.transforms.base import AbstractDataTransform
+
+
+__all__ = ["NoisyPositions"]
+
+
+class NoisyPositions(AbstractDataTransform):
+    def __init__(self, scale: float = 1e-3) -> None:
+        """
+        Initializes a NoisyPositions transform.
+
+        This class generates i.i.d. Gaussian displacements to atom
+        coordinates, and adds a new ``noisy_pos`` key to the data
+        sample. While there is no prescribed ordering of transforms,
+        if graphs are available in the sample the transform will
+        act on the graph over the raw point cloud positions. If
+        your pipeline involves graph creation, note that this _could_
+        affect the resulting edges produced, depending on the scale of
+        noise used.
+
+        Implemented from the strategy described by Zaidi _et al._ 2023,
+        https://openreview.net/pdf?id=tYIMtogyee
+
+        Parameters
+        ----------
+        scale : float
+            Scale used to multiply N~(0, I_3) Gaussian noise
+        """
+        super().__init__()
+        self.scale = scale
+
+    def __call__(self, data: DataDict) -> DataDict:
+        if "graph" in data:
+            graph = data["graph"]
+            if isinstance(graph, DGLGraph):
+                pos = graph.ndata["pos"]
+            else:
+                # assume it's a PyG graph, grab as attribute
+                pos = graph.pos
+        else:
+            # otherwise it's a point cloud
+            pos = data["pos"]
+        noise = torch.randn_like(pos) * self.scale
+        noisy_pos = pos + noise
+        # write the noisy node data; same logic as before
+        if "graph" in data:
+            graph = data["graph"]
+            if isinstance(graph, DGLGraph):
+                graph.ndata["noisy_pos"] = noisy_pos
+            else:
+                setattr(graph, "noisy_pos", noisy_pos)
+        else:
+            data["noisy_pos"] = noisy_pos
+        return data

--- a/matsciml/datasets/transforms/pretraining/noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/noisy_positions.py
@@ -58,7 +58,7 @@ class NoisyPositions(AbstractDataTransform):
         else:
             data["noisy_pos"] = noisy_pos
         # set targets so that tasks know what to do
-        data["targets"]["denoise"] = pos
+        data["targets"]["denoise"] = noise
         if "pretraining" in data["target_types"]:
             data["target_types"]["pretraining"].append("denoise")
         else:

--- a/matsciml/datasets/transforms/pretraining/noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/noisy_positions.py
@@ -60,7 +60,7 @@ class NoisyPositions(AbstractDataTransform):
         # set targets so that tasks know what to do
         data["targets"]["denoise"] = pos
         if "pretraining" in data["target_types"]:
-            data["target_types"]["pretraining"].append(pos)
+            data["target_types"]["pretraining"].append("denoise")
         else:
-            data["target_types"]["pretraining"] = [pos]
+            data["target_types"]["pretraining"] = ["denoise"]
         return data

--- a/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
@@ -61,6 +61,20 @@ def test_noisy_graph(dset_name, graph_type):
 
 
 @pytest.mark.parametrize("dset_name", valid_dsets)
+def test_noisy_pointcloud_datamodule(dset_name):
+    """Test the transform on point cloud types with batching."""
+    dm = MatSciMLDataModule.from_devset(
+        dset_name,
+        batch_size=4,
+    )
+    dm.setup("fit")
+    loader = dm.train_dataloader()
+    batch = next(iter(loader))
+    assert "noisy_pos" in batch
+    assert torch.isfinite(batch["noisy_pos"]).all()
+
+
+@pytest.mark.parametrize("dset_name", valid_dsets)
 @pytest.mark.parametrize("graph_type", ["pyg", "dgl"])
 def test_noisy_graph_datamodule(dset_name, graph_type):
     """Test the transform on graph types with batching."""

--- a/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
@@ -5,6 +5,7 @@ import torch
 from dgl import DGLGraph
 
 from matsciml.common.registry import registry
+from matsciml.lightning import MatSciMLDataModule
 from matsciml.datasets.transforms.pretraining import NoisyPositions
 from matsciml.datasets.transforms import (
     PeriodicPropertiesTransform,
@@ -57,3 +58,32 @@ def test_noisy_graph(dset_name, graph_type):
             target = graph
         assert "noisy_pos" in target
         assert torch.isfinite(target["noisy_pos"]).all()
+
+
+@pytest.mark.parametrize("dset_name", valid_dsets)
+@pytest.mark.parametrize("graph_type", ["pyg", "dgl"])
+def test_noisy_graph_datamodule(dset_name, graph_type):
+    """Test the transform on graph types with batching."""
+    dm = MatSciMLDataModule.from_devset(
+        dset_name,
+        dset_kwargs=dict(
+            transforms=[
+                NoisyPositions(),
+                PeriodicPropertiesTransform(6.0, adaptive_cutoff=True),
+                PointCloudToGraphTransform(
+                    graph_type, node_keys=["atomic_numbers", "pos", "noisy_pos"]
+                ),
+            ],
+        ),
+        batch_size=4,
+    )
+    dm.setup("fit")
+    loader = dm.train_dataloader()
+    batch = next(iter(loader))
+    graph = batch["graph"]
+    if isinstance(graph, DGLGraph):
+        target = graph.ndata
+    else:
+        target = graph
+    assert "noisy_pos" in target
+    assert torch.isfinite(target["noisy_pos"]).all()

--- a/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from dgl import DGLGraph
+
+from matsciml.common.registry import registry
+from matsciml.datasets.transforms.pretraining import NoisyPositions
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+
+
+dset_names = registry.__entries__["datasets"].keys()
+valid_dsets = list(
+    filter(
+        lambda x: all(
+            [match not in x for match in ["PyG", "Multi", "Cdvae", "PointGroup"]]
+        ),
+        dset_names,
+    )
+)
+
+
+@pytest.mark.parametrize("dset_name", valid_dsets)
+def test_noisy_pointcloud(dset_name):
+    """Test the transform on the raw point clouds"""
+    dset_class = registry.get_dataset_class(dset_name)
+    dset = dset_class.from_devset(transforms=[NoisyPositions()])
+    for index in range(10):
+        sample = dset.__getitem__(index)
+        assert "noisy_pos" in sample
+        assert torch.isfinite(sample["noisy_pos"]).all()
+
+
+@pytest.mark.parametrize("dset_name", valid_dsets)
+@pytest.mark.parametrize("graph_type", ["pyg", "dgl"])
+def test_noisy_graph(dset_name, graph_type):
+    """Test the transform on graph types."""
+    dset_class = registry.get_dataset_class(dset_name)
+    dset = dset_class.from_devset(
+        transforms=[
+            NoisyPositions(),
+            PeriodicPropertiesTransform(6.0, adaptive_cutoff=True),
+            PointCloudToGraphTransform(
+                graph_type, node_keys=["atomic_numbers", "pos", "noisy_pos"]
+            ),
+        ]
+    )
+    for index in range(10):
+        sample = dset.__getitem__(index)
+        graph = sample["graph"]
+        if isinstance(graph, DGLGraph):
+            target = graph.ndata
+        else:
+            target = graph
+        assert "noisy_pos" in target
+        assert torch.isfinite(target["noisy_pos"]).all()

--- a/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
@@ -64,8 +64,7 @@ def test_noisy_graph(dset_name, graph_type):
 def test_noisy_pointcloud_datamodule(dset_name):
     """Test the transform on point cloud types with batching."""
     dm = MatSciMLDataModule.from_devset(
-        dset_name,
-        batch_size=4,
+        dset_name, batch_size=4, dset_kwargs={"transforms": [NoisyPositions()]}
     )
     dm.setup("fit")
     loader = dm.train_dataloader()

--- a/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
@@ -75,6 +75,8 @@ def test_noisy_pointcloud_datamodule(dset_name):
     batch = next(iter(loader))
     assert "noisy_pos" in batch
     assert torch.isfinite(batch["noisy_pos"]).all()
+    assert "pretraining" in batch["target_types"]
+    assert "denoise" in batch["target_types"]["pretraining"]
 
 
 @pytest.mark.parametrize("dset_name", valid_dsets)
@@ -104,3 +106,5 @@ def test_noisy_graph_datamodule(dset_name, graph_type):
         target = graph
     assert "noisy_pos" in target
     assert torch.isfinite(target["noisy_pos"]).all()
+    assert "pretraining" in batch["target_types"]
+    assert "denoise" in batch["target_types"]["pretraining"]

--- a/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
@@ -33,6 +33,8 @@ def test_noisy_pointcloud(dset_name):
         sample = dset.__getitem__(index)
         assert "noisy_pos" in sample
         assert torch.isfinite(sample["noisy_pos"]).all()
+        assert "pretraining" in sample["target_types"]
+        assert "denoise" in sample["target_types"]["pretraining"]
 
 
 @pytest.mark.parametrize("dset_name", valid_dsets)
@@ -58,6 +60,8 @@ def test_noisy_graph(dset_name, graph_type):
             target = graph
         assert "noisy_pos" in target
         assert torch.isfinite(target["noisy_pos"]).all()
+        assert "pretraining" in sample["target_types"]
+        assert "denoise" in sample["target_types"]["pretraining"]
 
 
 @pytest.mark.parametrize("dset_name", valid_dsets)

--- a/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
+++ b/matsciml/datasets/transforms/pretraining/tests/test_noisy_positions.py
@@ -44,8 +44,8 @@ def test_noisy_graph(dset_name, graph_type):
     dset_class = registry.get_dataset_class(dset_name)
     dset = dset_class.from_devset(
         transforms=[
-            NoisyPositions(),
             PeriodicPropertiesTransform(6.0, adaptive_cutoff=True),
+            NoisyPositions(),
             PointCloudToGraphTransform(
                 graph_type, node_keys=["atomic_numbers", "pos", "noisy_pos"]
             ),
@@ -87,8 +87,8 @@ def test_noisy_graph_datamodule(dset_name, graph_type):
         dset_name,
         dset_kwargs=dict(
             transforms=[
-                NoisyPositions(),
                 PeriodicPropertiesTransform(6.0, adaptive_cutoff=True),
+                NoisyPositions(),
                 PointCloudToGraphTransform(
                     graph_type, node_keys=["atomic_numbers", "pos", "noisy_pos"]
                 ),

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -681,7 +681,7 @@ class BaseTaskModule(pl.LightningModule):
         if encoder_class is not None and encoder_kwargs:
             try:
                 encoder = encoder_class(**encoder_kwargs)
-            except:
+            except:  # noqa: E722
                 raise ValueError(
                     f"Unable to instantiate encoder {encoder_class} with kwargs: {encoder_kwargs}.",
                 )
@@ -943,7 +943,7 @@ class BaseTaskModule(pl.LightningModule):
             metrics[f"train_{key}"] = value
         try:
             batch_size = self.encoder.read_batch_size(batch)
-        except:
+        except:  # noqa: E722
             warn(
                 "Unable to parse batch size from data, defaulting to `None` for logging.",
             )
@@ -963,7 +963,7 @@ class BaseTaskModule(pl.LightningModule):
             metrics[f"val_{key}"] = value
         try:
             batch_size = self.encoder.read_batch_size(batch)
-        except:
+        except:  # noqa: E722
             warn(
                 "Unable to parse batch size from data, defaulting to `None` for logging.",
             )
@@ -983,7 +983,7 @@ class BaseTaskModule(pl.LightningModule):
             metrics[f"test_{key}"] = value
         try:
             batch_size = self.encoder.read_batch_size(batch)
-        except:
+        except:  # noqa: E722
             warn(
                 "Unable to parse batch size from data, defaulting to `None` for logging.",
             )
@@ -1274,7 +1274,7 @@ class MaceEnergyForceTask(BaseTaskModule):
             target_val = targets[key]
             if self.uses_normalizers:
                 target_val = self.normalizers[key].norm(target_val)
-            if self.loss_coeff == None:
+            if self.loss_coeff is None:
                 coefficient = 1.0
             else:
                 coefficient = self.loss_coeff[key]
@@ -1342,7 +1342,7 @@ class MaceEnergyForceTask(BaseTaskModule):
             metrics[f"val_{key}"] = value
         try:
             batch_size = self.encoder.read_batch_size(batch)
-        except:
+        except:  # noqa: E722
             warn(
                 "Unable to parse batch size from data, defaulting to `None` for logging."
             )
@@ -1363,7 +1363,7 @@ class MaceEnergyForceTask(BaseTaskModule):
             metrics[f"test_{key}"] = value
         try:
             batch_size = self.encoder.read_batch_size(batch)
-        except:
+        except:  # noqa: E722
             warn(
                 "Unable to parse batch size from data, defaulting to `None` for logging."
             )
@@ -1732,7 +1732,7 @@ class ForceRegressionTask(BaseTaskModule):
             metrics[f"train_{key}"] = value
         try:
             batch_size = self.encoder.read_batch_size(batch)
-        except:
+        except:  # noqa: E722
             warn(
                 "Unable to parse batch size from data, defaulting to `None` for logging.",
             )

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -2937,7 +2937,7 @@ class NodeDenoisingTask(BaseTaskModule):
     ) -> None:
         if task_keys is not None:
             warn("Task keys were passed to NodeDenoisingTask, but is not used.")
-            task_keys = ["denoise"]
+        task_keys = ["denoise"]
         super().__init__(
             encoder,
             encoder_class,

--- a/matsciml/models/tests/test_tasks.py
+++ b/matsciml/models/tests/test_tasks.py
@@ -157,6 +157,7 @@ def test_gradfree_force_regression():
 
 
 def test_denoising_task(egnn_config):
+    """Tests the denoising task on materials project with EGNN"""
     dm = MatSciMLDataModule.from_devset(
         "MaterialsProjectDataset",
         dset_kwargs={

--- a/matsciml/models/tests/test_tasks.py
+++ b/matsciml/models/tests/test_tasks.py
@@ -56,7 +56,7 @@ def egnn_config():
     return {"encoder_class": PLEGNNBackbone, "encoder_kwargs": model_args}
 
 
-def test_force_regression():
+def test_force_regression(egnn_config):
     devset = MatSciMLDataModule.from_devset(
         "S2EFDataset",
         dset_kwargs={
@@ -69,36 +69,7 @@ def test_force_regression():
             ],
         },
     )
-    model_args = {
-        "embed_in_dim": 128,
-        "embed_hidden_dim": 32,
-        "embed_out_dim": 128,
-        "embed_depth": 5,
-        "embed_feat_dims": [128, 128, 128],
-        "embed_message_dims": [128, 128, 128],
-        "embed_position_dims": [64, 64],
-        "embed_edge_attributes_dim": 0,
-        "embed_activation": "relu",
-        "embed_residual": True,
-        "embed_normalize": True,
-        "embed_tanh": True,
-        "embed_activate_last": False,
-        "embed_k_linears": 1,
-        "embed_use_attention": False,
-        "embed_attention_norm": "sigmoid",
-        "readout": "sum",
-        "node_projection_depth": 3,
-        "node_projection_hidden_dim": 128,
-        "node_projection_activation": "relu",
-        "prediction_out_dim": 1,
-        "prediction_depth": 3,
-        "prediction_hidden_dim": 128,
-        "prediction_activation": "relu",
-        "encoder_only": True,
-    }
-
-    model = PLEGNNBackbone(**model_args)
-    task = ForceRegressionTask(model)
+    task = ForceRegressionTask(**egnn_config)
     trainer = pl.Trainer(max_steps=5, logger=False, enable_checkpointing=False)
     trainer.fit(task, datamodule=devset)
     # make sure losses are tracked
@@ -106,7 +77,7 @@ def test_force_regression():
         assert f"train_{key}" in trainer.logged_metrics
 
 
-def test_gradfree_force_regression():
+def test_gradfree_force_regression(egnn_config):
     devset = MatSciMLDataModule.from_devset(
         "S2EFDataset",
         dset_kwargs={
@@ -119,37 +90,7 @@ def test_gradfree_force_regression():
             ],
         },
     )
-    model_args = {
-        "embed_in_dim": 128,
-        "embed_hidden_dim": 32,
-        "embed_out_dim": 128,
-        "embed_depth": 5,
-        "embed_feat_dims": [128, 128, 128],
-        "embed_message_dims": [128, 128, 128],
-        "embed_position_dims": [64, 64],
-        "embed_edge_attributes_dim": 0,
-        "embed_activation": "relu",
-        "embed_residual": True,
-        "embed_normalize": True,
-        "embed_tanh": True,
-        "embed_activate_last": False,
-        "embed_k_linears": 1,
-        "embed_use_attention": False,
-        "embed_attention_norm": "sigmoid",
-        "readout": "sum",
-        "node_projection_depth": 3,
-        "node_projection_hidden_dim": 128,
-        "node_projection_activation": "relu",
-        "prediction_out_dim": 1,
-        "prediction_depth": 3,
-        "prediction_hidden_dim": 128,
-        "prediction_activation": "relu",
-        "encoder_only": True,
-    }
-    task = GradFreeForceRegressionTask(
-        encoder_class=PLEGNNBackbone,
-        encoder_kwargs=model_args,
-    )
+    task = GradFreeForceRegressionTask(**egnn_config)
     trainer = pl.Trainer(max_steps=5, logger=False, enable_checkpointing=False)
     trainer.fit(task, datamodule=devset)
     # make sure losses are tracked

--- a/matsciml/models/tests/test_tasks.py
+++ b/matsciml/models/tests/test_tasks.py
@@ -1,18 +1,59 @@
 from __future__ import annotations
 
+import pytest
 import pytorch_lightning as pl
 
 from matsciml.datasets.materials_project import MaterialsProjectDataset
-from matsciml.datasets.transforms import PointCloudToGraphTransform
+from matsciml.datasets.transforms import (
+    PointCloudToGraphTransform,
+    PeriodicPropertiesTransform,
+    NoisyPositions,
+)
 from matsciml.lightning.data_utils import MatSciMLDataModule
 from matsciml.models import PLEGNNBackbone
-from matsciml.models.base import ForceRegressionTask, GradFreeForceRegressionTask
+from matsciml.models.base import (
+    ForceRegressionTask,
+    GradFreeForceRegressionTask,
+    NodeDenoisingTask,
+)
 
 pl.seed_everything(2156161)
 
 
 def test_regression_devset():
     dset = MaterialsProjectDataset.from_devset()  # noqa: F841
+
+
+@pytest.fixture
+def egnn_config():
+    model_args = {
+        "embed_in_dim": 128,
+        "embed_hidden_dim": 32,
+        "embed_out_dim": 128,
+        "embed_depth": 5,
+        "embed_feat_dims": [128, 128, 128],
+        "embed_message_dims": [128, 128, 128],
+        "embed_position_dims": [64, 64],
+        "embed_edge_attributes_dim": 0,
+        "embed_activation": "relu",
+        "embed_residual": True,
+        "embed_normalize": True,
+        "embed_tanh": True,
+        "embed_activate_last": False,
+        "embed_k_linears": 1,
+        "embed_use_attention": False,
+        "embed_attention_norm": "sigmoid",
+        "readout": "sum",
+        "node_projection_depth": 3,
+        "node_projection_hidden_dim": 128,
+        "node_projection_activation": "relu",
+        "prediction_out_dim": 1,
+        "prediction_depth": 3,
+        "prediction_hidden_dim": 128,
+        "prediction_activation": "relu",
+        "encoder_only": True,
+    }
+    return {"encoder_class": PLEGNNBackbone, "encoder_kwargs": model_args}
 
 
 def test_force_regression():
@@ -113,3 +154,23 @@ def test_gradfree_force_regression():
     trainer.fit(task, datamodule=devset)
     # make sure losses are tracked
     assert "train_force" in trainer.logged_metrics
+
+
+def test_denoising_task(egnn_config):
+    dm = MatSciMLDataModule.from_devset(
+        "MaterialsProjectDataset",
+        dset_kwargs={
+            "transforms": [
+                NoisyPositions(),
+                PeriodicPropertiesTransform(6.0, True),
+                PointCloudToGraphTransform(
+                    "dgl", node_keys=["atomic_numbers", "noisy_pos", "force"]
+                ),
+            ]
+        },
+        batch_size=8,
+    )
+    task = NodeDenoisingTask(**egnn_config, task_keys=["denoise"])
+    trainer = pl.Trainer(fast_dev_run=5)
+    trainer.fit(task, datamodule=dm)
+    assert "train_denoise" in trainer.logged_metrics


### PR DESCRIPTION
This PR adds a pretraining task to `matsciml` as described in [Zaidi _et al._](https://openreview.net/pdf?id=tYIMtogyee), where an encoder/output head is used to predict the noise injected into the input atom positions.

- An example script is given, under `examples/tasks/pretraining` that demonstrates its usage on EGNN+Alexandria dataset
- Implements a `NoisyPositions` data transform inside a `transforms.pretraining` module, which is intended to house other future pre-training transformations
    - Included unit tests that span datasets and representations; seems to be all green across supported datasets, point cloud, graphs
- Implements a `NodeDenoisingTask`, which handles the training.
    - Included a single unit test using DGL EGNN and Materials Project