### PR TITLE
Correcting SAM check for multitask case

### DIFF
--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -784,7 +784,7 @@ class SAM(Callback):
         with torch.enable_grad():
             loss = task._compute_losses(self.batch)
             # this is for the multitask case where there is more than on optimizer
-            if len(task.optimizers()) > 1:
+            if not isinstance(task.optimizers(), Optimizer):
                 loss = self.extract_optimizer_specific_loss(task, optimizer, loss)
             loss = self._get_loss(loss)
             if loss is not None:


### PR DESCRIPTION
Previous check would fail for the single task case, as Lightning will not return a list but the optimizer directly.

The check now looks to see if the actual optimizer is returned, and if not, will then run the multitask check.

Issue originally showed up in #191 CI checks.