### PR TITLE
Node embedding projections for `ForceRegressionTask`

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1501,6 +1501,7 @@ class ForceRegressionTask(BaseTaskModule):
         loss_func: type[nn.Module] | nn.Module = nn.L1Loss,
         task_keys: list[str] | None = None,
         output_kwargs: dict[str, Any] = {},
+        embedding_reduction_type: str = "sum",
         **kwargs,
     ) -> None:
         super().__init__(
@@ -1510,6 +1511,7 @@ class ForceRegressionTask(BaseTaskModule):
             loss_func,
             task_keys,
             output_kwargs,
+            embedding_reduction_type=embedding_reduction_type,
             **kwargs,
         )
         self.save_hyperparameters(ignore=["encoder", "loss_func"])

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1643,6 +1643,8 @@ class ForceRegressionTask(BaseTaskModule):
             self.embedding_reduction_type,
             d=3,
         )
+        # this may not do anything if we aren't frame averaging
+        # since the reduction is also done in the energy_and_force call
         outputs["energy"] = reduce(
             energy,
             "b ... d -> b d",

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1583,9 +1583,10 @@ class ForceRegressionTask(BaseTaskModule):
         outputs = {}
 
         def energy_and_force(
-            pos: torch.Tensor, system_embedding: torch.Tensor
+            pos: torch.Tensor, point_embeddings: torch.Tensor, reduction_method: str
         ) -> tuple[torch.Tensor, torch.Tensor]:
-            energy = self.output_heads["energy"](system_embedding)
+            node_energies = self.output_heads["energy"](point_embeddings)
+            energy = reduce(node_energies, "b ... -> b d", reduction_method, d=1)
             # now use autograd for force calculation
             force = (
                 -1

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1589,7 +1589,7 @@ class ForceRegressionTask(BaseTaskModule):
         ) -> tuple[torch.Tensor, torch.Tensor]:
             node_energies = self.output_heads["energy"](point_embeddings)
             # we sum over points and keep dimension as 1
-            energy = reduce(node_energies, "b ... -> b d", reduction_method, d=1)
+            energy = reduce(node_energies, "n ... d -> b ()", reduction_method)
             # now use autograd for force calculation
             force = (
                 -1

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1653,6 +1653,11 @@ class ForceRegressionTask(BaseTaskModule):
             self.embedding_reduction_type,
             d=1,
         )
+        # this ensures that we get a scalar value for every node
+        # representing the energy contribution
+        outputs["node_energies"] = reduce(
+            node_energies, "n ... d -> n ()", self.embedding_reduction_type
+        )
         return outputs
 
     def _get_targets(

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1600,23 +1600,25 @@ class ForceRegressionTask(BaseTaskModule):
                     create_graph=True,
                 )[0]
             )
-            return energy, force
+            return energy, force, node_energies
 
         # not using frame averaging
         if fa_pos is None:
-            energy, force = energy_and_force(
+            energy, force, node_energies = energy_and_force(
                 pos, embeddings.point_embedding, self.embedding_reduction_type
             )
         else:
             energy = []
             force = []
+            node_energies = []
             for idx, pos in enumerate(fa_pos):
                 frame_embedding = embeddings.point_embedding[:, idx, :]
-                frame_energy, frame_force = energy_and_force(
+                frame_energy, frame_force, frame_node_energies = energy_and_force(
                     pos, frame_embedding, self.embedding_reduction_type
                 )
                 force.append(frame_force)
                 energy.append(frame_energy)
+                node_energies.append(frame_node_energies)
 
         # check to see if we are frame averaging
         if fa_rot is not None:

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1655,9 +1655,7 @@ class ForceRegressionTask(BaseTaskModule):
         )
         # this ensures that we get a scalar value for every node
         # representing the energy contribution
-        outputs["node_energies"] = reduce(
-            node_energies, "n ... d -> n ()", self.embedding_reduction_type
-        )
+        outputs["node_energies"] = node_energies
         return outputs
 
     def _get_targets(

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1589,7 +1589,7 @@ class ForceRegressionTask(BaseTaskModule):
         ) -> tuple[torch.Tensor, torch.Tensor]:
             node_energies = self.output_heads["energy"](point_embeddings)
             # we sum over points and keep dimension as 1
-            energy = reduce(node_energies, "n ... d -> b ()", reduction_method)
+            energy = reduce(node_energies, "n ... d -> n ()", reduction_method)
             # now use autograd for force calculation
             force = (
                 -1

--- a/matsciml/models/tests/test_tasks.py
+++ b/matsciml/models/tests/test_tasks.py
@@ -10,7 +10,7 @@ from matsciml.datasets.transforms import (
     NoisyPositions,
 )
 from matsciml.lightning.data_utils import MatSciMLDataModule
-from matsciml.models import PLEGNNBackbone
+from matsciml.models import PLEGNNBackbone, FAENet
 from matsciml.models.base import (
     ForceRegressionTask,
     GradFreeForceRegressionTask,
@@ -56,6 +56,18 @@ def egnn_config():
     return {"encoder_class": PLEGNNBackbone, "encoder_kwargs": model_args}
 
 
+@pytest.fixture
+def faenet_config():
+    model_args = {
+        "average_frame_embeddings": False,
+        "pred_as_dict": False,
+        # "hidden_channels": 128,
+        # "out_dim": 128,
+        # "tag_hidden_channels": 32,
+    }
+    return {"encoder_class": FAENet, "encoder_kwargs": model_args}
+
+
 def test_force_regression(egnn_config):
     devset = MatSciMLDataModule.from_devset(
         "S2EFDataset",
@@ -70,6 +82,27 @@ def test_force_regression(egnn_config):
         },
     )
     task = ForceRegressionTask(**egnn_config)
+    trainer = pl.Trainer(max_steps=5, logger=False, enable_checkpointing=False)
+    trainer.fit(task, datamodule=devset)
+    # make sure losses are tracked
+    for key in ["energy", "force"]:
+        assert f"train_{key}" in trainer.logged_metrics
+
+
+def test_fa_force_regression(faenet_config):
+    devset = MatSciMLDataModule.from_devset(
+        "S2EFDataset",
+        dset_kwargs={
+            "transforms": [
+                PeriodicPropertiesTransform(6.0, True),
+                PointCloudToGraphTransform(
+                    "pyg",
+                    node_keys=["pos", "force", "atomic_numbers"],
+                ),
+            ],
+        },
+    )
+    task = ForceRegressionTask(**faenet_config)
     trainer = pl.Trainer(max_steps=5, logger=False, enable_checkpointing=False)
     trainer.fit(task, datamodule=devset)
     # make sure losses are tracked

--- a/matsciml/models/tests/test_tasks.py
+++ b/matsciml/models/tests/test_tasks.py
@@ -8,6 +8,7 @@ from matsciml.datasets.transforms import (
     PointCloudToGraphTransform,
     PeriodicPropertiesTransform,
     NoisyPositions,
+    FrameAveraging,
 )
 from matsciml.lightning.data_utils import MatSciMLDataModule
 from matsciml.models import PLEGNNBackbone, FAENet
@@ -61,9 +62,9 @@ def faenet_config():
     model_args = {
         "average_frame_embeddings": False,
         "pred_as_dict": False,
-        # "hidden_channels": 128,
-        # "out_dim": 128,
-        # "tag_hidden_channels": 32,
+        "hidden_channels": 128,
+        "out_dim": 128,
+        "tag_hidden_channels": 0,
     }
     return {"encoder_class": FAENet, "encoder_kwargs": model_args}
 
@@ -99,6 +100,7 @@ def test_fa_force_regression(faenet_config):
                     "pyg",
                     node_keys=["pos", "force", "atomic_numbers"],
                 ),
+                FrameAveraging(frame_averaging="3D", fa_method="stochastic"),
             ],
         },
     )


### PR DESCRIPTION
This PR refactors `ForceRegressionTask` to regress energies by reducing node contributions, as opposed to system-level embedding regression.

- Energy output head sees node embeddings now, rather than graph embeddings
- Define `readout` functions that depend on whether a graph structure is passed, and what framework is used. The reduction can be configured with the _task_ hyperparameter `embedding_reduction_type` 
- `process_embeddings` will pack the node energy contributions into the output dictionary.