### PR TITLE
Prettifying PyTest output in Github actions

### DIFF
--- a/.github/workflows/run_pytest_datasets.yml
+++ b/.github/workflows/run_pytest_datasets.yml
@@ -1,4 +1,6 @@
 name: Run data related PyTests
+env:
+  COLUMNS: 120
 on:
   pull_request:
     paths:
@@ -26,7 +28,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Install PyTest
         run: |
-          pip install pytest pytest-dependency
+          pip install pytest pytest-dependency pytest-pretty
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |

--- a/.github/workflows/run_pytest_endtoend.yml
+++ b/.github/workflows/run_pytest_endtoend.yml
@@ -1,4 +1,6 @@
 name: Run end-to-end suites for full pipeline coverage
+env:
+  COLUMNS: 120
 on:
   pull_request:
     paths:
@@ -31,7 +33,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Install PyTest
         run: |
-          pip install pytest pytest-dependency
+          pip install pytest pytest-dependency pytest-pretty
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |

--- a/.github/workflows/run_pytest_lightning.yml
+++ b/.github/workflows/run_pytest_lightning.yml
@@ -1,4 +1,6 @@
 name: Run PyTorch Lightning related PyTests
+env:
+  COLUMNS: 120
 on:
   pull_request:
     paths:
@@ -25,7 +27,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Install PyTest
         run: |
-          pip install pytest pytest-dependency
+          pip install pytest pytest-dependency pytest-pretty
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |

--- a/.github/workflows/run_pytest_models.yml
+++ b/.github/workflows/run_pytest_models.yml
@@ -1,4 +1,6 @@
 name: Run model and task related PyTests
+env:
+  COLUMNS: 120
 on:
   pull_request:
     paths:
@@ -25,7 +27,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Install PyTest
         run: |
-          pip install pytest pytest-dependency
+          pip install pytest pytest-dependency pytest-pretty
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |

--- a/.github/workflows/run_pytest_repo.yml
+++ b/.github/workflows/run_pytest_repo.yml
@@ -1,4 +1,6 @@
 name: Run broad spectrum PyTest on demand
+env:
+  COLUMNS: 120
 on:
   workflow_dispatch:
 jobs:
@@ -22,7 +24,7 @@ jobs:
         shell: micromamba-shell {0}
       - name: Install PyTest
         run: |
-          pip install pytest pytest-dependency
+          pip install pytest pytest-dependency pytest-pretty
         shell: micromamba-shell {0}
       - name: Print out environment
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,6 @@ version = {attr = "matsciml.__version__"}
 
 [tool.ruff.lint]
 ignore = ["F403", "F405"]
+
+[tool.pytest.ini_options]
+filterwarnings = ["ignore::UserWarning", "ignore::DeprecationWarning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,9 @@ all = [
 dev = [
   "ruff==0.4.0",
   "pre-commit",
-  "pytest"
+  "pytest",
+  "pytest-pretty",
+  "pytest-dependency"
 ]
 pyg = [
   "torch_geometric==2.4.0",


### PR DESCRIPTION
This PR adds `pytest-pretty` as a dependency to the actions workflows.

- Add `pytest-pretty` to `pyproject.toml` for `dev` specification
- Add `pytest-pretty` and a print formatting configuration to each PyTest workflow
- Configuring `pytest` to ignore deprecation warnings in `pyproject.toml`, which has been a huge (>300) source of text spam