### PR TITLE
General predict method for tasks

### DIFF
--- a/matsciml/interfaces/ase/base.py
+++ b/matsciml/interfaces/ase/base.py
@@ -254,7 +254,8 @@ class MatSciMLCalculator(Calculator):
             results = self.multitask_strategy(output, self.task_module)
             self.results = results
         else:
-            output = self.task_module(data_dict)
+            # use the specialized predict method, which will rescale data
+            output = self.task_module.predict(data_dict)
             # add outputs to self.results as expected by ase
             if "energy" in output:
                 self.results["energy"] = output["energy"].detach().item()

--- a/matsciml/interfaces/ase/base.py
+++ b/matsciml/interfaces/ase/base.py
@@ -248,14 +248,12 @@ class MatSciMLCalculator(Calculator):
         # get into format ready for matsciml model
         data_dict = self._format_pipeline(atoms)
         # run the data structure through the model
+        output = self.task_module.predict(data_dict)
         if isinstance(self.task_module, MultiTaskLitModule):
-            output = self.task_module.ase_calculate(data_dict)
             # use a more complicated parser for multitasks
             results = self.multitask_strategy(output, self.task_module)
             self.results = results
         else:
-            # use the specialized predict method, which will rescale data
-            output = self.task_module.predict(data_dict)
             # add outputs to self.results as expected by ase
             if "energy" in output:
                 self.results["energy"] = output["energy"].detach().item()

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -2573,7 +2573,8 @@ class MultiTaskLitModule(pl.LightningModule):
             # now loop through every dataset/output head pair
             for dset_name, subtask_name in self.dataset_task_pairs:
                 subtask = self.task_map[dset_name][subtask_name]
-                output = subtask(batch)
+                # use the predict method to get rescaled outputs
+                output = subtask.predict(batch)
                 # now add it to the rest of the results
                 if dset_name not in results:
                     results[dset_name] = {}

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -2533,20 +2533,18 @@ class MultiTaskLitModule(pl.LightningModule):
                     results[task_type] = subtask(batch)
             return results
 
-    def ase_calculate(self, batch: BatchDict) -> dict[str, dict[str, torch.Tensor]]:
+    def predict(self, batch: BatchDict) -> dict[str, dict[str, torch.Tensor]]:
         """
-        Currently "specialized" function that runs a set of data through
-        every single output head, ignoring the nominal dataset/subtask
-        unique mapping.
+        Similar logic to the `BaseTaskModule.predict` method, but implemented
+        for the multitask setting.
 
-        This is designed for ASE usage primarily, but ostensibly could be
-        used as _the_ inference call for a multitask module. Basically,
-        when the input data doesn't come from the same "datasets" used
-        for initialization/training, and we want to provide a "mixture of
-        experts" response.
+        The workflow is a linear combination of the two: we run the joint
+        embedder once, and then subsequently rely on the `predict` method
+        for each subtask to get outputs at their expected scales.
 
-        TODO: this could potentially be used as a template to redesign
-        the forward call to substantially simplify the multitask mapping.
+        This method also behaves a little differently from the other multitask
+        operations, as it runs a set of data through every single output head,
+        ignoring the nominal dataset/subtask unique mapping.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR adds a base `predict` method to tasks, which is intended to be used for inference workflows. This method acts as a wrapper for the task `forward` call, but includes the additional step of applying the inverse normalization to the outputs, so that they are rescaled appropriately.

A summary of changes:

1. The `predict` definition in `BaseTaskModule`, which is inherited by all tasks except `MultiTaskModule`
2. Refactored the `MultiTaskModule.ase_calculate` to be `predict`, so that the interface is consistent. The workflow is more or less unchanged from before, but relies on `subtask.predict`.
3. For `ForceRegressionTask`, we override the `predict` logic slightly by rescaling both forces and node energies using the energy normalization factor _if_ dedicated normalizers are not provided by those values separately.
4. Updated the `ase` calculator code to rely on the `predict` interface, regardless of whether it is multitask or not.