### PR TITLE
Optional Task Loss Scaling

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -698,6 +698,8 @@ class BaseTaskModule(pl.LightningModule):
         self.output_kwargs = default_heads
         self.normalize_kwargs = normalize_kwargs
         self.task_keys = task_keys
+        breakpoint()
+        self.task_loss_scaling = None
         self.embedding_reduction_type = embedding_reduction_type
         self.save_hyperparameters(ignore=["encoder", "loss_func"])
 
@@ -741,6 +743,31 @@ class BaseTaskModule(pl.LightningModule):
         # some tasks like ForceRegressionTask doesn't actually use an output
         # head for the forces
         return True
+
+    @property
+    def task_loss_scaling(self) -> list[str]:
+        return self._task_loss_scaling
+
+    @task_loss_scaling.setter
+    def task_loss_scaling(self, loss_scaling_dict: dict[str, float] | None) -> None:
+        """
+        Adds loss scaling per task. Ensures task loss scaling key is present in the 
+        task loss keys.
+
+        Parameters
+        ----------
+        loss_scaling_dict : dict[str, float]
+            Dictionary used to map a task key to a scaling value.
+        """
+
+        # Check if task loss scaling key is present in task keys.
+
+        if loss_scaling_dict is None:
+            loss_scaling_dict = {}
+        if not isinstance(loss_scaling_dict, dict):
+            raise TypeError(f"task_loss_scaling {loss_scaling_dict} must be a dictionary, got type {type(loss_scaling_dict)}.")
+        self._task_loss_scaling = loss_scaling_dict
+        self.hparams["task_loss_scaling"] = self._task_loss_scaling
 
     @abstractmethod
     def _make_output_heads(self) -> nn.ModuleDict: ...

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -746,7 +746,7 @@ class BaseTaskModule(pl.LightningModule):
         return True
 
     @property
-    def task_loss_scaling(self) -> list[str]:
+    def task_loss_scaling(self) -> dict[str, float]:
         return self._task_loss_scaling
 
     @task_loss_scaling.setter

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -698,7 +698,7 @@ class BaseTaskModule(pl.LightningModule):
         self.output_kwargs = default_heads
         self.normalize_kwargs = normalize_kwargs
         self.task_keys = task_keys
-        self._task_loss_scaling = kwargs.get("task_loss_scaling", None)
+        self._task_loss_scaling = kwargs.get("task_loss_scaling", {})
         if self.task_keys != []:
             self.task_loss_scaling = self._task_loss_scaling
         self.embedding_reduction_type = embedding_reduction_type

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -699,7 +699,7 @@ class BaseTaskModule(pl.LightningModule):
         self.normalize_kwargs = normalize_kwargs
         self.task_keys = task_keys
         self._task_loss_scaling = kwargs.get("task_loss_scaling", {})
-        if self.task_keys != []:
+        if len(self.task_keys) > 0:
             self.task_loss_scaling = self._task_loss_scaling
         self.embedding_reduction_type = embedding_reduction_type
         self.save_hyperparameters(ignore=["encoder", "loss_func"])

--- a/matsciml/models/tests/test_task_loss_scaling.py
+++ b/matsciml/models/tests/test_task_loss_scaling.py
@@ -124,3 +124,13 @@ def test_scalar_regression(egnn_config):
     # make sure losses are tracked
     for key in ["efermi", "energy_total"]:
         assert f"train_{key}" in trainer.logged_metrics
+
+    task = ScalarRegressionTask(
+        **egnn_config,
+        task_keys=["efermi", "energy_total", "relative_energy"],
+    )
+    trainer = pl.Trainer(max_steps=5, logger=False, enable_checkpointing=False)
+    trainer.fit(task, datamodule=devset)
+    # make sure losses are tracked
+    for key in ["efermi", "energy_total"]:
+        assert f"train_{key}" in trainer.logged_metrics

--- a/matsciml/models/tests/test_task_loss_scaling.py
+++ b/matsciml/models/tests/test_task_loss_scaling.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+import pytorch_lightning as pl
+
+from matsciml.datasets.materials_project import MaterialsProjectDataset
+from matsciml.datasets.transforms import (
+    PointCloudToGraphTransform,
+    PeriodicPropertiesTransform,
+    NoisyPositions,
+    FrameAveraging,
+)
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models import PLEGNNBackbone, FAENet
+from matsciml.models.base import (
+    ForceRegressionTask,
+    GradFreeForceRegressionTask,
+    NodeDenoisingTask,
+)
+
+pl.seed_everything(2156161)
+
+
+def test_regression_devset():
+    dset = MaterialsProjectDataset.from_devset()  # noqa: F841
+
+
+@pytest.fixture
+def egnn_config():
+    model_args = {
+        "embed_in_dim": 128,
+        "embed_hidden_dim": 32,
+        "embed_out_dim": 128,
+        "embed_depth": 5,
+        "embed_feat_dims": [128, 128, 128],
+        "embed_message_dims": [128, 128, 128],
+        "embed_position_dims": [64, 64],
+        "embed_edge_attributes_dim": 0,
+        "embed_activation": "relu",
+        "embed_residual": True,
+        "embed_normalize": True,
+        "embed_tanh": True,
+        "embed_activate_last": False,
+        "embed_k_linears": 1,
+        "embed_use_attention": False,
+        "embed_attention_norm": "sigmoid",
+        "readout": "sum",
+        "node_projection_depth": 3,
+        "node_projection_hidden_dim": 128,
+        "node_projection_activation": "relu",
+        "prediction_out_dim": 1,
+        "prediction_depth": 3,
+        "prediction_hidden_dim": 128,
+        "prediction_activation": "relu",
+        "encoder_only": True,
+    }
+    return {"encoder_class": PLEGNNBackbone, "encoder_kwargs": model_args}
+
+
+def test_force_regression(egnn_config):
+    devset = MatSciMLDataModule.from_devset(
+        "S2EFDataset",
+        dset_kwargs={
+            "transforms": [
+                PointCloudToGraphTransform(
+                    "dgl",
+                    cutoff_dist=20.0,
+                    node_keys=["pos", "atomic_numbers"],
+                ),
+            ],
+        },
+    )
+    task = ForceRegressionTask(
+        **egnn_config,
+        task_keys=["energy", "force"],
+        task_loss_scaling={"energy": 1, "force": 10},
+    )
+    trainer = pl.Trainer(max_steps=5, logger=False, enable_checkpointing=False)
+    trainer.fit(task, datamodule=devset)
+    # make sure losses are tracked
+    for key in ["energy", "force"]:
+        assert f"train_{key}" in trainer.logged_metrics


### PR DESCRIPTION
This PR adds the ability to optionally add a multiplicative scale factor to the loss value for each task head (`scaled_loss = loss * scale_value`). This parameter is an optional input to the specific task being used which maps specified loss scaling keys to existing task keys. Any task keys that do not have a task_loss_scaling key will default to 1. 

Example:
```python
task = ScalarRegressionTask(
  **egnn_config,
  task_keys=["efermi", "energy_total", "relative_energy"],
  task_loss_scaling={"efermi": 1e-5, "energy_total": 1e4},
)
```
In the above example, the two keys `efermi` and `energy_total` will have a specific scale applied, whicle `relative_energy` will default to a scale factor of 1.