### PR TITLE
Override force standard deviation with energy

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1974,6 +1974,16 @@ class ForceRegressionTask(BaseTaskModule):
             logger.warning(
                 "Energy normalization was specified, but not force. I'm adding it for you."
             )
+        # in the case where the energy and force std values are mismatched,
+        # we override the force one with the energy one
+        if "energy" in normalizers and "force" in normalizers:
+            energy_std = normalizers["energy"].std
+            force_std = normalizers["force"].std
+            if energy_std != force_std:
+                normalizers["force"].std = energy_std
+                logger.warning(
+                    "Force normalization std is overridden with the energy std."
+                )
         return normalizers
 
 


### PR DESCRIPTION
This PR forcibly overrides the force normalization standard deviation value with an energy one, if both normalizers are present in the `ForceRegressionTask`.

In #234, the new branch condition (if an energy normalizer is created but not a force one) was intended to be a simple QoL improvement by automatically creating a force normalizer based on the corresponding energy standard deviation value. The catch, however, was that this condition I think will only trigger for previously created tasks, or if `task_keys` are not passed, and was not triggering in LiPS training runs (i.e. "force" normalizer was present, but was a standard normal distribution).

This PR makes it so that we compare values of the force and energy `std`, and if they are not equal, the energy `std` value overwrites the force one to ensure consistency. While there could be some instance where they might not be equal, the intended behavior now for `ForceRegressionTask` is that force is a derivative of energy, and should follow suit.