### PR TITLE
Manual step for learning rate schedulers in `ForceRegressionTask`

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1947,13 +1947,14 @@ class ForceRegressionTask(BaseTaskModule):
         # step learning rate schedulers at the end of epochs
         if self.trainer.is_last_batch:
             schedulers = self.lr_schedulers()
-            if isinstance(schedulers, list):
-                for s in schedulers:
-                    # for schedulers that need a metric
-                    if isinstance(s, lr_scheduler.ReduceLROnPlateau):
-                        s.step(loss, self.current_epoch)
-                    else:
-                        s.step(epoch=self.current_epoch)
+            if not isinstance(schedulers, list):
+                schedulers = [schedulers]
+            for s in schedulers:
+                # for schedulers that need a metric
+                if isinstance(s, lr_scheduler.ReduceLROnPlateau):
+                    s.step(loss, self.current_epoch)
+                else:
+                    s.step(epoch=self.current_epoch)
             else:
                 if isinstance(schedulers, lr_scheduler.ReduceLROnPlateau):
                     schedulers.step(loss, self.current_epoch)

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1955,11 +1955,6 @@ class ForceRegressionTask(BaseTaskModule):
                     s.step(loss, self.current_epoch)
                 else:
                     s.step(epoch=self.current_epoch)
-            else:
-                if isinstance(schedulers, lr_scheduler.ReduceLROnPlateau):
-                    schedulers.step(loss, self.current_epoch)
-                else:
-                    schedulers.step(epoch=self.current_epoch)
         return loss_dict
 
     def _make_normalizers(self) -> dict[str, Normalizer]:


### PR DESCRIPTION
This PR fixes the unintended behavior of not stepping learning rate schedulers during `ForceRegressionTask` training. Because we use manual optimization, this kind of flew under the radar and I caught it while monitoring the learning rate.

The way this is implemented assumes the learning rate is stepped once per epoch: in some cases a per-batch cadence might be desirable, but can cross that bridge when we get there.