### PR TITLE
Allow `hidden_irreps` to be passed through the mace wrapper

### DIFF
--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -56,14 +56,12 @@ class MACEWrapper(AbstractPyGModel):
             raise KeyError(
                 "Please use `num_atom_embedding` instead of passing `num_elements`."
             )
-        if "hidden_irreps" in mace_kwargs:
-            raise KeyError(
-                "Please use `atom_embedding_dim` instead of passing `hidden_irreps`."
-            )
-        atom_embedding_dim = Irreps(f"{atom_embedding_dim}x0e")
+        hidden_irreps = mace_kwargs.get(
+            "hidden_irreps", Irreps(f"{atom_embedding_dim}x0e")
+        )
         # pack stuff into the mace kwargs
         mace_kwargs["num_elements"] = num_atom_embedding
-        mace_kwargs["hidden_irreps"] = atom_embedding_dim
+        mace_kwargs["hidden_irreps"] = hidden_irreps
         mace_kwargs["atomic_numbers"] = list(range(1, num_atom_embedding + 1))
         if "atomic_energies" not in mace_kwargs:
             logger.warning("No ``atomic_energies`` provided, defaulting to ones.")


### PR DESCRIPTION
There are usecases in which the `hidden_irreps` may need to be passed in as an `o3.Irreps` module, such as `Irreps("16x0e+16x1o+16x2e")`. This update allows the `hidden_irreps` kwarg to be used in the mace wrapper, and defaults to construct this from `atom_embedding_dim` if not supplied. 