### PR TITLE
Atom weighted loss functions and `loss_func` argument refactor

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from contextlib import ExitStack, nullcontext
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, ContextManager, Dict, List, Optional, Type, Union
 from warnings import warn
@@ -763,6 +764,10 @@ class BaseTaskModule(pl.LightningModule):
         if not self.has_initialized:
             self.output_heads = self._make_output_heads()
             self.normalizers = self._make_normalizers()
+        # homogenize it into a dictionary mapping
+        if isinstance(self.loss_func, nn.Module):
+            loss_dict = nn.ModuleDict({key: deepcopy(self.loss_func) for key in values})
+            self.loss_func = loss_dict
         self.hparams["task_keys"] = self._task_keys
 
     @property

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -3437,7 +3437,7 @@ class NodeDenoisingTask(BaseTaskModule):
         encoder: nn.Module | None = None,
         encoder_class: type[nn.Module] | None = None,
         encoder_kwargs: dict[str, Any] | None = None,
-        loss_func: type[nn.Module] | nn.Module | None = None,
+        loss_func: type[nn.Module] | nn.Module | None = nn.MSELoss,
         task_keys: list[str] | None = None,
         output_kwargs: dict[str, Any] = {},
         lr: float = 0.0001,
@@ -3464,7 +3464,6 @@ class NodeDenoisingTask(BaseTaskModule):
             scheduler_kwargs,
             **kwargs,
         )
-        self.loss_func = nn.MSELoss()
 
     def _make_output_heads(self) -> nn.ModuleDict:
         # make a single output head for noise prediction applied to nodes

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -768,6 +768,13 @@ class BaseTaskModule(pl.LightningModule):
         if isinstance(self.loss_func, nn.Module):
             loss_dict = nn.ModuleDict({key: deepcopy(self.loss_func) for key in values})
             self.loss_func = loss_dict
+        # if a task key was given but not contained in loss_func
+        # user needs to figure out what to do
+        for key in values:
+            if key not in self.loss_func.keys():
+                raise KeyError(
+                    f"Task key {key} was specified but no loss function was specified."
+                )
         self.hparams["task_keys"] = self._task_keys
 
     @property

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -22,7 +22,6 @@ from matsciml.common.registry import registry
 from matsciml.common.types import AbstractGraph, BatchDict, DataDict, Embeddings
 from matsciml.models.common import OutputHead
 from matsciml.modules.normalizer import Normalizer
-from matsciml.models import losses as matsciml_losses
 
 logger = getLogger("matsciml")
 logger.setLevel("INFO")
@@ -1657,18 +1656,12 @@ class ForceRegressionTask(BaseTaskModule):
         encoder: nn.Module | None = None,
         encoder_class: type[nn.Module] | None = None,
         encoder_kwargs: dict[str, Any] | None = None,
-        loss_func: type[nn.Module] | nn.Module | None = None,
-        energy_loss_func: type[nn.Module] | nn.Module = matsciml_losses.AtomWeightedMSE,
-        force_loss_func: type[nn.Module] | nn.Module = nn.MSELoss,
+        loss_func: type[nn.Module] | nn.Module = nn.L1Loss,
         task_keys: list[str] | None = None,
         output_kwargs: dict[str, Any] = {},
         embedding_reduction_type: str = "sum",
         **kwargs,
     ) -> None:
-        if loss_func is not None:
-            logger.warning(
-                "loss_func is now ignored; please set energy/force_loss_func instead."
-            )
         super().__init__(
             encoder,
             encoder_class,
@@ -1679,15 +1672,7 @@ class ForceRegressionTask(BaseTaskModule):
             embedding_reduction_type=embedding_reduction_type,
             **kwargs,
         )
-        if isinstance(energy_loss_func, type):
-            energy_loss_func = energy_loss_func()
-        if isinstance(force_loss_func, type):
-            force_loss_func = force_loss_func()
-        self.energy_loss_func = energy_loss_func
-        self.force_loss_func = force_loss_func
-        self.save_hyperparameters(
-            ignore=["encoder", "loss_func", "energy_loss_func", "force_loss_func"]
-        )
+        self.save_hyperparameters(ignore=["encoder", "loss_func"])
         # have to enable double backprop
         self.automatic_optimization = False
 

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1038,7 +1038,8 @@ class BaseTaskModule(pl.LightningModule):
             target_val = targets[key]
             if self.uses_normalizers:
                 target_val = self.normalizers[key].norm(target_val)
-            loss = self.loss_func(predictions[key], target_val)
+            loss_func = self.loss_func[key]
+            loss = loss_func(predictions[key], target_val)
             losses[key] = loss * self.task_loss_scaling[key]
 
         total_loss: torch.Tensor = sum(losses.values())

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -3448,7 +3448,9 @@ class NodeDenoisingTask(BaseTaskModule):
         **kwargs,
     ) -> None:
         if task_keys is not None:
-            warn("Task keys were passed to NodeDenoisingTask, but is not used.")
+            logger.warning(
+                "Task keys were passed to NodeDenoisingTask, but is not used."
+            )
         task_keys = ["denoise"]
         super().__init__(
             encoder,

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -766,7 +766,9 @@ class BaseTaskModule(pl.LightningModule):
             self.output_heads = self._make_output_heads()
             self.normalizers = self._make_normalizers()
         # homogenize it into a dictionary mapping
-        if isinstance(self.loss_func, nn.Module):
+        if isinstance(self.loss_func, nn.Module) and not isinstance(
+            self.loss_func, nn.ModuleDict
+        ):
             loss_dict = nn.ModuleDict({key: deepcopy(self.loss_func) for key in values})
             self.loss_func = loss_dict
         # if a task key was given but not contained in loss_func

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -23,6 +23,7 @@ from matsciml.common.registry import registry
 from matsciml.common.types import AbstractGraph, BatchDict, DataDict, Embeddings
 from matsciml.models.common import OutputHead
 from matsciml.modules.normalizer import Normalizer
+from matsciml.models import losses as matsciml_losses
 
 logger = getLogger("matsciml")
 logger.setLevel("INFO")
@@ -1269,7 +1270,10 @@ class ScalarRegressionTask(BaseTaskModule):
         encoder: nn.Module | None = None,
         encoder_class: type[nn.Module] | None = None,
         encoder_kwargs: dict[str, Any] | None = None,
-        loss_func: type[nn.Module] | nn.Module = nn.MSELoss,
+        loss_func: type[nn.Module]
+        | nn.Module
+        | dict[str, nn.Module | type[nn.Module]]
+        | None = nn.MSELoss,
         task_keys: list[str] | None = None,
         output_kwargs: dict[str, Any] = {},
         **kwargs: Any,
@@ -1387,7 +1391,10 @@ class MaceEnergyForceTask(BaseTaskModule):
         encoder: Optional[nn.Module] = None,
         encoder_class: Optional[Type[nn.Module]] = None,
         encoder_kwargs: Optional[Dict[str, Any]] = None,
-        loss_func: Union[Type[nn.Module], nn.Module] = nn.MSELoss,
+        loss_func: type[nn.Module]
+        | nn.Module
+        | dict[str, nn.Module | type[nn.Module]]
+        | None = nn.MSELoss,
         loss_coeff: Optional[Dict[str, Any]] = None,
         task_keys: Optional[List[str]] = None,
         output_kwargs: Dict[str, Any] = {},
@@ -1614,7 +1621,10 @@ class BinaryClassificationTask(BaseTaskModule):
         encoder: nn.Module | None = None,
         encoder_class: type[nn.Module] | None = None,
         encoder_kwargs: dict[str, Any] | None = None,
-        loss_func: type[nn.Module] | nn.Module = nn.BCEWithLogitsLoss,
+        loss_func: type[nn.Module]
+        | nn.Module
+        | dict[str, nn.Module | type[nn.Module]]
+        | None = nn.BCEWithLogitsLoss,
         task_keys: list[str] | None = None,
         output_kwargs: dict[str, Any] = {},
         **kwargs,
@@ -1690,12 +1700,24 @@ class ForceRegressionTask(BaseTaskModule):
         encoder: nn.Module | None = None,
         encoder_class: type[nn.Module] | None = None,
         encoder_kwargs: dict[str, Any] | None = None,
-        loss_func: type[nn.Module] | nn.Module = nn.L1Loss,
+        loss_func: type[nn.Module]
+        | nn.Module
+        | dict[str, nn.Module | type[nn.Module]]
+        | None = None,
         task_keys: list[str] | None = None,
         output_kwargs: dict[str, Any] = {},
         embedding_reduction_type: str = "sum",
         **kwargs,
     ) -> None:
+        if not loss_func:
+            logger.warning(
+                "Loss functions were not specified. "
+                "Defaulting to AtomWeightedMSE for energy and MSE for force."
+            )
+            loss_func = {
+                "energy": matsciml_losses.AtomWeightedMSE(),
+                "force": nn.MSELoss(),
+            }
         super().__init__(
             encoder,
             encoder_class,
@@ -2109,7 +2131,10 @@ class GradFreeForceRegressionTask(ScalarRegressionTask):
         encoder: nn.Module | None = None,
         encoder_class: type[nn.Module] | None = None,
         encoder_kwargs: dict[str, Any] | None = None,
-        loss_func: type[nn.Module] | nn.Module = nn.MSELoss,
+        loss_func: type[nn.Module]
+        | nn.Module
+        | dict[str, nn.Module | type[nn.Module]]
+        | None = nn.MSELoss,
         output_kwargs: dict[str, Any] = {},
         **kwargs: Any,
     ) -> None:
@@ -2246,7 +2271,10 @@ class CrystalSymmetryClassificationTask(BaseTaskModule):
         encoder: nn.Module | None = None,
         encoder_class: type[nn.Module] | None = None,
         encoder_kwargs: dict[str, Any] | None = None,
-        loss_func: type[nn.Module] | nn.Module = nn.CrossEntropyLoss,
+        loss_func: type[nn.Module]
+        | nn.Module
+        | dict[str, nn.Module | type[nn.Module]]
+        | None = nn.CrossEntropyLoss,
         output_kwargs: dict[str, Any] = {},
         normalize_kwargs: dict[str, float] | None = None,
         freeze_embedding: bool = False,

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+__all__ = ["AtomWeightedL1", "AtomWeightedMSE"]
+
+
+class AtomWeightedL1(nn.Module):
+    """
+    Calculates the L1 loss between predicted and targets,
+    weighted by the number of atoms within each graph.
+    """
+
+    def forward(
+        self,
+        predicted: torch.Tensor,
+        targets: torch.Tensor,
+        atoms_per_graph: torch.Tensor,
+    ) -> torch.Tensor:
+        # check to make sure we are broad casting correctly
+        if (predicted.ndim != targets.ndim) and targets.size(-1) == 1:
+            predicted.unsqueeze_(-1)
+        # for N-d targets, we might want to keep unsqueezing
+        while atoms_per_graph.ndim < targets.ndim:
+            atoms_per_graph.unsqueeze_(-1)
+        # ensures that atoms_per_graph is type cast correctly
+        squared_error = (
+            (predicted - targets) / atoms_per_graph.to(predicted.dtype)
+        ).abs()
+        return squared_error.mean()
+
+
+class AtomWeightedMSE(nn.Module):
+    """
+    Calculates the mean-squared-error between predicted and targets,
+    weighted by the number of atoms within each graph.
+    """
+
+    def forward(
+        self,
+        predicted: torch.Tensor,
+        targets: torch.Tensor,
+        atoms_per_graph: torch.Tensor,
+    ) -> torch.Tensor:
+        # check to make sure we are broad casting correctly
+        if (predicted.ndim != targets.ndim) and targets.size(-1) == 1:
+            predicted.unsqueeze_(-1)
+        # for N-d targets, we might want to keep unsqueezing
+        while atoms_per_graph.ndim < targets.ndim:
+            atoms_per_graph.unsqueeze_(-1)
+        # ensures that atoms_per_graph is type cast correctly
+        squared_error = (
+            (predicted - targets) / atoms_per_graph.to(predicted.dtype)
+        ) ** 2.0
+        return squared_error.mean()

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -15,20 +15,18 @@ class AtomWeightedL1(nn.Module):
 
     def forward(
         self,
-        predicted: torch.Tensor,
-        targets: torch.Tensor,
+        input: torch.Tensor,
+        target: torch.Tensor,
         atoms_per_graph: torch.Tensor,
     ) -> torch.Tensor:
         # check to make sure we are broad casting correctly
-        if (predicted.ndim != targets.ndim) and targets.size(-1) == 1:
-            predicted.unsqueeze_(-1)
+        if (input.ndim != target.ndim) and target.size(-1) == 1:
+            input.unsqueeze_(-1)
         # for N-d targets, we might want to keep unsqueezing
-        while atoms_per_graph.ndim < targets.ndim:
+        while atoms_per_graph.ndim < target.ndim:
             atoms_per_graph.unsqueeze_(-1)
         # ensures that atoms_per_graph is type cast correctly
-        squared_error = (
-            (predicted - targets) / atoms_per_graph.to(predicted.dtype)
-        ).abs()
+        squared_error = ((input - target) / atoms_per_graph.to(input.dtype)).abs()
         return squared_error.mean()
 
 
@@ -40,24 +38,22 @@ class AtomWeightedMSE(nn.Module):
 
     def forward(
         self,
-        predicted: torch.Tensor,
-        targets: torch.Tensor,
+        input: torch.Tensor,
+        target: torch.Tensor,
         atoms_per_graph: torch.Tensor,
     ) -> torch.Tensor:
-        if atoms_per_graph.size(0) != targets.size(0):
+        if atoms_per_graph.size(0) != target.size(0):
             raise RuntimeError(
                 "Dimensions for atom-weighted loss do not match:"
-                f" expected atoms_per_graph to have {targets.size(0)} elements; got {atoms_per_graph.size(0)}."
+                f" expected atoms_per_graph to have {target.size(0)} elements; got {atoms_per_graph.size(0)}."
                 "This loss is intended to be applied to scalar targets only."
             )
         # check to make sure we are broad casting correctly
-        if (predicted.ndim != targets.ndim) and targets.size(-1) == 1:
-            predicted.unsqueeze_(-1)
+        if (input.ndim != target.ndim) and target.size(-1) == 1:
+            input.unsqueeze_(-1)
         # for N-d targets, we might want to keep unsqueezing
-        while atoms_per_graph.ndim < targets.ndim:
+        while atoms_per_graph.ndim < target.ndim:
             atoms_per_graph.unsqueeze_(-1)
         # ensures that atoms_per_graph is type cast correctly
-        squared_error = (
-            (predicted - targets) / atoms_per_graph.to(predicted.dtype)
-        ) ** 2.0
+        squared_error = ((input - target) / atoms_per_graph.to(input.dtype)) ** 2.0
         return squared_error.mean()

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -44,6 +44,12 @@ class AtomWeightedMSE(nn.Module):
         targets: torch.Tensor,
         atoms_per_graph: torch.Tensor,
     ) -> torch.Tensor:
+        if atoms_per_graph.size(0) != targets.size(0):
+            raise RuntimeError(
+                "Dimensions for atom-weighted loss do not match:"
+                f" expected atoms_per_graph to have {targets.size(0)} elements; got {atoms_per_graph.size(0)}."
+                "This loss is intended to be applied to scalar targets only."
+            )
         # check to make sure we are broad casting correctly
         if (predicted.ndim != targets.ndim) and targets.size(-1) == 1:
             predicted.unsqueeze_(-1)

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -19,6 +19,12 @@ class AtomWeightedL1(nn.Module):
         target: torch.Tensor,
         atoms_per_graph: torch.Tensor,
     ) -> torch.Tensor:
+        if atoms_per_graph.size(0) != target.size(0):
+            raise RuntimeError(
+                "Dimensions for atom-weighted loss do not match:"
+                f" expected atoms_per_graph to have {target.size(0)} elements; got {atoms_per_graph.size(0)}."
+                "This loss is intended to be applied to scalar targets only."
+            )
         # check to make sure we are broad casting correctly
         if (input.ndim != target.ndim) and target.size(-1) == 1:
             input.unsqueeze_(-1)

--- a/matsciml/models/tests/test_losses.py
+++ b/matsciml/models/tests/test_losses.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from matsciml.models import losses
+
+
+@pytest.fixture
+def atom_weighted_l1():
+    return losses.AtomWeightedL1()
+
+
+@pytest.fixture
+def atom_weighted_mse():
+    return losses.AtomWeightedMSE()
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (10,),
+        (10, 3),
+        (120, 1, 5),
+    ],
+)
+def test_weighted_mse(atom_weighted_mse, shape):
+    pred = torch.rand(*shape)
+    target = torch.rand_like(pred)
+    ptr = torch.randint(1, 100, (shape[0],))
+    atom_weighted_mse(pred, target, ptr)

--- a/matsciml/models/tests/test_task_loss_scaling.py
+++ b/matsciml/models/tests/test_task_loss_scaling.py
@@ -89,7 +89,7 @@ def test_force_regression(egnn_config):
     # Scenario where one task_key is set. Expect to use one task_loss_scaling value.
     task = ForceRegressionTask(
         **egnn_config,
-        task_keys=["force"],
+        task_keys=["force", "energy"],
         task_loss_scaling={"force": 10},
     )
     trainer = pl.Trainer(max_steps=5, logger=False, enable_checkpointing=False)


### PR DESCRIPTION
This PR adds support for MSE and L1 loss functions that are weighted by the number of atoms in each graph in the `matsciml.models.losses` module.

In order to enable usage of these functions with tasks that have both scalar (e.g. energy) and vector (e.g. force) targets, I've had to refactor `loss_func` as an argument to all tasks to support a dictionary mapping, whereby each key corresponds to a `task_key`, and the passed function the loss for that corresponding target. As an example:

```python
ForceRegressionTask(
   ...,
   loss_func={"energy": matsciml.models.losses.AtomWeightedMSE, "force": nn.MSELoss},
   ...
)
```

This does not break previous specifications: if a loss module is passed by itself (e.g. `loss_func = nn.MSELoss()`), the `task_keys.setter` method copy the function to be used for all targets.

Some refactoring was also needed in `_compute_losses` to allow for additional arguments to be passed into the loss function, e.g. in this case the number of atoms per graph. New loss functions in `losses` should try to be consistent in function signatures with native PyTorch ones (e.g. `input` and `target`) for consistent mapping.