### PR TITLE
Fixing checkpoint mechanism for exponential moving average

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1289,6 +1289,28 @@ class BaseTaskModule(pl.LightningModule):
         task.encoder.load_state_dict(encoder_weights)
         return task
 
+    def on_save_checkpoint(self, checkpoint):
+        """Override checkpoint saving to facilitate EMA weights loading."""
+        super().on_save_checkpoint(checkpoint)
+        # this case checks for EMA weights, where we give up on
+        # the non-averaged weights in favor of the averaged ones
+        checkpoint["state_dict"] = self.state_dict()
+        if hasattr(self, "ema_module"):
+            logger.info("Replacing model weights with exponential moving average.")
+            for key, value in self.ema_module.state_dict().items():
+                if key != "n_averaged":
+                    # remove the module prefix for EMA state
+                    tree = key.split(".")
+                    renamed_key = ".".join(tree[1:])
+                    assert (
+                        renamed_key in checkpoint["state_dict"]
+                    ), f"Unexpected key in EMA module: {renamed_key}"
+                    checkpoint["state_dict"][renamed_key] = value
+            # now remove the redundant EMA weights to unblock checkpoint loading later
+            for key in list(checkpoint["state_dict"].keys()):
+                if "ema_module" in key:
+                    del checkpoint["state_dict"][key]
+
 
 @registry.register_task("ScalarRegressionTask")
 class ScalarRegressionTask(BaseTaskModule):

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -3247,6 +3247,28 @@ class MultiTaskLitModule(pl.LightningModule):
             "MultiTask should be reloaded using the `matsciml.models.multitask_from_checkpoint` function instead.",
         )
 
+    def on_save_checkpoint(self, checkpoint):
+        """Override checkpoint saving to facilitate EMA weights loading."""
+        super().on_save_checkpoint(checkpoint)
+        # this case checks for EMA weights, where we give up on
+        # the non-averaged weights in favor of the averaged ones
+        checkpoint["state_dict"] = self.state_dict()
+        if hasattr(self, "ema_module"):
+            logger.info("Replacing model weights with exponential moving average.")
+            for key, value in self.ema_module.state_dict().items():
+                if key != "n_averaged":
+                    # remove the module prefix for EMA state
+                    tree = key.split(".")
+                    renamed_key = ".".join(tree[1:])
+                    assert (
+                        renamed_key in checkpoint["state_dict"]
+                    ), f"Unexpected key in EMA module: {renamed_key}"
+                    checkpoint["state_dict"][renamed_key] = value
+            # now remove the redundant EMA weights to unblock checkpoint loading later
+            for key in list(checkpoint["state_dict"].keys()):
+                if "ema_module" in key:
+                    del checkpoint["state_dict"][key]
+
     @classmethod
     def from_pretrained_encoder(cls, task_ckpt_path: str | Path, **kwargs):
         """


### PR DESCRIPTION
This PR/commit fixes checkpoint saving in the round-trip process.

The problem lies with `ExponentialMovingAverageCallback` creating an `ema_module` attribute that is not normally part of tasks, otherwise leading to a lot of manual wrangling and remapping of `state_dict` when trying to load a checkpoint.

This PR addresses the issue by overriding `on_save_checkpoint` in `BaseTaskModule` and `MultiTaskLitModule`, where if there an `ema_module` exists at the time of checkpoint saving, we overwrite the corresponding `state_dict` tensors using the averaged weights.

This would impact training restarts since the weights are discontinuous, but the main intention of this is to facilitate easy reloading for inference.