### PR TITLE
Pytest Updates

### DIFF
--- a/examples/model_demos/mace_wrapper.py
+++ b/examples/model_demos/mace_wrapper.py
@@ -36,6 +36,7 @@ task = ScalarRegressionTask(
         "correlation": 1,
         "radial_type": "bessel",
         "gate": nn.Identity(),
+        "distance_transform": None,
     },
     task_keys=["energy_relaxed"],
 )

--- a/experiments/models/mace_pyg.yaml
+++ b/experiments/models/mace_pyg.yaml
@@ -25,6 +25,7 @@ encoder_kwargs:
   num_polynomial_cutoff: 5.0
   r_max: 6.0
   radial_type: bessel
+  distance_transform: None
   atomic_energies:
     class_path: torch.Tensor
     init_args:

--- a/matsciml/models/pyg/mace/wrapper/tests/test_mace_wrapper.py
+++ b/matsciml/models/pyg/mace/wrapper/tests/test_mace_wrapper.py
@@ -44,6 +44,7 @@ def mace_architecture() -> MACEWrapper:
         "correlation": 1,
         "radial_type": "bessel",
         "gate": nn.Identity(),
+        "distance_transform": None,
     }
     model = MACEWrapper(**model_config)
     return model

--- a/matsciml/models/pyg/tests/test_egnn.py
+++ b/matsciml/models/pyg/tests/test_egnn.py
@@ -63,7 +63,7 @@ def test_model_forward_nograd(dset_class_name: str, egnn_architecture: EGNN):
         Concrete EGNN object with some parameters
     """
     transforms = [
-        PeriodicPropertiesTransform(cutoff_radius=6.0),
+        PeriodicPropertiesTransform(cutoff_radius=6.0, adaptive_cutoff=True),
         PointCloudToGraphTransform("pyg"),
     ]
     dm = MatSciMLDataModule.from_devset(

--- a/matsciml/models/tests/test_multi_task.py
+++ b/matsciml/models/tests/test_multi_task.py
@@ -85,10 +85,10 @@ def test_multitask_init(is2re_s2ef, model_def):
     dm = is2re_s2ef
     encoder = model_def
     is2re = ScalarRegressionTask(encoder, task_keys=["energy_init", "energy_relaxed"])
-    s2ef = ForceRegressionTask(encoder, task_keys=["energy"])
+    s2ef = ForceRegressionTask(encoder, task_keys=["energy", "force"])
 
     # pass task keys to make sure output heads are created
-    task = MultiTaskLitModule(
+    _ = MultiTaskLitModule(
         ("IS2REDataset", is2re),
         ("S2EFDataset", s2ef),
         task_keys=dm.target_keys,


### PR DESCRIPTION
Recent changes from #254 and #256 warrant updating some pytests.

* Adding new kwarg to mace tests, example scripts, and experiment configs.
* Adding `adaptive_true` to a `PeriodicPropertiesTransform` used in one test.
* Adding `force` task_key inside one test that uses `ForceRegressionTask`.