### PR TITLE
Experiments - Arg Check Update

### DIFF
--- a/experiments/models/tests/test_model_creation.py
+++ b/experiments/models/tests/test_model_creation.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from experiments.utils.utils import instantiate_arg_dict
+
+from experiments.models import available_models
+
+models = list(available_models.keys())
+models.remove("generic")
+
+
+@pytest.mark.parametrize("model", models)
+def test_instantiate_model_dict(model):
+    model_dict = available_models[model]
+    instantiate_arg_dict(model_dict)

--- a/experiments/utils/utils.py
+++ b/experiments/utils/utils.py
@@ -3,17 +3,6 @@ import os
 
 import matsciml  # noqa: F401
 from matsciml.models.common import get_class_from_name
-from matsciml.common.inspection import get_model_all_args
-
-
-def verify_class_args(input_class, input_args):
-    print(input_class)
-    all_args = get_model_all_args(input_class)
-
-    for key in input_args:
-        assert (
-            key in all_args
-        ), f"{key} was passed as a kwarg but does not match expected arguments."
 
 
 def instantiate_arg_dict(input: Union[list, dict[str, Any]]) -> dict[str, Any]:

--- a/experiments/utils/utils.py
+++ b/experiments/utils/utils.py
@@ -7,6 +7,7 @@ from matsciml.common.inspection import get_model_all_args
 
 
 def verify_class_args(input_class, input_args):
+    print(input_class)
     all_args = get_model_all_args(input_class)
 
     for key in input_args:
@@ -45,7 +46,6 @@ def instantiate_arg_dict(input: Union[list, dict[str, Any]]) -> dict[str, Any]:
                 else:
                     transform_args = input_args
                 class_path = get_class_from_name(class_path)
-                verify_class_args(class_path, transform_args)
                 return class_path(**transform_args)
             if key == "encoder_class":
                 input[key] = get_class_from_name(value["class_path"])
@@ -53,7 +53,6 @@ def instantiate_arg_dict(input: Union[list, dict[str, Any]]) -> dict[str, Any]:
                 class_path = value["class_path"]
                 class_path = get_class_from_name(class_path)
                 input_args = value.get("init_args", {})
-                verify_class_args(class_path, input_args)
                 input[key] = class_path(**input_args)
             else:
                 input[key] = instantiate_arg_dict(value)


### PR DESCRIPTION
The arg checking in the experiments folder was causing problems. In a lot of cases such as `torch.Tensor` and `e3nn.nn.Irreps` the required args are not in the class `__init__` so the arg checking fails. Additionally, when models like `MACEWrapper` are checked for default args by looking at the encoder_kwargs, failures may occur due to a submodule sometimes being used (e.g. `ScaleShiftMACE`). The `MACEWrapper` already handles argument checking, and it seems to be overly complex for general input classes, so I am purging it for now.

Also adding a test for instantiating models, which would have caught this problem sooner. 