### PR TITLE
Implementing loss scaling scheduler callback and schedulers

### DIFF
--- a/examples/callbacks/loss_scheduling.py
+++ b/examples/callbacks/loss_scheduling.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytorch_lightning as pl
+
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    DistancesTransform,
+    PointCloudToGraphTransform,
+)
+from matsciml.lightning.data_utils import MatSciMLDataModule
+from matsciml.models import SchNet
+from matsciml.models.base import ScalarRegressionTask
+
+from matsciml.lightning.callbacks import LossScalingScheduler
+from matsciml.lightning.loss_scaling import SigmoidScalingSchedule
+
+"""
+This script demonstrates how to add loss scaling schedules
+to training runs.
+"""
+
+# construct a scalar regression task with SchNet encoder
+task = ScalarRegressionTask(
+    encoder_class=SchNet,
+    # kwargs to be passed into the creation of SchNet model
+    encoder_kwargs={
+        "encoder_only": True,
+        "hidden_feats": [128, 128, 128],
+        "atom_embedding_dim": 128,
+    },
+    output_kwargs={"lazy": False, "hidden_dim": 128, "input_dim": 128},
+    # which keys to use as targets
+    task_keys=["energy_relaxed"],
+)
+
+# Use IS2RE devset to test workflow
+# SchNet uses RBFs, and expects edge features corresponding to atom-atom distances
+dm = MatSciMLDataModule.from_devset(
+    "IS2REDataset",
+    dset_kwargs={
+        "transforms": [
+            PeriodicPropertiesTransform(6.0, True),
+            PointCloudToGraphTransform(
+                "dgl",
+                node_keys=["pos", "atomic_numbers"],
+            ),
+            DistancesTransform(),
+        ],
+    },
+)
+
+# run several epochs with a limited number of train batches
+# to make sure nothing breaks between updates
+trainer = pl.Trainer(
+    max_epochs=10,
+    limit_train_batches=10,
+    logger=False,
+    enable_checkpointing=False,
+    callbacks=[
+        LossScalingScheduler(
+            SigmoidScalingSchedule(
+                "energy_relaxed",
+                initial_value=10.0,  # the first value will not be this exactly
+                end_value=1.0,  # but close to it, due to nature of sigmoid
+                center_frac=0.5,  # this means the sigmoid flips at half the total steps
+                curvature=1e-7,  # can be modified to change ramping behavior
+                step_frequency="step",
+            ),
+            log_level="DEBUG",  # this makes it verbose, but setting it to INFO will surpress most
+        )
+    ],
+)
+trainer.fit(task, datamodule=dm)
+# print out the final scaling rates
+print(task.task_loss_scaling)

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -1496,7 +1496,7 @@ class ExponentialMovingAverageCallback(Callback):
 
 
 class LossScalingScheduler(Callback):
-    def __init__(self, *schedules: list[BaseScalingSchedule]) -> None:
+    def __init__(self, *schedules: BaseScalingSchedule) -> None:
         """
         Callback for dynamically adjusting loss scaling values over
         the course of training, a la curriculum learning.
@@ -1509,8 +1509,8 @@ class LossScalingScheduler(Callback):
 
         Parameters
         ----------
-        args : list[BaseScalingSchedule]
-            List of loss value schedulers.
+        args : BaseScalingSchedule
+            Scaling schedules for as many tasks as being performed.
         """
         super().__init__()
         assert len(schedules) > 0, "Must pass individual schedules to loss scheduler!"

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -32,6 +32,24 @@ from matsciml.models.base import BaseTaskModule
 from matsciml.common.types import Embeddings, BatchDict
 from matsciml.lightning.loss_scaling import BaseScalingSchedule
 
+__all__ = [
+    "LeaderboardWriter",
+    "GradientCheckCallback",
+    "UnusedParametersCallback",
+    "ThroughputCallback",
+    "ForwardNaNDetection",
+    "ManualGradientClip",
+    "MonitorGradients",
+    "GarbageCallback",
+    "InferenceWriter",
+    "CodeCarbonCallback",
+    "SAM",
+    "TrainingHelperCallback",
+    "ModelAutocorrelation",
+    "ExponentialMovingAverageCallback",
+    "LossScalingScheduler",
+]
+
 
 class LeaderboardWriter(BasePredictionWriter):
     """
@@ -1496,7 +1514,11 @@ class ExponentialMovingAverageCallback(Callback):
 
 
 class LossScalingScheduler(Callback):
-    def __init__(self, *schedules: BaseScalingSchedule) -> None:
+    def __init__(
+        self,
+        *schedules: BaseScalingSchedule,
+        log_level: Literal["INFO", "DEBUG", "WARNING", "CRITICAL"] = "INFO",
+    ) -> None:
         """
         Callback for dynamically adjusting loss scaling values over
         the course of training, a la curriculum learning.
@@ -1516,6 +1538,7 @@ class LossScalingScheduler(Callback):
         assert len(schedules) > 0, "Must pass individual schedules to loss scheduler!"
         self.schedules = schedules
         self._logger = getLogger("matsciml.loss_scaling_scheduler")
+        self._logger.setLevel(log_level)
         self._logger.debug(f"Configured {len(self.schedules)} schedules.")
         self._logger.debug(
             f"Schedules have {[s.key for s in self.schedules]} task keys."

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -1525,6 +1525,11 @@ class LossScalingScheduler(Callback):
         self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"
     ) -> None:
         for schedule in self.schedules:
+            # check to make sure the schedule key actually exists in the task
+            if schedule.key not in pl_module.task_loss_scaling:
+                raise KeyError(
+                    f"Schedule for {schedule.key} expected, but not specified as a task key!"
+                )
             # schedules grab what information they need from the
             # trainer and task modules
             schedule.setup(trainer, pl_module)

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -1526,7 +1526,7 @@ class LossScalingScheduler(Callback):
     ) -> None:
         for schedule in self.schedules:
             # check to make sure the schedule key actually exists in the task
-            if schedule.key not in pl_module.task_loss_scaling:
+            if schedule.key not in pl_module.task_keys:
                 raise KeyError(
                     f"Schedule for {schedule.key} expected, but not specified as a task key!"
                 )

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -1547,6 +1547,7 @@ class LossScalingScheduler(Callback):
     def on_fit_start(
         self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"
     ) -> None:
+        trainer.datamodule.setup("fit")
         for schedule in self.schedules:
             # check to make sure the schedule key actually exists in the task
             if schedule.key not in pl_module.task_keys:

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -1576,6 +1576,9 @@ class LossScalingScheduler(Callback):
                 try:
                     new_scaling_value = schedule.step()
                     pl_module.task_loss_scaling[target_key] = new_scaling_value
+                    self._logger.debug(
+                        f"Advanced {target_key} to new value: {new_scaling_value}"
+                    )
                 except StopIteration:
                     self._logger.warning(
                         f"{target_key} has run out of scheduled values; this may be unintentional."
@@ -1593,6 +1596,9 @@ class LossScalingScheduler(Callback):
                 try:
                     new_scaling_value = schedule.step()
                     pl_module.task_loss_scaling[target_key] = new_scaling_value
+                    self._logger.debug(
+                        f"Advanced {target_key} to new value: {new_scaling_value}"
+                    )
                 except StopIteration:
                     self._logger.warning(
                         f"{target_key} has run out of scheduled values; this may be unintentional."

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -123,3 +123,5 @@ class LinearScalingSchedule(BaseScalingSchedule):
             else:
                 num_steps = expected_epochs
             self.set_grid(num_steps)
+        # set the initial scaling value
+        pl_module.task_loss_scaling[self.key] = self.initial_value

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod, ABC
 from typing import Literal, Generator
+from functools import cached_property
 
 import numpy as np
 from pytorch_lightning import Trainer, LightningModule
@@ -84,7 +85,7 @@ class LinearScalingSchedule(BaseScalingSchedule):
         self.end_value = end_value
         self.step_frequency = step_frequency
 
-    @property
+    @cached_property
     def schedule(self) -> Generator[float, None, None]:
         delta = self.initial_value - self.end_value
         # linear ramp to go from initial to end values

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 from typing import Literal, Generator
 from functools import cached_property
+from logging import getLogger
 
 import numpy as np
 from pytorch_lightning import Trainer, LightningModule
@@ -168,8 +169,18 @@ class SigmoidScalingSchedule(BaseScalingSchedule):
         self.initial_value = initial_value
         self.end_value = end_value
         self.step_frequency = step_frequency
+        assert 0.0 < center_frac < 1.0, "Center fraction value must be between [0,1]"
         self.center_frac = center_frac
         self.curvature = curvature
+        self._logger = getLogger(f"matsciml.sigmoid_loss_scaling.{key}")
+        if curvature > 1e-2:
+            self._logger.warning(
+                "Curvature value is larger than expected; make sure this is intended!"
+            )
+        if curvature < 1e-9:
+            self._logger.warning(
+                "Curvature value is very small; make sure this is intended!"
+            )
 
     @staticmethod
     def sigmoid_curve(

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -87,9 +87,12 @@ class LinearScalingSchedule(BaseScalingSchedule):
 
     @cached_property
     def schedule(self) -> Generator[float, None, None]:
-        delta = self.initial_value - self.end_value
+        delta = np.abs(self.initial_value - self.end_value)
+        delta_values = self.grid * delta
+        if self.initial_value > self.end_value:
+            delta_values = np.negative(delta_values)
         # linear ramp to go from initial to end values
-        schedule = (self.grid * delta) + self.initial_value
+        schedule = delta_values + self.initial_value
         for value in schedule:
             yield value
 

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -76,14 +76,17 @@ class BaseScalingSchedule(ABC):
         pl_module : LightningModule
             Instances of a LightningModule; not used in this setup.
         """
-        if step_count := trainer.max_steps:
+        if (step_count := trainer.max_steps) > -1:
             self.set_grid(step_count)
         else:
-            train_loader = trainer.train_dataloader()
+            train_loader = trainer.datamodule.train_dataloader()
             # num_train_batches is how many batches loaded up per loader, per epoch
             expected_epochs = trainer.max_epochs
             if self.step_frequency == "step":
-                num_train_batches = len(train_loader)
+                if trainer.limit_train_batches <= 1.0:
+                    num_train_batches = len(train_loader)
+                else:
+                    num_train_batches = trainer.limit_train_batches
                 num_steps = int(num_train_batches * expected_epochs)
             else:
                 num_steps = expected_epochs

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -94,6 +94,9 @@ class BaseScalingSchedule(ABC):
         # set the initial scaling value
         pl_module.task_loss_scaling[self.key] = self.initial_value
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__} for {self.key} - start: {self.initial_value}, end: {self.end_value}"
+
 
 class LinearScalingSchedule(BaseScalingSchedule):
     def __init__(

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -6,6 +6,8 @@ from typing import Literal, Generator
 import numpy as np
 from pytorch_lightning import Trainer, LightningModule
 
+__all__ = ["LinearScalingSchedule"]
+
 
 class BaseScalingSchedule(ABC):
     """

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -7,7 +7,7 @@ from functools import cached_property
 import numpy as np
 from pytorch_lightning import Trainer, LightningModule
 
-__all__ = ["LinearScalingSchedule"]
+__all__ = ["LinearScalingSchedule", "SigmoidScalingSchedule"]
 
 
 class BaseScalingSchedule(ABC):

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -233,7 +233,7 @@ class SigmoidScalingSchedule(BaseScalingSchedule):
         """
         k_c = curvature**center_frac
         k_t = curvature**t
-        numerator = initial * k_c + end * k_t
+        numerator = end * k_c + initial * k_t
         denominator = k_c + k_t
         return numerator / denominator
 

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -63,10 +63,32 @@ class BaseScalingSchedule(ABC):
             "Must override `schedule` property and setter methods."
         )
 
-    @abstractmethod
     def setup(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        """Configures the schedule by grabbing whatever is needed from trainer/module"""
-        ...
+        """
+        This configures the grid based on either the total number of
+        projected steps or epochs, depending on what was specified.
+
+        Parameters
+        ----------
+        trainer : Trainer
+            Instance of a PyTorch Lightning trainer.
+        pl_module : LightningModule
+            Instances of a LightningModule; not used in this setup.
+        """
+        if step_count := trainer.max_steps:
+            self.set_grid(step_count)
+        else:
+            train_loader = trainer.train_dataloader()
+            # num_train_batches is how many batches loaded up per loader, per epoch
+            expected_epochs = trainer.max_epochs
+            if self.step_frequency == "step":
+                num_train_batches = len(train_loader)
+                num_steps = int(num_train_batches * expected_epochs)
+            else:
+                num_steps = expected_epochs
+            self.set_grid(num_steps)
+        # set the initial scaling value
+        pl_module.task_loss_scaling[self.key] = self.initial_value
 
 
 class LinearScalingSchedule(BaseScalingSchedule):
@@ -98,30 +120,3 @@ class LinearScalingSchedule(BaseScalingSchedule):
 
     def set_grid(self, total_steps: int, *args, **kwargs) -> None:
         self._grid = np.linspace(0.0, 1.0, total_steps)
-
-    def setup(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        """
-        This configures the grid based on either the total number of
-        projected steps or epochs, depending on what was specified.
-
-        Parameters
-        ----------
-        trainer : Trainer
-            Instance of a PyTorch Lightning trainer.
-        pl_module : LightningModule
-            Instances of a LightningModule; not used in this setup.
-        """
-        if step_count := trainer.max_steps:
-            self.set_grid(step_count)
-        else:
-            train_loader = trainer.train_dataloader()
-            # num_train_batches is how many batches loaded up per loader, per epoch
-            expected_epochs = trainer.max_epochs
-            if self.step_frequency == "step":
-                num_train_batches = len(train_loader)
-                num_steps = int(num_train_batches * expected_epochs)
-            else:
-                num_steps = expected_epochs
-            self.set_grid(num_steps)
-        # set the initial scaling value
-        pl_module.task_loss_scaling[self.key] = self.initial_value

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -81,3 +81,11 @@ class LinearScalingSchedule(BaseScalingSchedule):
             end_value = initial_value
         self.end_value = end_value
         self.step_frequency = step_frequency
+
+    @property
+    def schedule(self) -> Generator[float, None, None]:
+        delta = self.initial_value - self.end_value
+        # linear ramp to go from initial to end values
+        schedule = (self.grid * delta) + self.initial_value
+        for value in schedule:
+            yield value

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -16,6 +16,15 @@ class BaseScalingSchedule(ABC):
     """
 
     @property
+    def key(self) -> str:
+        """References the target key this scaling value maps to."""
+        return self._key
+
+    @key.setter
+    def key(self, value: str) -> None:
+        self._key = value
+
+    @property
     def grid(self) -> np.ndarray:
         return self._grid
 

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from abc import abstractmethod, ABC
+from typing import Literal, Generator
+
+from pytorch_lightning import Trainer, LightningModule
+
+
+class BaseScalingSchedule(ABC):
+    """
+    Implements the abstract class for scaling schedulers.
+
+    Subclasses will implement the actual schedules, and all of
+    the boilerplate (e.g. setup and step methods) are lifted here.
+    """
+
+    @property
+    def step_frequency(self) -> Literal["step", "epoch"]:
+        return self._step_frequency
+
+    @step_frequency.setter
+    def step_frequency(self, value: Literal["step", "epoch"]) -> None:
+        assert value in [
+            "step",
+            "epoch",
+        ], "Invalid step frequency; only step/epoch are supported."
+        self._step_frequency = value
+
+    def step(self) -> float:
+        """Function that returns a value at some point in time."""
+        return next(self.schedule)
+
+    @property
+    @abstractmethod
+    def schedule(self) -> Generator[float, None, None]:
+        raise NotImplementedError(
+            "Must override `schedule` property and setter methods."
+        )
+
+    @abstractmethod
+    def setup(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Configures the schedule by grabbing whatever is needed from trainer/module"""
+        ...

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -132,6 +132,37 @@ class SigmoidScalingSchedule(BaseScalingSchedule):
         curvature: float = 5e-7,
         step_frequency: Literal["step", "epoch"] = "step",
     ) -> None:
+        """
+        Schedules a sigmoidal scheduling curve.
+
+        This provides an exponential ramp between initial and
+        end values, with controllable turning point and rate
+        of change.
+
+        Parameters
+        ----------
+        key : str
+            Task key that this schedule maps to.
+        initial : float
+            Value of the left asymptote; i.e. for t < 0.
+        end : float
+            Value of the right asymptote; i.e. for t > 0.
+        center_frac : float
+            For t in [0,1], this is the turning point of the
+            curve. Assuming this range spans the whole training
+            run, 0.5 would place the turning point at half the
+            epochs/training steps.
+        curvature : float
+            The rate at which the values change. Small values of `curvature`
+            (in orders of magnitude) increases the rate of change such that
+            the changeover becomes much more abrupt, spending more steps/epochs
+            closer to their asymptotes. Values between 1e-2 and 1e-9 are
+            recommended; larger values will have a very gradual ramp up but
+            will not necessarily obey the initial value exactly.
+        step_frequency : Literal['step', 'epoch']
+            Frequency at which this schedule works. This dictates
+            the number of grid points we expect to ramp with.
+        """
         super().__init__()
         self.key = key
         self.initial_value = initial_value
@@ -157,7 +188,7 @@ class SigmoidScalingSchedule(BaseScalingSchedule):
         change determined by curvature.
 
         The explicit assumption  here is that all of the 'action' occurs
-        between t \in [0,1], although it is defined beyond those ranges
+        between t in [0,1], although it is defined beyond those ranges
         (i.e. the initial and end values).
 
         Parameters

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 from typing import Literal, Generator
 
+import numpy as np
 from pytorch_lightning import Trainer, LightningModule
 
 
@@ -13,6 +14,19 @@ class BaseScalingSchedule(ABC):
     Subclasses will implement the actual schedules, and all of
     the boilerplate (e.g. setup and step methods) are lifted here.
     """
+
+    @property
+    def grid(self) -> np.ndarray:
+        return self._grid
+
+    @abstractmethod
+    def set_grid(self, *args, **kwargs) -> None:
+        raise NotImplementedError(
+            "Requires concrete method of computing time grid for scheduling."
+        )
+
+    def __len__(self) -> int:
+        return len(self.grid)
 
     @property
     def step_frequency(self) -> Literal["step", "epoch"]:

--- a/matsciml/lightning/loss_scaling.py
+++ b/matsciml/lightning/loss_scaling.py
@@ -64,3 +64,20 @@ class BaseScalingSchedule(ABC):
     def setup(self, trainer: Trainer, pl_module: LightningModule) -> None:
         """Configures the schedule by grabbing whatever is needed from trainer/module"""
         ...
+
+
+class LinearScalingSchedule(BaseScalingSchedule):
+    def __init__(
+        self,
+        key: str,
+        initial_value: float,
+        end_value: float | None = None,
+        step_frequency: Literal["step", "epoch"] = "epoch",
+    ) -> None:
+        super().__init__()
+        self.key = key
+        self.initial_value = initial_value
+        if not end_value:
+            end_value = initial_value
+        self.end_value = end_value
+        self.step_frequency = step_frequency

--- a/matsciml/lightning/tests/test_loss_scaling_schedules.py
+++ b/matsciml/lightning/tests/test_loss_scaling_schedules.py
@@ -22,7 +22,7 @@ from matsciml.datasets.transforms import (
 def task_and_dm():
     t = ScalarRegressionTask(
         encoder_class=EGNN,
-        encoder_kwargs={"hidden_dim": 128, "output_dim": 64},
+        encoder_kwargs={"hidden_dim": 128, "output_dim": 64, "num_conv": 1},
         task_keys=["energy"],
     )
     dm = MatSciMLDataModule.from_devset(

--- a/matsciml/lightning/tests/test_loss_scaling_schedules.py
+++ b/matsciml/lightning/tests/test_loss_scaling_schedules.py
@@ -64,7 +64,7 @@ def test_linear_schedule_with_trainer(task_and_dm):
 
 
 def test_linear_schedule_with_bad_key(task_and_dm):
-    """Tests that the linear schedule works under intended conditions."""
+    """Tests that the linear schedule breaks if the key doesn't match task."""
     task, dm = task_and_dm
     sched_callback = LossScalingScheduler(
         LinearScalingSchedule("non-existent-key", 1.0, 10.0, "step"),
@@ -75,7 +75,7 @@ def test_linear_schedule_with_bad_key(task_and_dm):
 
 
 def test_linear_schedule_with_epoch_step(task_and_dm):
-    """Tests that the linear schedule works under intended conditions."""
+    """Tests that the epoch linear schedule doesn't trigger when we only step."""
     task, dm = task_and_dm
     sched_callback = LossScalingScheduler(
         LinearScalingSchedule("energy", 1.0, 10.0, "epoch"),

--- a/matsciml/lightning/tests/test_loss_scaling_schedules.py
+++ b/matsciml/lightning/tests/test_loss_scaling_schedules.py
@@ -57,6 +57,8 @@ def test_linear_schedule_with_trainer(task_and_dm):
     )
     trainer = Trainer(fast_dev_run=10, callbacks=sched_callback)
     trainer.fit(task, datamodule=dm)
+    scheduler = sched_callback.schedules[0]
+    assert task.task_loss_scaling["energy"] != scheduler.initial_value
 
 
 def test_linear_schedule_with_bad_key(task_and_dm):

--- a/matsciml/lightning/tests/test_loss_scaling_schedules.py
+++ b/matsciml/lightning/tests/test_loss_scaling_schedules.py
@@ -57,3 +57,14 @@ def test_linear_schedule_with_trainer(task_and_dm):
     )
     trainer = Trainer(fast_dev_run=10, callbacks=sched_callback)
     trainer.fit(task, datamodule=dm)
+
+
+def test_linear_schedule_with_bad_key(task_and_dm):
+    """Tests that the linear schedule works under intended conditions."""
+    task, dm = task_and_dm
+    sched_callback = LossScalingScheduler(
+        LinearScalingSchedule("non-existent-key", 1.0, 10.0, "step"),
+    )
+    trainer = Trainer(fast_dev_run=10, callbacks=sched_callback)
+    with pytest.raises(KeyError):
+        trainer.fit(task, datamodule=dm)

--- a/matsciml/lightning/tests/test_loss_scaling_schedules.py
+++ b/matsciml/lightning/tests/test_loss_scaling_schedules.py
@@ -58,7 +58,9 @@ def test_linear_schedule_with_trainer(task_and_dm):
     trainer = Trainer(fast_dev_run=10, callbacks=sched_callback)
     trainer.fit(task, datamodule=dm)
     scheduler = sched_callback.schedules[0]
+    # make sure that the scaling values are set correctly
     assert task.task_loss_scaling["energy"] != scheduler.initial_value
+    assert task.task_loss_scaling["energy"] == scheduler.end_value
 
 
 def test_linear_schedule_with_bad_key(task_and_dm):

--- a/matsciml/lightning/tests/test_loss_scaling_schedules.py
+++ b/matsciml/lightning/tests/test_loss_scaling_schedules.py
@@ -127,4 +127,4 @@ def test_sigmoid_schedule_with_trainer(task_and_dm):
     )
     # make sure the value is close-ish to the end value, not exactly
     # due to curvature
-    assert per_error > 0.85
+    assert per_error < 0.01

--- a/matsciml/lightning/tests/test_loss_scaling_schedules.py
+++ b/matsciml/lightning/tests/test_loss_scaling_schedules.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+import numpy as np
+
+from matsciml.lightning.loss_scaling import LinearScalingSchedule
+from matsciml.models.pyg import EGNN
+from matsciml.models import ScalarRegressionTask
+from matsciml.lightning import MatSciMLDataModule
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+
+
+@pytest.fixture
+def task_and_dm():
+    t = ScalarRegressionTask(
+        encoder_class=EGNN,
+        encoder_kwargs={"hidden_dim": 128, "output_dim": 64},
+        task_keys=["energy"],
+    )
+    dm = MatSciMLDataModule.from_devset(
+        "LiPSDataset",
+        dset_kwargs={
+            "transforms": [
+                PeriodicPropertiesTransform(6.0, True),
+                PointCloudToGraphTransform(
+                    "pyg", node_keys=["pos", "atomic_numbers", "force"]
+                ),
+            ]
+        },
+    )
+    return t, dm
+
+
+@pytest.mark.parametrize("initial", (0.5, 1.5, 5.0))
+@pytest.mark.parametrize("end", (2.0, 0.5, 100.0))
+@pytest.mark.parametrize("num_steps", (10, 100, 5000))
+def test_linear_schedule_without_trainer(initial, end, num_steps):
+    sched = LinearScalingSchedule("test", initial, end)
+    sched.set_grid(num_steps)
+    rates = [sched.step() for _ in range(len(sched))]
+    assert rates
+    assert len(rates) == num_steps
+    expected = np.linspace(initial, end, num_steps)
+    assert np.allclose(np.array(rates), expected)

--- a/matsciml/lightning/tests/test_loss_scaling_schedules.py
+++ b/matsciml/lightning/tests/test_loss_scaling_schedules.py
@@ -55,7 +55,7 @@ def test_linear_schedule_with_trainer(task_and_dm):
     sched_callback = LossScalingScheduler(
         LinearScalingSchedule("energy", 1.0, 10.0, "step"),
     )
-    trainer = Trainer(fast_dev_run=10, callbacks=sched_callback)
+    trainer = Trainer(fast_dev_run=5, callbacks=sched_callback)
     trainer.fit(task, datamodule=dm)
     scheduler = sched_callback.schedules[0]
     # make sure that the scaling values are set correctly
@@ -72,3 +72,16 @@ def test_linear_schedule_with_bad_key(task_and_dm):
     trainer = Trainer(fast_dev_run=10, callbacks=sched_callback)
     with pytest.raises(KeyError):
         trainer.fit(task, datamodule=dm)
+
+
+def test_linear_schedule_with_epoch_step(task_and_dm):
+    """Tests that the linear schedule works under intended conditions."""
+    task, dm = task_and_dm
+    sched_callback = LossScalingScheduler(
+        LinearScalingSchedule("energy", 1.0, 10.0, "epoch"),
+    )
+    trainer = Trainer(fast_dev_run=5, callbacks=sched_callback)
+    trainer.fit(task, datamodule=dm)
+    scheduler = sched_callback.schedules[0]
+    # since we step at an epoch rate, this shouldn't have changed
+    assert task.task_loss_scaling["energy"] == scheduler.initial_value


### PR DESCRIPTION
This PR adds a new callback, called `LossScalingScheduler`, and scheduler classes that will modify the relative loss weights over the course of training.

- Two types of schedulers are implemented: `LinearScalingSchedule` and `SigmoidScalingSchedule`. The former will generate a linear ramp from start to end over steps or epochs, and the latter gives a gradual ramp up in the form of a sigmoid curve.
- The `LossScalingScheduler` is configured by passing schedules that are mapped to task keys, and for every training step or epoch (set by the schedules), applies a new value of the weighting to the appropriate task.
- The example script `examples/callbacks/loss_scheduling.py` is provided to show how it is configured.

This is useful for implementing curricula, where we prioritize learning of different properties over time.