### PR TITLE
Allow Loading of Checkpoints in Experiments Pipeline

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -21,6 +21,27 @@ dataset:
       - energy
 ```
 
+### Checkpoint Loading
+Pretrained model checkpoints may be loaded for use in downstream tasks. Models can be loaded and used *as-is*, or only the encoder may be used.
+
+To load a checkpoint, add the `load_weights` field to the experiment config:
+```yaml
+model: egnn_dgl
+dataset:
+  oqmd:
+    - task: ScalarRegressionTask
+      targets:
+       - energy
+load_weights:
+   method: checkpoint
+   type: local
+   path: ./path/to/checkpoint
+```
+* `method` specifies whether to use the model *as-is* (`checkpoint`), or *encoder-only* (`pretrained`) in the checkpoint.
+* `type` specifies where to load the checkpoint from. Currently only locally stored checkpoints may be used.
+* `path` points to the location of the checkpoint.
+
+
 In general, and experiment may the be launched by running:
 `python experiments/training_script.py --experiment_config ./experiments/configs/single_task.yaml`
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -38,8 +38,8 @@ load_weights:
    path: ./path/to/checkpoint
 ```
 * `method` specifies whether to use the model *as-is* (`checkpoint`), or *encoder-only* (`pretrained`) in the checkpoint.
-* `type` specifies where to load the checkpoint from. Currently only locally stored checkpoints may be used.
-* `path` points to the location of the checkpoint.
+* `type` specifies where to load the checkpoint from (`local`, or `wandb`).
+* `path` points to the location of the checkpoint. WandB checkpoints may be specified by pointing to the model artifact, typically specified by: `entity-name/project-name/model-version:number`
 
 
 In general, and experiment may the be launched by running:

--- a/experiments/task_config/task_config.py
+++ b/experiments/task_config/task_config.py
@@ -57,17 +57,19 @@ def load_from_checkpoint(
     method = load_config["method"]
     load_type = load_config["type"]
     if not isinstance(task, MultiTaskLitModule):
-        if load_type == "local":
-            if method == "checkpoint":
-                task = task.load_from_checkpoint(ckpt)
-            if method == "pretrained":
-                task = task.from_pretrained_encoder(ckpt, **task_args)
         if load_type == "wandb":
             # creates lightning wandb logger object and a new run
             wandb_logger = get_wandb_logger()
             artifact = Path(wandb_logger.download_artifact(ckpt))
-            task = task.load_from_checkpoint(artifact.joinpath("model.ckpt"))
-
+            ckpt = artifact.joinpath("model.ckpt")
+        if method == "checkpoint":
+            task = task.load_from_checkpoint(ckpt)
+        elif method == "pretrained":
+            task = task.from_pretrained_encoder(ckpt, **task_args)
+        else:
+            raise Exception(
+                "Unsupported method for loading checkpoint. Must be 'checkpoint' or 'pretrained'"
+            )
     else:
         task = multitask_from_checkpoint(ckpt)
     return task


### PR DESCRIPTION
This PR addressed #263 for loading checkpoints using the experiments cli. Local or WandB stored checkpoints may be loaded and used for continual training, or encoder weight transfer to a new task. Checkpoints associated with training from the `MultiTaskLitModule` are processed using `matsciml.models.multitask_from_checkpoint` which has limited functionality at the moment, and is only suited for continuing training.