### PR TITLE
Matgl upgrade to 1.1.3 + CHGNet Integration

### DIFF
--- a/experiments/configs/models/chgnet_dgl.yaml
+++ b/experiments/configs/models/chgnet_dgl.yaml
@@ -1,5 +1,5 @@
 encoder_class:
-  class_path: matsciml.models.M3GNet
+  class_path: matsciml.models.CHGNet
 encoder_kwargs:
   element_types:
     class_path: matsciml.datasets.utils.element_types

--- a/experiments/configs/models/chgnet_dgl.yaml
+++ b/experiments/configs/models/chgnet_dgl.yaml
@@ -1,0 +1,22 @@
+encoder_class:
+  class_path: matsciml.models.M3GNet
+encoder_kwargs:
+  element_types:
+    class_path: matsciml.datasets.utils.element_types
+output_kwargs:
+  lazy: False
+  input_dim: 64
+  hidden_dim: 64
+transforms:
+  - class_path: matsciml.datasets.transforms.PeriodicPropertiesTransform
+    init_args:
+      cutoff_radius: 6.5
+      adaptive_cutoff: True
+  - class_path: matsciml.datasets.transforms.PointCloudToGraphTransform
+    init_args:
+      backend: dgl
+      cutoff_dist: 20.0
+      node_keys:
+        - "pos"
+        - "atomic_numbers"
+  - class_path: matsciml.datasets.transforms.MGLDataTransform

--- a/matsciml/models/dgl/__init__.py
+++ b/matsciml/models/dgl/__init__.py
@@ -14,6 +14,7 @@ if package_registry["dgl"]:
     from matsciml.models.dgl.mpnn import MPNN
     from matsciml.models.dgl.schnet_dgl import SchNet
     from matsciml.models.dgl.tensornet import TensorNet
+    from matsciml.models.dgl.chgnet import CHGNet
 
     __all__ = [
         "DimeNetPP",
@@ -25,4 +26,5 @@ if package_registry["dgl"]:
         "MPNN",
         "SchNet",
         "TensorNet",
+        "CHGNet",
     ]

--- a/matsciml/models/dgl/chgnet.py
+++ b/matsciml/models/dgl/chgnet.py
@@ -55,8 +55,6 @@ class CHGNet(AbstractDGLModel, MGLCHGNet):
         Returns:
             torch.Tensor: Model output.
         """
-        # g.edata["pbc_offshift"] = g.edata["offsets"]
-        # g.ndata["node_type"] = g.ndata["atomic_numbers"].long()
         # compute bond vectors and distances and add to g, needs to be computed here to register gradients
         bond_vec, bond_dist = compute_pair_vector_and_distance(g)
         g.edata["bond_vec"] = bond_vec.to(g.device)

--- a/matsciml/models/dgl/chgnet.py
+++ b/matsciml/models/dgl/chgnet.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import dgl
+from dgl import readout_edges, readout_nodes
+import torch
+
+from matgl.graph.compute import (
+    compute_pair_vector_and_distance,
+    compute_theta,
+    create_line_graph,
+    ensure_line_graph_compatibility,
+)
+from matgl.utils.cutoff import polynomial_cutoff
+from matgl.models import CHGNet as MGLCHGNet
+
+from matsciml.common.types import Embeddings
+from matsciml.common.registry import registry
+from matsciml.models.base import AbstractDGLModel
+
+__all__ = ["CHGNet"]
+
+
+@registry.register_model("CHGNet")
+class CHGNet(AbstractDGLModel, MGLCHGNet):
+    def __init__(self, element_types: list[str], *args, **kwargs):
+        super().__init__(atom_embedding_dim=len(element_types))
+        self.atom_embedding = MGLCHGNet(element_types).atom_embedding
+        self.element_types = element_types
+
+    def _forward(
+        self,
+        graph: dgl.DGLGraph,
+        node_feats: torch.Tensor,
+        edge_feats: torch.Tensor,
+        graph_feats: torch.Tensor,
+        pos: torch.Tensor | None = None,
+        **kwargs,
+    ) -> Embeddings:
+        outputs = self.chgnet_forward(graph, **kwargs)
+        return Embeddings(outputs[0], outputs[1])
+
+    def chgnet_forward(
+        self,
+        g: dgl.DGLGraph,
+        state_attr: torch.Tensor | None = None,
+        l_g: dgl.DGLGraph | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Forward pass of the model.
+
+        Args:
+            g (dgl.DGLGraph): Input g.
+            state_attr (torch.Tensor, optional): State features. Defaults to None.
+            l_g (dgl.DGLGraph, optional): Line graph. Defaults to None and is computed internally.
+
+        Returns:
+            torch.Tensor: Model output.
+        """
+        # g.edata["pbc_offshift"] = g.edata["offsets"]
+        # g.ndata["node_type"] = g.ndata["atomic_numbers"].long()
+        # compute bond vectors and distances and add to g, needs to be computed here to register gradients
+        bond_vec, bond_dist = compute_pair_vector_and_distance(g)
+        g.edata["bond_vec"] = bond_vec.to(g.device)
+        g.edata["bond_dist"] = bond_dist.to(g.device)
+        bond_expansion = self.bond_expansion(bond_dist)
+        smooth_cutoff = polynomial_cutoff(
+            bond_expansion, self.cutoff, self.cutoff_exponent
+        )
+        g.edata["bond_expansion"] = smooth_cutoff * bond_expansion
+
+        # create bond graph (line graoh) with necessary node and edge data
+        if l_g is None:
+            bond_graph = create_line_graph(g, self.three_body_cutoff, directed=True)
+        else:
+            # need to ensure the line graph matches the graph
+            bond_graph = ensure_line_graph_compatibility(
+                g, l_g, self.three_body_cutoff, directed=True
+            )
+
+        bond_graph.ndata["bond_index"] = bond_graph.ndata["edge_ids"]
+        threebody_bond_expansion = self.threebody_bond_expansion(
+            bond_graph.ndata["bond_dist"]
+        )
+        smooth_cutoff = polynomial_cutoff(
+            threebody_bond_expansion, self.three_body_cutoff, self.cutoff_exponent
+        )
+        bond_graph.ndata["bond_expansion"] = smooth_cutoff * threebody_bond_expansion
+        # the center atom is the dst atom of the src bond or the reverse (the src atom of the dst bond)
+        # need to use "bond_index" just to be safe always
+        bond_indices = bond_graph.ndata["bond_index"][bond_graph.edges()[0]]
+        bond_graph.edata["center_atom_index"] = g.edges()[1][bond_indices]
+        bond_graph.apply_edges(compute_theta)
+        bond_graph.edata["angle_expansion"] = self.angle_expansion(
+            bond_graph.edata["theta"]
+        )
+
+        # compute state, atom, bond and angle embeddings
+        atom_features = self.atom_embedding(g.ndata["node_type"])
+        bond_features = self.bond_embedding(g.edata["bond_expansion"])
+        angle_features = self.angle_embedding(bond_graph.edata["angle_expansion"])
+        if self.state_embedding is not None and state_attr is not None:
+            state_attr = self.state_embedding(state_attr)
+        else:
+            state_attr = None
+
+        # shared message weights
+        atom_bond_weights = (
+            self.atom_bond_weights(g.edata["bond_expansion"])
+            if self.atom_bond_weights is not None
+            else None
+        )
+        bond_bond_weights = (
+            self.bond_bond_weights(g.edata["bond_expansion"])
+            if self.bond_bond_weights is not None
+            else None
+        )
+        threebody_bond_weights = (
+            self.threebody_bond_weights(bond_graph.ndata["bond_expansion"])
+            if self.threebody_bond_weights is not None
+            else None
+        )
+
+        # message passing layers
+        for i in range(self.n_blocks - 1):
+            atom_features, bond_features, state_attr = self.atom_graph_layers[i](
+                g,
+                atom_features,
+                bond_features,
+                state_attr,
+                atom_bond_weights,
+                bond_bond_weights,
+            )
+            bond_features, angle_features = self.bond_graph_layers[i](
+                bond_graph,
+                atom_features,
+                bond_features,
+                angle_features,
+                threebody_bond_weights,
+            )
+
+        # site wise target readout
+        g.ndata["magmom"] = self.sitewise_readout(atom_features)
+
+        # last atom graph message passing layer
+        atom_features, bond_features, state_attr = self.atom_graph_layers[-1](
+            g,
+            atom_features,
+            bond_features,
+            state_attr,
+            atom_bond_weights,
+            bond_bond_weights,
+        )
+
+        # really only needed if using the readout modules in _readout.py
+        # g.ndata["node_feat"] = atom_features
+        # g.edata["edge_feat"] = bond_features
+        # bond_graph.edata["angle_features"] = angle_features
+
+        # readout
+        if self.readout_field == "atom_feat":
+            g.ndata["atom_feat"] = self.final_layer(atom_features)
+            structure_properties = readout_nodes(
+                g, "atom_feat", op=self.readout_operation
+            )
+        elif self.readout_field == "bond_feat":
+            g.edata["bond_feat"] = self.final_layer(bond_features)
+            structure_properties = readout_edges(
+                g, "bond_feat", op=self.readout_operation
+            )
+        else:  # self.readout_field == "angle_feat":
+            bond_graph.edata["angle_feat"] = self.final_layer(angle_features)
+            structure_properties = readout_edges(
+                bond_graph, "angle_feat", op=self.readout_operation
+            )
+
+        structure_properties = torch.squeeze(structure_properties)
+        matsciml_output = (structure_properties, atom_features)
+        return matsciml_output

--- a/matsciml/models/dgl/m3gnet.py
+++ b/matsciml/models/dgl/m3gnet.py
@@ -24,7 +24,7 @@ class M3GNet(AbstractDGLModel):
         self, element_types: list[str], return_all_layer_output: bool, *args, **kwargs
     ):
         super().__init__(atom_embedding_dim=len(element_types))
-        self.elemenet_types = element_types
+        self.element_types = element_types
         self.all_embeddings = return_all_layer_output
         self.model = matgl_m3gnet(element_types, *args, **kwargs)
         self.atom_embedding = self.model.embedding.layer_node_embedding

--- a/matsciml/models/dgl/tests/test_chgnet.py
+++ b/matsciml/models/dgl/tests/test_chgnet.py
@@ -1,0 +1,104 @@
+import pytest
+import pytorch_lightning as pl
+
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+    MGLDataTransform,
+)
+from matsciml.lightning import MatSciMLDataModule
+from matsciml.common.registry import registry
+from matsciml.models import CHGNet
+from matsciml.datasets.utils import element_types
+from matsciml.models.base import ForceRegressionTask, GradFreeForceRegressionTask
+
+import torch
+
+
+# fixture for some nominal set of hyperparameters that can be used
+# across datasets
+@pytest.fixture
+def model_fixture() -> CHGNet:
+    model = CHGNet(element_types=element_types())
+    return model
+
+
+@pytest.fixture
+def devset_fixture() -> MatSciMLDataModule:
+    devset = MatSciMLDataModule.from_devset(
+        "S2EFDataset",
+        dset_kwargs={
+            "transforms": [
+                PeriodicPropertiesTransform(cutoff_radius=10.0),
+                PointCloudToGraphTransform(
+                    "dgl",
+                    cutoff_dist=20.0,
+                    node_keys=["pos", "atomic_numbers"],
+                ),
+                MGLDataTransform(),
+            ],
+        },
+    )
+    return devset
+
+
+# here we filter out datasets from the registry that don't make sense
+ignore_dset = ["Multi", "PyG", "Cdvae", "SyntheticPointGroupDataset"]
+filtered_list = list(
+    filter(
+        lambda x: all([target_str not in x for target_str in ignore_dset]),
+        registry.__entries__["datasets"].keys(),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "dset_class_name",
+    filtered_list,
+)
+def test_model_forward_nograd(dset_class_name: str, model_fixture: CHGNet):
+    transforms = [
+        PeriodicPropertiesTransform(cutoff_radius=6.0),
+        PointCloudToGraphTransform("dgl"),
+        MGLDataTransform(),
+    ]
+    dm = MatSciMLDataModule.from_devset(
+        dset_class_name,
+        batch_size=8,
+        dset_kwargs={"transforms": transforms},
+    )
+    # dummy initialization
+    dm.setup("fit")
+    loader = dm.train_dataloader()
+    batch = next(iter(loader))
+    # run the model without gradient tracking
+    with torch.no_grad():
+        embeddings = model_fixture(batch)
+    # returns embeddings, and runs numerical checks
+    for z in [embeddings.system_embedding, embeddings.point_embedding]:
+        assert torch.isreal(z).all()
+        assert ~torch.isnan(z).all()  # check there are no NaNs
+        assert torch.isfinite(z).all()
+        assert torch.all(torch.abs(z) <= 1000)  # ensure reasonable values
+
+
+def test_force_regression(model_fixture, devset_fixture):
+    task = ForceRegressionTask(
+        model_fixture, output_kwargs={"lazy": False, "input_dim": 64, "hidden_dim": 64}
+    )
+    trainer = pl.Trainer(fast_dev_run=10)
+    trainer.fit(task, datamodule=devset_fixture)
+    # make sure losses are tracked
+    for key in ["energy", "force"]:
+        assert f"train_{key}" in trainer.logged_metrics
+
+
+def test_gradfree_force_regression(model_fixture, devset_fixture):
+    task = GradFreeForceRegressionTask(
+        model_fixture,
+        output_kwargs={"lazy": False, "input_dim": 64, "hidden_dim": 64},
+    )
+    trainer = pl.Trainer(fast_dev_run=10)
+    trainer.fit(task, datamodule=devset_fixture)
+    # make sure losses are tracked
+    assert "train_force" in trainer.logged_metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "pymatgen==2024.3.1",
   "schema>=0.7.5",
   "ase>=3.22.1",
-  "matgl==1.0.0",
+  "matgl==1.1.3",
   "einops==0.8.0",
   "mendeleev==0.17.0",
   "e3nn",


### PR DESCRIPTION
This PR takes over dependabot PR #269 and also includes the addition of CHGNet from `matgl` which was introduced in `matgl-v1.1.0`. The PR also includes updates to `TensorNet` forward pass which still must be copied in manually.  