### PR TITLE
SAM callback step/epoch skipping configuration

### DIFF
--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -716,6 +716,7 @@ class SAM(Callback):
         skip_step_count: int | None = None,
         skip_epoch_count: int | float | None = None,
         logging: bool = False,
+        log_level: Literal["DEBUG", "INFO", "WARNING"] = "WARNING",
     ) -> None:
         """
         Set up the ``SAM (Sharpness Aware Minimization)`` callback.
@@ -756,6 +757,12 @@ class SAM(Callback):
         logging : bool, default False
             If set to True, logs the behavior of SAM to console. This is useful
             for debugging.
+        log_level: Literal["INFO", "DEBUG", "WARNING"], default "WARNING"
+            Sets the logging level if logging is specified. By default the
+            level is set to warnings, which will not report when SAM is not running
+            but still warn the user when the gradient norm is smaller than
+            machine epsilon. Set the level to "INFO" or lower if you wish to
+            check when SAM is *not* running.
 
         Examples
         --------
@@ -781,7 +788,7 @@ class SAM(Callback):
         self.skip_epoch_count = skip_epoch_count
         if logging:
             self.logger = getLogger("matsciml.callbacks.SAM")
-            self.logger.setLevel("INFO")
+            self.logger.setLevel(log_level)
         else:
             self.logger = None
 

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -847,13 +847,13 @@ class SAM(Callback):
         current_epoch = trainer.current_epoch
         # by default we start SAM, and toggle off if conditions met
         start_sam = True
-        if self.skip_epoch_count and not self.skip_epoch_count < current_epoch:
+        if self.skip_epoch_count and current_epoch < self.skip_epoch_count:
             start_sam = False
             if self.logger:
                 self.logger.info(
                     "Required number of epochs not met; not running SAM yet."
                 )
-        if self.skip_step_count and not self.skip_step_count < current_step:
+        if self.skip_step_count and current_step < self.skip_step_count:
             start_sam = False
             if self.logger:
                 self.logger.info(

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -803,6 +803,8 @@ class SAM(Callback):
         # an integer count for easier comparison
         if self.skip_epoch_count and not self.skip_epoch_count.is_integer():
             self.skip_epoch_count = int(self.max_epochs * self.skip_epoch_count)
+        # add floating point epsilon for later use
+        self.epsilon = torch.finfo(pl_module.dtype).eps
 
     @staticmethod
     def _get_params(optimizer: Optimizer) -> Iterator[torch.Tensor]:

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -781,6 +781,7 @@ class SAM(Callback):
         self.skip_epoch_count = skip_epoch_count
         if logging:
             self.logger = getLogger("matsciml.callbacks.SAM")
+            self.logger.setLevel("INFO")
         else:
             self.logger = None
 

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -840,13 +840,13 @@ class SAM(Callback):
         current_epoch = trainer.current_epoch
         # by default we start SAM, and toggle off if conditions met
         start_sam = True
-        if self.skip_epoch_count and self.skip_epoch_count < current_epoch:
+        if self.skip_epoch_count and not self.skip_epoch_count < current_epoch:
             start_sam = False
             if self.logger:
                 self.logger.info(
-                    "Required number of steps not met; not running SAM yet."
+                    "Required number of epochs not met; not running SAM yet."
                 )
-        if self.skip_step_count and self.skip_step_count < current_step:
+        if self.skip_step_count and not self.skip_step_count < current_step:
             start_sam = False
             if self.logger:
                 self.logger.info(

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -818,6 +818,16 @@ class SAM(Callback):
     ) -> None:
         self.batch = batch
         self.batch_idx = batch_idx
+        # add flag to determine if we should run SAM on this step
+        current_step = trainer.current_step
+        current_epoch = trainer.current_epoch
+        # by default we start SAM, and toggle off if conditions met
+        start_sam = True
+        if self.skip_epoch_count and self.skip_epoch_count < current_epoch:
+            start_sam = False
+        if self.skip_step_count and self.skip_step_count < current_step:
+            start_sam = False
+        self.start_sam = start_sam
 
     def extract_optimizer_specific_loss(self, task, optimizer, loss):
         optimizer_names = copy(task.optimizer_names)

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -821,7 +821,7 @@ class SAM(Callback):
         self.batch = batch
         self.batch_idx = batch_idx
         # add flag to determine if we should run SAM on this step
-        current_step = trainer.current_step
+        current_step = trainer.global_step
         current_epoch = trainer.current_epoch
         # by default we start SAM, and toggle off if conditions met
         start_sam = True

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -836,8 +836,16 @@ class SAM(Callback):
         start_sam = True
         if self.skip_epoch_count and self.skip_epoch_count < current_epoch:
             start_sam = False
+            if self.logger:
+                self.logger.info(
+                    "Required number of steps not met; not running SAM yet."
+                )
         if self.skip_step_count and self.skip_step_count < current_step:
             start_sam = False
+            if self.logger:
+                self.logger.info(
+                    "Required number of steps not met; not running SAM yet."
+                )
         self.start_sam = start_sam
 
     def extract_optimizer_specific_loss(self, task, optimizer, loss):

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -715,6 +715,7 @@ class SAM(Callback):
         adaptive: bool = False,
         skip_step_count: int | None = None,
         skip_epoch_count: int | float | None = None,
+        logging: bool = False,
     ) -> None:
         """
         Set up the ``SAM (Sharpness Aware Minimization)`` callback.
@@ -752,6 +753,9 @@ class SAM(Callback):
             to wait before SAM triggers. The default setting, None, will not
             wait any epochs before invoking SAM. Mutually exclusive with
             ``skip_step_count``.
+        logging : bool, default False
+            If set to True, logs the behavior of SAM to console. This is useful
+            for debugging.
 
         Examples
         --------
@@ -775,6 +779,10 @@ class SAM(Callback):
                 0 < skip_epoch_count < 1.0
             ), "Decimal `skip_epoch_count` passed not within [0,1]."
         self.skip_epoch_count = skip_epoch_count
+        if logging:
+            self.logger = getLogger("matsciml.callbacks.SAM")
+        else:
+            self.logger = None
 
     def on_fit_start(
         self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -765,6 +765,10 @@ class SAM(Callback):
         super().__init__()
         self.rho = rho
         self.adaptive = adaptive
+        if skip_epoch_count and skip_epoch_count:
+            raise ValueError(
+                "`skip_epoch_count` and `skip_step_count` are mutually exclusive for SAM."
+            )
         self.skip_step_count = skip_step_count
         self.skip_epoch_count = skip_epoch_count
 

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -709,7 +709,13 @@ if package_registry["codecarbon"]:
 
 
 class SAM(Callback):
-    def __init__(self, rho: float = 0.05, adaptive: bool = False) -> None:
+    def __init__(
+        self,
+        rho: float = 0.05,
+        adaptive: bool = False,
+        skip_step_count: int | None = None,
+        skip_epoch_count: int | float | None = None,
+    ) -> None:
         """
         Set up the ``SAM (Sharpness Aware Minimization)`` callback.
         https://arxiv.org/abs/2010.01412
@@ -734,6 +740,18 @@ class SAM(Callback):
         adaptive : bool
             A boolean flag indicating whether to adaptively normalize weights.
             Defaults to False.
+        skip_step_count : int | None, default None
+            Specifies an integer number of steps to skip before SAM is actually
+            in effect. By default is set to None, which starts SAM from the
+            first steps. Mutually exclusive with ``skip_epoch_count``.
+        skip_epoch_count : int | float | None, default None
+            Specifies the number of epochs to skip before SAM is in effect.
+            If an integer is passed, this corresponds to the exact epoch
+            count to wait before SAM is used. If a float between [0,1]
+            is passed, this corresponds to the fraction of the ``trainer.max_epochs``
+            to wait before SAM triggers. The default setting, None, will not
+            wait any epochs before invoking SAM. Mutually exclusive with
+            ``skip_step_count``.
 
         Examples
         --------
@@ -747,6 +765,8 @@ class SAM(Callback):
         super().__init__()
         self.rho = rho
         self.adaptive = adaptive
+        self.skip_step_count = skip_step_count
+        self.skip_epoch_count = skip_epoch_count
 
     @staticmethod
     def _get_params(optimizer: Optimizer) -> Iterator[torch.Tensor]:

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -786,6 +786,8 @@ class SAM(Callback):
             self.max_steps = trainer.max_steps
         else:
             # work out the total number of expected steps
+            if not trainer.train_dataloader:
+                trainer.fit_loop.setup_data()
             train_len = len(trainer.train_dataloader)
             self.max_steps = train_len * self.max_epochs
         # if a fractional epoch skip is specified, convert it to


### PR DESCRIPTION
This PR refactors SAM to allow the ability to specify a number of steps or epochs to delay sharpness awareness by adding the `skip_step_count` and `skip_epoch_count` parameters to the `SAM.__init__`. The former accepts integers, which specifies the minimum number of steps to pass before SAM activates, while the latter accepts both integers and a fraction between [0,1].

Additionally, a configurable logger has been added to `SAM`, which informs the user when the gradient norm goes below machine epsilon, i.e. indicating numerical instability. Logging is not on by default.