### PR TITLE
Configuring `sphix` to use class `__init__` docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,3 +19,6 @@ html_static_path = ["_static"]
 # configure napoleon docstrings
 napoleon_numpy_docstring = True
 napoleon_preprocess_types = True
+
+# ensure __init__ is used for class documentation
+autoclass_content = "both"


### PR DESCRIPTION
This PR closes #285 by adding a simple one-line configuration to the `sphinx` `conf.py`, which globally makes sure that `autoclass` will also use the docstring for `__init__` when generating documentation.