### PR TITLE
SAM configuration check fixes

### DIFF
--- a/examples/callbacks/SAM.py
+++ b/examples/callbacks/SAM.py
@@ -36,6 +36,8 @@ dm = MatSciMLDataModule.from_devset(
     },
 )
 
-# run a quick training loop
-trainer = pl.Trainer(fast_dev_run=1000, callbacks=[SAM()])
+# run a quick training loop, skipping the first five steps
+trainer = pl.Trainer(
+    fast_dev_run=100, callbacks=[SAM(skip_step_count=5, logging=True, log_level="INFO")]
+)
 trainer.fit(task, datamodule=dm)

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -808,7 +808,7 @@ class SAM(Callback):
             self.max_steps = train_len * self.max_epochs
         # if a fractional epoch skip is specified, convert it to
         # an integer count for easier comparison
-        if self.skip_epoch_count and not self.skip_epoch_count.is_integer():
+        if self.skip_epoch_count and isinstance(self.skip_epoch_count, float):
             self.skip_epoch_count = int(self.max_epochs * self.skip_epoch_count)
         # add floating point epsilon for later use
         self.epsilon = torch.tensor(

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -810,6 +810,10 @@ class SAM(Callback):
         # an integer count for easier comparison
         if self.skip_epoch_count and isinstance(self.skip_epoch_count, float):
             self.skip_epoch_count = int(self.max_epochs * self.skip_epoch_count)
+            if self.logger:
+                self.logger.info(
+                    f"Fractional epoch skip - will start SAM from epoch {self.skip_epoch_count}, max epochs {self.max_epochs}."
+                )
         # add floating point epsilon for later use
         self.epsilon = torch.tensor(
             [torch.finfo(pl_module.dtype).eps],

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -776,7 +776,7 @@ class SAM(Callback):
         super().__init__()
         self.rho = rho
         self.adaptive = adaptive
-        if skip_epoch_count and skip_epoch_count:
+        if skip_step_count and skip_epoch_count:
             raise ValueError(
                 "`skip_epoch_count` and `skip_step_count` are mutually exclusive for SAM."
             )

--- a/matsciml/lightning/callbacks.py
+++ b/matsciml/lightning/callbacks.py
@@ -781,7 +781,7 @@ class SAM(Callback):
                 "`skip_epoch_count` and `skip_step_count` are mutually exclusive for SAM."
             )
         self.skip_step_count = skip_step_count
-        if skip_epoch_count and not skip_epoch_count.is_integer():
+        if skip_epoch_count and isinstance(skip_epoch_count, float):
             assert (
                 0 < skip_epoch_count < 1.0
             ), "Decimal `skip_epoch_count` passed not within [0,1]."


### PR DESCRIPTION
This PR fixes bugs associated with the `skip_*` configuration options to the SAM callback introduced in #284:

- Fixed the nothing logical comparison for `skip_epoch_count` and `skip_epoch_count` in `__init__`, which meant any value of `skip_epoch_count` would fail the assertion
- Changed `is_integer` checks to `isinstance(skip_epoch_count, float)`; this was a mistake from my IDE that confused me into thinking it was a method for `float` _as well as_ strings.
- Added a logging step that reports which epoch SAM when a fractional value is passed to `skip_epoch_count`