### PR TITLE
Using `None` defaults when logger and callbacks are unspecified to CLI

### DIFF
--- a/experiments/trainer_config/trainer_config.py
+++ b/experiments/trainer_config/trainer_config.py
@@ -37,11 +37,14 @@ def setup_trainer(config: dict[str, Any], trainer_args: dict[str, Any]) -> pl.Tr
         trainer_args.pop("loggers")
     else:
         loggers = None
+    # if callbacks were requested, configure them
     if "callbacks" in trainer_args:
         callbacks = []
         for callback in trainer_args["callbacks"]:
             callbacks.append(callback)
         trainer_args.pop("callbacks")
+    else:
+        callbacks = None
 
     trainer_kwargs = trainer_args["generic"]
     trainer_kwargs.update(trainer_args[run_type])

--- a/experiments/trainer_config/trainer_config.py
+++ b/experiments/trainer_config/trainer_config.py
@@ -31,11 +31,14 @@ def setup_trainer(
     trainer_args = setup_extra_trainer_args(config["log_path"], trainer_args)
     trainer_args = instantiate_arg_dict(deepcopy(trainer_args))
     trainer_args = update_arg_dict("trainer", trainer_args, config["cli_args"])
+    # if loggers were requested, configure them
     if "loggers" in trainer_args:
         loggers = []
         for logger in trainer_args["loggers"]:
             loggers.append(logger)
         trainer_args.pop("loggers")
+    else:
+        loggers = None
     if "callbacks" in trainer_args:
         callbacks = []
         for callback in trainer_args["callbacks"]:

--- a/experiments/trainer_config/trainer_config.py
+++ b/experiments/trainer_config/trainer_config.py
@@ -24,9 +24,7 @@ def setup_extra_trainer_args(
     return trainer_args
 
 
-def setup_trainer(
-    config: dict[str, Any], trainer_args: dict[str, Any]
-) -> pl.LightningModule:
+def setup_trainer(config: dict[str, Any], trainer_args: dict[str, Any]) -> pl.Trainer:
     run_type = config["run_type"]
     trainer_args = setup_extra_trainer_args(config["log_path"], trainer_args)
     trainer_args = instantiate_arg_dict(deepcopy(trainer_args))


### PR DESCRIPTION
This PR fixes trainer configurations that are missing `logger` and `callback` specifications in the CLI.

Prior, `experiments/trainer_config/trainer_config.py` was written such that the `loggers` and `callbacks` variables are defined only if they exist in `trainer_args`, and were passed into `pl.Trainer(...)` regardless. This PR fixes the issue by adding `else` cases that default `loggers` and `callbacks` to `None` when not used, which is what `Trainer` uses as a default as well.