### PR TITLE
Parity inference task

### DIFF
--- a/docs/source/inference.rst
+++ b/docs/source/inference.rst
@@ -36,7 +36,9 @@ The ``ParityInferenceTask`` helps perform this task by using the PyTorch Lightni
 The default ``Trainer`` settings will create a ``lightning_logs`` directory, followed by an experiment
 number. Within it, once your inference run completes, there will be a ``inference_data.json`` that you
 can then load in. The data is sorted by the name of the target (e.g. ``energy``, ``bandgap``), under
-these keys, ``predictions`` and ``targets``.
+these keys, ``predictions`` and ``targets``. Note that ``pred_split`` does not necessarily have to be
+a completely different hold out: you can pass your training LMDB path if you wish to double check the
+performance of your model after training, or you can use it with unseen samples.
 
 .. note::
 

--- a/docs/source/inference.rst
+++ b/docs/source/inference.rst
@@ -1,0 +1,60 @@
+Inference
+=========
+
+"Inference" can be a bit of an overloaded term, and this page is broken down into different possible
+downstream use cases for trained models.
+
+Parity plots and model evaluations
+----------------------------------
+
+The simplest/most straightforward thing to check the performance of a model is to look beyond reduced metrics; i.e. anything that
+has been averaged over batches, epochs, etc. Parity plots help verify linear relationships between predictions and ground truths
+by simply iterating over the evaluation subset of data, averaging.
+
+The ``ParityInferenceTask`` helps perform this task by using the PyTorch Lightning ``predict`` pipelines. With a pre-trained
+``matsciml`` task checkpoint, you simply need to run the following:
+
+.. codeblock:: python
+
+    import pytorch_lightning as pl
+
+    from matsciml.models.inference import ParityInferenceTask
+    from matsciml.lightning import MatSciMLDataModule
+
+    # configure data module the way that you need to
+    dm = MatSciMLDataModule(
+        dataset="NameofDataset",
+        pred_split="/path/to/lmdb/split",
+        batch_size=64   # this is just to amoritize model calls
+    )
+    task = ParityInferenceTask.from_pretrained_checkpoint("/path/to/checkpoint")
+
+    trainer = pl.Trainer()   # optionally, configure logger/limit_predict_batches
+    trainer.predict(task, datamodule=dm)
+
+
+The default ``Trainer`` settings will create a ``lightning_logs`` directory, followed by an experiment
+number. Within it, once your inference run completes, there will be a ``inference_data.json`` that you
+can then load in. The data is sorted by the name of the target (e.g. ``energy``, ``bandgap``), under
+these keys, ``predictions`` and ``targets``.
+
+.. note::
+
+    For developers, this is handled by the ``matsciml.models.inference.ParityData`` class. This is
+    mainly to standardize the output and provide a means to serialize the data as JSON.
+
+
+
+.. autoclass:: matsciml.models.inference.ParityInferenceTask
+   :members:
+
+
+
+Performing molecular dynamics simulations
+-----------------------------------------
+
+Currently, the main method of interfacing with dynamical simulations is through the ``ase`` package.
+Documentation for this is ongoing, but examples can be found under ``examples/interfaces``.
+
+.. autoclass:: matsciml.interfaces.ase.MatSciMLCalculator
+    :members:

--- a/matsciml/lightning/data_utils.py
+++ b/matsciml/lightning/data_utils.py
@@ -250,7 +250,7 @@ class MatSciMLDataModule(pl.LightningDataModule):
                 dset = self._make_dataset(split_path, self.dataset)
                 splits[key] = dset
         # specialty case for 'inference' or prediction runs
-        if hasattr(self.hparams, "pred_split"):
+        if isinstance(self.hparams.pred_split, (str, Path)):
             pred_split_path = self.hparams.pred_split
             if isinstance(pred_split_path, str):
                 pred_split_path = Path(pred_split_path)

--- a/matsciml/models/inference.py
+++ b/matsciml/models/inference.py
@@ -71,8 +71,8 @@ class ParityData:
 
     def to_json(self) -> str:
         return_dict = {}
-        targets = self.targets
-        predictions = self.predictions
+        targets = self.targets.cpu()
+        predictions = self.predictions.cpu()
         # do some preliminary checks to the data
         if targets.ndim != predictions.ndim:
             self.logger.warning(

--- a/matsciml/models/inference.py
+++ b/matsciml/models/inference.py
@@ -70,7 +70,7 @@ class ParityData:
             values.squeeze_()
         self._predictions.append(values)
 
-    def to_json(self) -> str:
+    def to_json(self) -> dict[str, list]:
         return_dict = {}
         targets = self.targets.cpu()
         predictions = self.predictions.cpu()
@@ -88,7 +88,7 @@ class ParityData:
         return_dict["predictions"] = predictions.tolist()
         return_dict["targets"] = targets.tolist()
         return_dict["name"] = self.name
-        return json.dumps(return_dict)
+        return return_dict
 
 
 class BaseInferenceTask(ABC, pl.LightningModule):

--- a/matsciml/models/inference.py
+++ b/matsciml/models/inference.py
@@ -17,6 +17,12 @@ class BaseInferenceTask(ABC, pl.LightningModule):
         super().__init__()
         self.model = pretrained_model
 
+    def training_step(self, *args, **kwargs) -> None:
+        """Overrides Lightning method to prevent task being used for training."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} is not intended for training."
+        )
+
     @abstractmethod
     def predict_step(
         self,

--- a/matsciml/models/inference.py
+++ b/matsciml/models/inference.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import pytorch_lightning as pl
 import torch
@@ -23,8 +23,7 @@ class BaseInferenceTask(ABC, pl.LightningModule):
         batch: BatchDict,
         batch_idx: int,
         dataloader_idx: int = 0,
-    ) -> Any:
-        ...
+    ) -> Any: ...
 
     @classmethod
     def from_pretrained_checkpoint(
@@ -58,7 +57,7 @@ class BaseInferenceTask(ABC, pl.LightningModule):
             task_ckpt_path = Path(task_ckpt_path)
         assert (
             task_ckpt_path.exists()
-        ), f"Encoder checkpoint filepath specified but does not exist."
+        ), "Encoder checkpoint filepath specified but does not exist."
         ckpt = torch.load(task_ckpt_path)
         select_kwargs = {}
         for key in ["encoder_class", "encoder_kwargs"]:

--- a/matsciml/models/tests/test_parity_inference.py
+++ b/matsciml/models/tests/test_parity_inference.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import shutil
+import json
+from pathlib import Path
+
+import pytest
+import pytorch_lightning as pl
+
+from matsciml.models.inference import ParityInferenceTask
+from matsciml.models.base import ScalarRegressionTask
+from matsciml.models.pyg import EGNN
+from matsciml.lightning import MatSciMLDataModule
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "dset_params", [("MaterialsProjectDataset", "efermi"), ("LiPSDataset", "energy")]
+)
+def test_parity_inference_workflow(dset_params):
+    dataset_name, keys = dset_params
+    dm = MatSciMLDataModule.from_devset(
+        dataset_name,
+        dset_kwargs={
+            "transforms": [
+                PeriodicPropertiesTransform(6.0, True),
+                PointCloudToGraphTransform("pyg"),
+            ]
+        },
+        batch_size=8,
+    )
+    task = ScalarRegressionTask(
+        encoder_class=EGNN,
+        encoder_kwargs={"hidden_dim": 16, "output_dim": 16, "num_conv": 2},
+        output_kwargs={"hidden_dim": 16},
+        task_keys=[
+            keys,
+        ],
+    )
+    # train the model briefly to initialize output heads
+    trainer = pl.Trainer(max_epochs=1, limit_train_batches=10, limit_val_batches=0)
+    trainer.fit(task, dm)
+    # now do the inference part
+    wrapper = ParityInferenceTask(task)
+    trainer.predict(wrapper, datamodule=dm)
+    assert trainer.log_dir is not None
+    log_dir = Path(trainer.log_dir)
+    assert log_dir.exists()
+    # open the result and make sure it's not empty
+    with open(log_dir.joinpath("inference_data.json"), "r") as read_file:
+        data = json.load(read_file)
+    assert len(data) != 0
+    shutil.rmtree("lightning_logs", ignore_errors=True)


### PR DESCRIPTION
This PR implements a `ParityInferenceTask` (with the lack of a better naming for it), which is used to run a datasplit through a model to evaluate predicted vs. actual, beyond just looking at reduced metrics like MSE/MAE. This task should be pretty straightforward to set up and run, and does not need additional logger configuration. After running `trainer.predict`, an `inference_data.json` is produced in the experiment folder (`trainer.log_dir/<name>/inference_data.json`) that can then be reviewed offline.

- Implements a `ParityData` structure which is mostly just a helper class for accumulating data.
- Implements the `ParityInferenceTask`, which in itself just provides the `predict_step` and `on_predict_epoch_end` functions to be called in the PyTorch Lightning `predict` pipeline.
- Unit test that verifies functionality on three datasets using EGNN. This tests simple functionality end-to-end, up to checking that the contents of the output JSON exists at all.
- Updated the documentation to include an "Inference" section, of which the first entry is this approach.