### PR TITLE
Fixes to parity inference task

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ The Open MatSciML Toolkit
    training
    callbacks
    experiment-interface
+   inference
    best-practices
    how-to
    developers

--- a/docs/source/inference.rst
+++ b/docs/source/inference.rst
@@ -40,6 +40,12 @@ these keys, ``predictions`` and ``targets``. Note that ``pred_split`` does not n
 a completely different hold out: you can pass your training LMDB path if you wish to double check the
 performance of your model after training, or you can use it with unseen samples.
 
+Note that by default, `predict` triggers PyTorch's inference mode, which is a specialized case where
+absolutely no autograd is enabled. ``ForceRegressionTask`` uses automatic differentiation to evaluate
+forces, and so for inference tasks that require gradients, you **must** pass `inference_mode=False` to
+``pl.Trainer``.
+
+
 .. note::
 
     For developers, this is handled by the ``matsciml.models.inference.ParityData`` class. This is

--- a/matsciml/lightning/data_utils.py
+++ b/matsciml/lightning/data_utils.py
@@ -291,7 +291,7 @@ class MatSciMLDataModule(pl.LightningDataModule):
             target,
             batch_size=self.hparams.batch_size,
             num_workers=self.hparams.num_workers,
-            collate_fn=self.dataset.collate_fn,
+            collate_fn=target.collate_fn,
             persistent_workers=self.persistent_workers,
         )
 

--- a/matsciml/lightning/data_utils.py
+++ b/matsciml/lightning/data_utils.py
@@ -259,6 +259,9 @@ class MatSciMLDataModule(pl.LightningDataModule):
                     f"Prediction split provided, but not found: {pred_split_path}"
                 )
             dset = self._make_dataset(pred_split_path, self.dataset)
+            # assumes that if we're providing a predict set, we're not going
+            # to be doing training in the same run
+            self.dataset = dset
             splits["pred"] = dset
         # the last case assumes only the dataset is passed, we will treat it as train
         if len(splits) == 0:

--- a/matsciml/models/inference.py
+++ b/matsciml/models/inference.py
@@ -60,7 +60,7 @@ class ParityData:
 
     @property
     def predictions(self) -> torch.Tensor:
-        return torch.vstack(self._targets)
+        return torch.vstack(self._predictions)
 
     @predictions.setter
     def predictions(self, values: torch.Tensor) -> None:


### PR DESCRIPTION
This PR provides some fixes to the `ParityInferenceTask` implemented in #294.

- Fixes incorrect mapping the in `predictions` property of `ParityData`, which caused targets and predictions to return the same tensor.
- Fixes missing entry in documentation for the general inference page
- Fixed mapping for `collate_fn` in the predict dataloader, in the case that only `pred_split` is specified and `self.dataset` is not defined as a `Dataset` object.
- QoL update to `BaseInferenceTask` class methods, allowing specific tasks to be loaded in, as well as a simplified pipeline to load in an artifact from `wandb`.