### PR TITLE
ASE Calculator Updates

### DIFF
--- a/matsciml/interfaces/ase/base.py
+++ b/matsciml/interfaces/ase/base.py
@@ -158,7 +158,7 @@ class MatSciMLCalculator(Calculator):
             specifies how model outputs should be mapped to Calculator expected
             results. for example {"ase_expected": "model_output"} -> {"forces": "force"}
         matsciml_model : bool, default True
-            flag indiciating whether model was trained with matsciml or not.
+            flag indicating whether model was trained with matsciml or not.
         """
         super().__init__(
             restart, label=label, atoms=atoms, directory=directory, **kwargs

--- a/matsciml/interfaces/ase/base.py
+++ b/matsciml/interfaces/ase/base.py
@@ -97,7 +97,6 @@ class MatSciMLCalculator(Calculator):
         directory=".",
         conversion_factor: float | dict[str, float] = 1.0,
         multitask_strategy: str | Callable | mt.AbstractStrategy = "AverageTasks",
-        data_type: torch.dtype | None = None,
         output_map: dict[str, str] | None = None,
         matsciml_model: bool = True,
         **kwargs,
@@ -150,10 +149,6 @@ class MatSciMLCalculator(Calculator):
             to ``ase``. If a single ``float`` is passed, we assume that
             the conversion is applied to the energy output. Each factor
             is multiplied with the result.
-        data_type : torch.dtype | None, default None
-            if specified, will convert data to this type instead
-            of looking at ``self.task_module.dtype`` which may not be
-            available in the case of 3rd party models.
         output_map : dict[str, str] | None, default None
             specifies how model outputs should be mapped to Calculator expected
             results. for example {"ase_expected": "model_output"} -> {"forces": "force"}
@@ -198,7 +193,6 @@ class MatSciMLCalculator(Calculator):
                 )
             multitask_strategy = cls_name()
         self.multitask_strategy = multitask_strategy
-        self.data_type = data_type
         self.matsciml_model = matsciml_model
         self.output_map = dict(
             zip(self.implemented_properties, self.implemented_properties)
@@ -229,10 +223,7 @@ class MatSciMLCalculator(Calculator):
 
     @property
     def dtype(self) -> torch.dtype | str:
-        if self.data_type:
-            dtype = self.data_type
-        else:
-            dtype = self.task_module.dtype
+        dtype = self.task_module.dtype
         return dtype
 
     def _format_atoms(self, atoms: Atoms) -> DataDict:

--- a/matsciml/interfaces/ase/base.py
+++ b/matsciml/interfaces/ase/base.py
@@ -94,6 +94,7 @@ class MatSciMLCalculator(Calculator):
         directory=".",
         conversion_factor: float | dict[str, float] = 1.0,
         multitask_strategy: str | Callable | mt.AbstractStrategy = "AverageTasks",
+        data_type: torch.dtype | None = None,
         **kwargs,
     ):
         """
@@ -144,6 +145,9 @@ class MatSciMLCalculator(Calculator):
             to ``ase``. If a single ``float`` is passed, we assume that
             the conversion is applied to the energy output. Each factor
             is multiplied with the result.
+        data_type: if specified, will convert data to this type instead
+            of looking at ``self.task_module.dtype`` which may not be
+            available in the case of 3rd party models.
         """
         super().__init__(
             restart, label=label, atoms=atoms, directory=directory, **kwargs
@@ -182,6 +186,7 @@ class MatSciMLCalculator(Calculator):
                 )
             multitask_strategy = cls_name()
         self.multitask_strategy = multitask_strategy
+        self.data_type = data_type
 
     @property
     def conversion_factor(self) -> dict[str, float]:
@@ -200,7 +205,10 @@ class MatSciMLCalculator(Calculator):
 
     @property
     def dtype(self) -> torch.dtype | str:
-        dtype = self.task_module.dtype
+        if self.data_type:
+            dtype = self.data_type
+        else:
+            dtype = self.task_module.dtype
         return dtype
 
     def _format_atoms(self, atoms: Atoms) -> DataDict:

--- a/matsciml/interfaces/ase/base.py
+++ b/matsciml/interfaces/ase/base.py
@@ -281,7 +281,7 @@ class MatSciMLCalculator(Calculator):
             # run the data structure through the model
             output = self.task_module.predict(data_dict)
         else:
-            output = self.task_module.predict(atoms)
+            output = self.task_module.forward(atoms)
         if isinstance(self.task_module, MultiTaskLitModule):
             # use a more complicated parser for multitasks
             results = self.multitask_strategy(output, self.task_module)
@@ -290,9 +290,15 @@ class MatSciMLCalculator(Calculator):
             # add outputs to self.results as expected by ase, as specified by ``properties``
             # "ase_properties" are those in ``properties``.
             for ase_property in properties:
-                model_output = output.get(self.output_map[ase_property], None)
+                model_property = self.output_map[ase_property]
+                model_output = output.get(model_property, None)
                 if model_output is not None:
                     self.results[ase_property] = model_output.detach().numpy()
+                else:
+                    raise KeyError(
+                        f"Expected model to return {model_property} as an output."
+                    )
+
             if len(self.results) == 0:
                 raise RuntimeError(
                     f"No expected properties were written. Output dict: {output}"

--- a/matsciml/interfaces/ase/tests/test_ase_calc.py
+++ b/matsciml/interfaces/ase/tests/test_ase_calc.py
@@ -48,7 +48,9 @@ def test_egnn_energy_forces(egnn_config: dict, test_pbc: Atoms, pbc_transform: l
     task = ForceRegressionTask(
         encoder_class=EGNN, encoder_kwargs=egnn_config, output_kwargs={"hidden_dim": 32}
     )
-    calc = MatSciMLCalculator(task, transforms=pbc_transform)
+    calc = MatSciMLCalculator(
+        task, transforms=pbc_transform, output_map={"forces": "force"}
+    )
     atoms = test_pbc.copy()
     atoms.calc = calc
     energy = atoms.get_potential_energy()
@@ -62,7 +64,9 @@ def test_egnn_dynamics(egnn_config: dict, test_pbc: Atoms, pbc_transform: list):
     task = ForceRegressionTask(
         encoder_class=EGNN, encoder_kwargs=egnn_config, output_kwargs={"hidden_dim": 32}
     )
-    calc = MatSciMLCalculator(task, transforms=pbc_transform)
+    calc = MatSciMLCalculator(
+        task, transforms=pbc_transform, output_map={"forces": "force"}
+    )
     atoms = test_pbc.copy()
     atoms.calc = calc
     dyn = VelocityVerlet(atoms, timestep=5 * units.fs, logfile="md.log")

--- a/matsciml/interfaces/ase/tests/test_ase_calc.py
+++ b/matsciml/interfaces/ase/tests/test_ase_calc.py
@@ -104,7 +104,6 @@ def test_matgl():
 
     matgl_model.matgl_forward = matgl_model.forward
     matgl_model.forward = MethodType(forward, matgl_model)
-    matgl_model.predict = MethodType(forward, matgl_model)
 
     calc = MatSciMLCalculator(matgl_model, matsciml_model=False)
     pos = np.random.normal(0.0, 1.0, size=(10, 3))
@@ -112,7 +111,6 @@ def test_matgl():
     # a different range of atomic numbers.
     atomic_numbers = np.random.randint(1, 94, size=(10,))
     atoms = Atoms(numbers=atomic_numbers, positions=pos)
-    atoms = atoms.copy()
     atoms.calc = calc
     energy = atoms.get_potential_energy()
     assert np.isfinite(energy)

--- a/matsciml/interfaces/ase/tests/test_ase_calc.py
+++ b/matsciml/interfaces/ase/tests/test_ase_calc.py
@@ -79,7 +79,7 @@ def test_egnn_dynamics(egnn_config: dict, test_pbc: Atoms, pbc_transform: list):
     dyn.run(3)
 
 
-def test_matƒgl():
+def test_matgl():
     matgl_model = matgl.load_model("CHGNet-MPtrj-2024.2.13-PES-11M")
 
     def forward(self, atoms):

--- a/matsciml/interfaces/ase/tests/test_ase_calc.py
+++ b/matsciml/interfaces/ase/tests/test_ase_calc.py
@@ -106,10 +106,11 @@ def test_matgl():
     matgl_model.forward = MethodType(forward, matgl_model)
     matgl_model.predict = MethodType(forward, matgl_model)
 
-    matgl_model.predict = MethodType(forward, matgl_model)
     calc = MatSciMLCalculator(matgl_model, matsciml_model=False)
     pos = np.random.normal(0.0, 1.0, size=(10, 3))
-    atomic_numbers = np.random.randint(1, 89, size=(10,))
+    # Using a different atoms object due to pretrained model atom embedding expecting
+    # a different range of atomic numbers.
+    atomic_numbers = np.random.randint(1, 94, size=(10,))
     atoms = Atoms(numbers=atomic_numbers, positions=pos)
     atoms = atoms.copy()
     atoms.calc = calc

--- a/matsciml/interfaces/ase/tests/test_ase_calc.py
+++ b/matsciml/interfaces/ase/tests/test_ase_calc.py
@@ -14,6 +14,12 @@ from matsciml.models.base import (
     ForceRegressionTask,
 )
 from matsciml.models.pyg import EGNN
+from types import MethodType
+
+import matgl
+import torch
+from matgl.ext.ase import Atoms2Graph
+
 
 np.random.seed(21516136)
 
@@ -71,3 +77,43 @@ def test_egnn_dynamics(egnn_config: dict, test_pbc: Atoms, pbc_transform: list):
     atoms.calc = calc
     dyn = VelocityVerlet(atoms, timestep=5 * units.fs, logfile="md.log")
     dyn.run(3)
+
+
+def test_matƒgl():
+    matgl_model = matgl.load_model("CHGNet-MPtrj-2024.2.13-PES-11M")
+
+    def forward(self, atoms):
+        graph_converter = Atoms2Graph(
+            element_types=matgl_model.model.element_types,
+            cutoff=matgl_model.model.cutoff,
+        )
+        graph, lattice, state_feats_default = graph_converter.get_graph(atoms)
+        graph.edata["pbc_offshift"] = torch.matmul(
+            graph.edata["pbc_offset"], lattice[0]
+        )
+        graph.ndata["pos"] = graph.ndata["frac_coords"] @ lattice[0]
+        state_feats = torch.tensor(state_feats_default)
+        total_energies, forces, stresses, *others = self.matgl_forward(
+            graph, lattice, state_feats
+        )
+        output = {}
+        output["energy"] = total_energies
+        output["forces"] = forces
+        output["stress"] = stresses
+        return output
+
+    matgl_model.matgl_forward = matgl_model.forward
+    matgl_model.forward = MethodType(forward, matgl_model)
+    matgl_model.predict = MethodType(forward, matgl_model)
+
+    matgl_model.predict = MethodType(forward, matgl_model)
+    calc = MatSciMLCalculator(matgl_model, matsciml_model=False)
+    pos = np.random.normal(0.0, 1.0, size=(10, 3))
+    atomic_numbers = np.random.randint(1, 89, size=(10,))
+    atoms = Atoms(numbers=atomic_numbers, positions=pos)
+    atoms = atoms.copy()
+    atoms.calc = calc
+    energy = atoms.get_potential_energy()
+    assert np.isfinite(energy)
+    forces = atoms.get_forces()
+    assert np.isfinite(forces).all()


### PR DESCRIPTION
This pr updates the ASE calculator interface to accommodate a few changes:

* Use models that were not trained with matsciml. This eliminates the requirement for the model to be one of `ForceRegressionTask`, etc. 
* Map from model output keys to keys that are expected by ASE. Currently, the calculator manually renames model outputs to expected outputs by ase, for example the model output `force` gets mapped into `forces`. This mapping should now be passes as a dictionary to the calculator on instantiation if required. 
* The calculator will now iterate through the properties passed into `_calculate` to build the results dictionary.
* Add the `concatenate_keys` function which also adds properties to PyG graphs that are expected by models like MACE, add a few extra keys to `_format_atoms`, and change when type casting is called. 
* Updated tests to reflect new changes, added test using a pretrained `matgl` model. 