### PR TITLE
LMDB traversal cli

### DIFF
--- a/docs/source/best-practices.rst
+++ b/docs/source/best-practices.rst
@@ -282,6 +282,63 @@ This callback will also zero out ``NaN`` gradients, allowing training to resume
 and hoping for the problem to self-correct as the model has a chance to learn
 from various training samples.
 
+Inspecting the data
+^^^^^^^^^^^^^^^^^^^
+
+When things are not behaving as intended, it can be beneficial to inspect the
+data whether you are training or making predictions off new data. The ``lmdb_cli``
+is a simple command-line interface that provides rudimentary functions to
+inspect LMDB contents without writing a script to do so.
+
+A good place to start would be to accumulate running statistics over the dataset
+using ``lmdb_cli dump_statistics``, which will compute a running average over a
+specified window length, reporting these values live and dumping them to a JSON
+file when completed as well.
+
+
+.. code-block:: console
+
+  ❯ lmdb_cli dump-statistics --help
+  Usage: lmdb_cli dump-statistics [OPTIONS] LMDB_DIR
+
+    Loads an LMDB dataset and iterates through the dataset, computing a running
+    average for numeric properties that updates interactively and written to a
+    JSON file afterwards.
+
+    The JSON file will be named after the dataset class used to interpret the
+    data followed by the specific directory/split name and written to the
+    current folder.
+
+    Parameters ---------- lmdb_dir : PathLike     Path to an LMDB folder
+    structure. dataset_type : str, optional     Class name for the dataset to
+    interpret the LMDB data. By     default is ``None``, which uses
+    ``BaseLMDBDataset`` to     load the data. Checks against the ``matsciml``
+    registry for     available datasets. periodic : bool, default True
+    Whether to enable periodic properties transform. radius : float     Cut-off
+    radius used by the periodic property transform. adaptive_cutoff : bool,
+    default True     Whether to enable the adapative cut-off in the periodic
+    properties transform. graph_backend : Optional, Literal['pyg', 'dgl']
+    Optional choice for graph backend to use. The default is ``pyg``,     which
+    emits PyTorch Geometric graphs. num_samples : int, optional     If provided,
+    sets the maximum number of samples to iterate     over.
+
+  Options:
+    -d, --dataset_type [AlexandriaDataset|CMDataset|CdvaeLMDBDataset|ColabFitDataset|IS2REDataset|LiPSDataset|MaterialsProjectDataset|MaterialsTrajectoryDataset|MultiDataset|NomadDataset|OQMDDataset|PyGCdvaeDataset|PyGMaterialsProjectDataset|S2EFDataset|SyntheticPointGroupDataset]
+                                    Dataset class name to use to map the data.
+    -p, --periodic                  Flag to disable the periodic transform.
+    -r, --radius FLOAT              Cut-off radius for periodic property
+                                    transform.  [default: 6.0]
+    -a, --adaptive_cutoff           Flag to disable the adaptive cutoff used in
+                                    periodic transform.
+    -g, --graph_backend [pyg|dgl]   Graph backend for transformation.
+    -n, --num_samples INTEGER       If specified, corresponds to the maximum
+                                    number of samples to compute with.
+    -w, --window_size INTEGER       Window size for computing the running
+                                    average over.
+    --help                          Show this message and exit.
+
+
+
 Understanding training dynamics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -70,6 +70,32 @@ the full functional pipeline; perfect for development!
    :members:
 
 
+Inspecting LMDB datasets in the command-line
+############################################
+
+It can be useful to inspect the data you are trying to train or predict off of, especially
+when things are not behaving as intended. Unfortunately, LMDB is a binary format, and with
+it, makes inspecting data a little harder than plain text like CSV or JSON.
+
+To help with this, ``matsciml`` comes with a ``lmdb_cli`` command line interface that
+provides a few helper functions to inspect data contained in LMDB, ranging from looking
+at the expected data structure and types, to generating and retrieving graphs and computing
+statistics for them.
+
+The currently implemented commands are:
+
+.. autofunction:: matsciml.datasets.lmdb_cli.print_structure
+
+
+.. autofunction:: matsciml.datasets.lmdb_cli.check_sample
+
+
+.. autofunction:: matsciml.datasets.lmdb_cli.interactive
+
+
+.. autofunction:: matsciml.datasets.lmdb_cli.dump_statistics
+
+
 Dataset API reference
 #####################
 

--- a/matsciml/datasets/lmdb_cli.py
+++ b/matsciml/datasets/lmdb_cli.py
@@ -70,7 +70,92 @@ def print_structure(lmdb_dir: PathLike):
 @click.argument(
     "lmdb_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True)
 )
-def summarize(lmdb_dir: PathLike): ...
+@click.argument("index", type=int)
+@click.option(
+    "-d",
+    "--dataset_type",
+    type=click.Choice(__available_datasets__),
+    default=None,
+    help="Dataset class name to use to map the data.",
+)
+@click.option(
+    "-p",
+    "--periodic",
+    is_flag=True,
+    default=True,
+    help="Flag to disable the periodic transform.",
+)
+@click.option(
+    "-r",
+    "--radius",
+    type=float,
+    default=6.0,
+    show_default=True,
+    help="Cut-off radius for periodic property transform.",
+)
+@click.option(
+    "-a",
+    "--adaptive_cutoff",
+    is_flag=True,
+    default=True,
+    help="Flag to disable the adaptive cutoff used in periodic transform.",
+)
+@click.option(
+    "-g",
+    "--graph_backend",
+    type=click.Choice(["pyg", "dgl"], case_sensitive=False),
+    default="pyg",
+    help="Graph backend for transformation.",
+)
+def check_sample(
+    lmdb_dir: PathLike,
+    index: int,
+    periodic,
+    graph_backend,
+    dataset_type,
+    radius,
+    adaptive_cutoff,
+):
+    """
+    Given an LMDB path and a data index, perform optional transforms
+    and print out what the specific sample contains.
+
+    Parameters
+    ----------
+    lmdb_dir : PathLike
+        Path to an LMDB folder structure.
+    index : int
+        Index to the data sample.
+    dataset_type : str, optional
+        Class name for the dataset to interpret the LMDB data. By
+        default is ``None``, which uses ``BaseLMDBDataset`` to
+        load the data. Checks against the ``matsciml`` registry for
+        available datasets.
+    periodic : bool, default True
+        Whether to enable periodic properties transform.
+    radius : float
+        Cut-off radius used by the periodic property transform.
+    adaptive_cutoff : bool, default True
+        Whether to enable the adapative cut-off in the periodic
+        properties transform.
+    graph_backend : Optional, Literal['pyg', 'dgl']
+        Optional choice for graph backend to use. The default is ``pyg``,
+        which emits PyTorch Geometric graphs.
+    """
+    transforms = []
+    if periodic:
+        transforms.append(PeriodicPropertiesTransform(radius, adaptive_cutoff))
+    if graph_backend:
+        transforms.append(PointCloudToGraphTransform(graph_backend))
+    target_class = (
+        BaseLMDBDataset
+        if not dataset_type
+        else registry.get_dataset_class(dataset_type)
+    )
+    dataset = target_class(Path(lmdb_dir).resolve(), transforms=transforms)
+    sample = dataset.__getitem__(index)
+    for key, value in sample.items():
+        click.echo(f"Key - {key}, value: {value}")
 
 
 @main.command()

--- a/matsciml/datasets/lmdb_cli.py
+++ b/matsciml/datasets/lmdb_cli.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
+import code
 from os import PathLike
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from json import dumps
 
 import click
 
+from matsciml import datasets  # noqa: F401
+from matsciml.common.registry import registry
 from matsciml.datasets.base import BaseLMDBDataset
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+
+
+__available_datasets__ = sorted(list(registry.__entries__["datasets"].keys()))
 
 
 def _recurse_dictionary_types(input_dict: dict[Any, Any]) -> dict[Any, str]:
@@ -54,6 +64,105 @@ def print_structure(lmdb_dir: PathLike):
     sample_struct = _recurse_dictionary_types(sample)
     click.echo("Data in LMDB sample corresponds to the following structure:")
     click.echo(dumps(sample_struct, sort_keys=True, indent=2))
+
+
+@main.command()
+@click.argument(
+    "lmdb_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True)
+)
+def summarize(lmdb_dir: PathLike): ...
+
+
+@main.command()
+@click.argument(
+    "lmdb_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True)
+)
+@click.option(
+    "-d",
+    "--dataset_type",
+    type=click.Choice(__available_datasets__),
+    default=None,
+    help="Dataset class name to use to map the data.",
+)
+@click.option(
+    "-p",
+    "--periodic",
+    is_flag=True,
+    default=True,
+    help="Flag to disable the periodic transform.",
+)
+@click.option(
+    "-r",
+    "--radius",
+    type=float,
+    default=6.0,
+    show_default=True,
+    help="Cut-off radius for periodic property transform.",
+)
+@click.option(
+    "-a",
+    "--adaptive_cutoff",
+    is_flag=True,
+    default=True,
+    help="Flag to disable the adaptive cutoff used in periodic transform.",
+)
+@click.option(
+    "-g",
+    "--graph_backend",
+    type=click.Choice(["pyg", "dgl"], case_sensitive=False),
+    default="pyg",
+    help="Graph backend for transformation.",
+)
+def interactive(
+    lmdb_dir: PathLike,
+    dataset_type: str | None,
+    periodic: bool,
+    radius: float,
+    adaptive_cutoff: bool,
+    graph_backend: Literal["pyg", "dgl"] | None,
+):
+    """
+    Loads an LMDB dataset and switches over to an interactive session.
+
+    This allows you to quickly load up an LMDB dataset and perform some interactive
+    debugging. The additional options provide control over graph creation (or lack
+    thereof).
+
+    You can subsequently iterate through the ``dataset`` variable however you
+    wish, but typically with the ``__getitem__(<index>)`` method.
+
+    Parameters
+    ----------
+    lmdb_dir : PathLike
+        Path to an LMDB folder structure.
+    dataset_type : str, optional
+        Class name for the dataset to interpret the LMDB data. By
+        default is ``None``, which uses ``BaseLMDBDataset`` to
+        load the data. Checks against the ``matsciml`` registry for
+        available datasets.
+    periodic : bool, default True
+        Whether to enable periodic properties transform.
+    radius : float
+        Cut-off radius used by the periodic property transform.
+    adaptive_cutoff : bool, default True
+        Whether to enable the adapative cut-off in the periodic
+        properties transform.
+    graph_backend : Optional, Literal['pyg', 'dgl']
+        Optional choice for graph backend to use. The default is ``pyg``,
+        which emits PyTorch Geometric graphs.
+    """
+    transforms = []
+    if periodic:
+        transforms.append(PeriodicPropertiesTransform(radius, adaptive_cutoff))
+    if graph_backend:
+        transforms.append(PointCloudToGraphTransform(graph_backend))
+    target_class = (
+        BaseLMDBDataset
+        if not dataset_type
+        else registry.get_dataset_class(dataset_type)
+    )
+    dataset = target_class(Path(lmdb_dir).resolve(), transforms=transforms)  # noqa: F401
+    code.interact(local=locals())
 
 
 if __name__ == "__main__":

--- a/matsciml/datasets/lmdb_cli.py
+++ b/matsciml/datasets/lmdb_cli.py
@@ -388,14 +388,13 @@ def dump_statistics(
     window_size: int,
 ):
     """
-    Loads an LMDB dataset and switches over to an interactive session.
+    Loads an LMDB dataset and iterates through the dataset,
+    computing a running average for numeric properties that
+    updates interactively and written to a JSON file afterwards.
 
-    This allows you to quickly load up an LMDB dataset and perform some interactive
-    debugging. The additional options provide control over graph creation (or lack
-    thereof).
-
-    You can subsequently iterate through the ``dataset`` variable however you
-    wish, but typically with the ``__getitem__(<index>)`` method.
+    The JSON file will be named after the dataset class used
+    to interpret the data followed by the specific directory/split
+    name and written to the current folder.
 
     Parameters
     ----------

--- a/matsciml/datasets/lmdb_cli.py
+++ b/matsciml/datasets/lmdb_cli.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from os import PathLike
+from pathlib import Path
+from typing import Any
+from json import dumps
+
+import click
+
+from matsciml.datasets.base import BaseLMDBDataset
+
+
+def _recurse_dictionary_types(input_dict: dict[Any, Any]) -> dict[Any, str]:
+    return_dict = {}
+    for key, value in input_dict.items():
+        if isinstance(value, dict):
+            return_dict[key] = _recurse_dictionary_types(value)
+        else:
+            return_dict[key] = type(value).__name__
+    return return_dict
+
+
+@click.group()
+def main() -> None:
+    """
+    A command-line interface for inspecting Open MatSciML Toolkit LMDB files.
+
+    Subcommands provide a number of utilities that can be helpful for checking
+    the contents of an LMDB dataset in the command line without necessarily
+    writing bespoke code.
+    """
+    ...
+
+
+@main.command()
+@click.argument(
+    "lmdb_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True)
+)
+def print_structure(lmdb_dir: PathLike):
+    """
+    Retrieve the first sample in an LMDB set and print out its keys.
+
+    This is useful for checking whether or not the key you expect
+    is present in the data. This function uses ``BaseLMDBDataset``
+    to load in the data, without assuming any particular dataset type.
+
+    Parameters
+    ----------
+    lmdb_dir : PathLike
+        String or Path object pointing to an LMDB directory.
+    """
+    dset = BaseLMDBDataset(Path(lmdb_dir).resolve())
+    sample = dset.__getitem__(0)
+    sample_struct = _recurse_dictionary_types(sample)
+    click.echo("Data in LMDB sample corresponds to the following structure:")
+    click.echo(dumps(sample_struct, sort_keys=True, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ license = {file = "LICENSE.md"}
 name = "matsciml"
 requires-python = ">=3.8"
 
+[project.scripts]
+lmdb_cli = "matsciml.datasets.lmdb_cli:main"
+
 [project.optional-dependencies]
 all = [
   "matsciml[dev,symmetry,pyg]",


### PR DESCRIPTION
This PR adds a big QoL oriented CLI, which provides some high level functionality for inspecting LMDB datasets.

- Adds a `matsciml.datasets.lmdb_cli` module, which houses a `click`-based interface with multiple commands that perform various LMDB inspection tasks
- Updates `pyproject.toml` to install `lmdb_cli` as a "script", which allows you to access the CLI after installing `matsciml` simply by running `lmdb_cli` in the command line.
- Accompanying documentaton