### PR TITLE
Quantile-based loss mechanism

### DIFF
--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -150,3 +150,21 @@ potential difficulty in the task.
 
 .. autoclass:: matsciml.models.base.NodeDenoisingTask
    :members:
+
+
+Loss functions
+==============
+
+Each task will have a default loss function that is ensured to work for that particular task.
+Some tasks and datasets may need more flexibility in how training signals are computed, and
+the currently implemented interface for tasks allows a dictionary mapping of task key and
+loss function to be passed as a hyperparameter. In addition to the typical PyTorch losses
+like ``L1Loss`` and ``MSELoss``, we also implement some loss functions based on ideas borrowed
+from other repositories, such as MACE.
+
+.. autoclass:: matsciml.models.losses.AtomWeightedMSE
+   :members:
+
+
+.. autoclass:: matsciml.models.losses.BatchQuantileLoss
+   :members:

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -108,9 +108,8 @@ class BatchQuantileLoss(nn.Module):
         self.loss_func = loss_func
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-        assert target.ndim >= 2, "BatchQuantileLoss assumes vector quantites."
         if self.use_norm:
-            target_quantity = target.norm(dim=-1)
+            target_quantity = target.norm(dim=-1, keepdim=True)
         else:
             target_quantity = target
         target_quantiles = torch.quantile(target_quantity, q=self.quantiles)

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -71,7 +71,7 @@ class BatchQuantileLoss(nn.Module):
     def __init__(
         self,
         quantile_weights: dict[float, float],
-        loss_func: Callable | Literal["mse", "rmse", "huber"],
+        loss_func: Callable | Literal["mse", "mae", "rmse", "huber"],
         use_norm: bool = True,
         huber_delta: float | None = None,
     ) -> None:
@@ -98,7 +98,7 @@ class BatchQuantileLoss(nn.Module):
             than the last bin take on these respective values, while
             quantile in between bin ranges include the lower quantile
             and up to (not including) the next bin.
-        loss_func : Callable | Literal['mse', 'rmse', 'huber']
+        loss_func : Callable | Literal['mse', 'mae', 'rmse', 'huber']
             Actual metric function. If a string literal is given, then
             one of the built-in PyTorch functional losses are used
             based on either MSE, RMSE, or Huber loss. If a ``Callable``
@@ -143,6 +143,8 @@ class BatchQuantileLoss(nn.Module):
         if isinstance(loss_func, str):
             if loss_func == "mse":
                 loss_func = partial(torch.nn.functional.mse_loss, reduction="none")
+            elif loss_func == "mae":
+                loss_func = partial(torch.nn.functional.l1_loss, reduction="none")
             elif loss_func == "rmse":
                 raise NotImplementedError("RMSE function has not yet been implemented.")
             elif loss_func == "huber":

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -166,7 +166,7 @@ class BatchQuantileLoss(nn.Module):
         # define the first quantile bracket
         target_weights[target_quantity < target_quantiles[0]] = self.weights[0]
         # now do quantiles in between
-        for index in range(1, len(self.weights) - 1):
+        for index in range(len(self.weights) - 1):
             curr_quantile = self.quantiles[index]
             next_quantile = self.quantiles[index + 1]
             curr_weight = self.weights[index]

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -90,6 +90,10 @@ class BatchQuantileLoss(nn.Module):
         weight predicted vs. actual margins, as computed with ``loss_func``.
         The mean of the weighted loss is then returned.
 
+        In the case of ``loss_func='huber'``, the ``huber_delta`` argument specifies
+        the margin used to switch between MAE and MSE losses. This value
+        is applied globally (i.e. regardless of the quantile).
+
         Parameters
         ----------
         quantile_weights : dict[float, float]

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -158,7 +158,11 @@ class BatchQuantileLoss(nn.Module):
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         if self.use_norm:
-            target_quantity = target.norm(dim=-1, keepdim=True)
+            if target.ndim == 1:
+                temp_target = target.unsqueeze(-1)
+            else:
+                temp_target = target
+            target_quantity = temp_target.norm(dim=-1, keepdim=True)
         else:
             target_quantity = target
         target_quantiles = torch.quantile(target_quantity, q=self.quantiles)

--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -179,7 +179,7 @@ class BatchQuantileLoss(nn.Module):
             )
             target_weights[mask] = curr_weight
         # the last bin
-        target_weights[target_quantity > target_quantiles[-1]] = self.weights[-1]
+        target_weights[target_quantity >= target_quantiles[-1]] = self.weights[-1]
         unweighted_loss = self.loss_func(input, target)
         weighted_loss = unweighted_loss * target_weights
         return weighted_loss.mean()

--- a/matsciml/models/tests/test_losses.py
+++ b/matsciml/models/tests/test_losses.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 import pytest
 import torch
+from lightning import pytorch as pl
 
+from matsciml.lightning import MatSciMLDataModule
+from matsciml.datasets.transforms import (
+    PeriodicPropertiesTransform,
+    PointCloudToGraphTransform,
+)
+from matsciml.models.base import ForceRegressionTask
+from matsciml.models.pyg import EGNN
 from matsciml.models import losses
 
 
@@ -47,3 +55,30 @@ def test_quantile_loss(shape, quantiles, use_norm, loss_func):
     l_func = losses.BatchQuantileLoss(quantiles, loss_func, use_norm, huber_delta=0.01)
     loss = l_func(x, y)
     loss.mean().backward()
+
+
+def test_quantile_loss_egnn():
+    task = ForceRegressionTask(
+        encoder_class=EGNN,
+        encoder_kwargs={"hidden_dim": 64, "output_dim": 64},
+        output_kwargs={"lazy": False, "input_dim": 64, "hidden_dim": 64},
+        loss_func={
+            "energy": torch.nn.MSELoss,
+            "force": losses.BatchQuantileLoss(
+                {0.1: 0.5, 0.25: 0.9, 0.5: 1.5, 0.85: 2.0, 0.95: 1.0},
+                loss_func="huber",
+                huber_delta=0.01,
+            ),
+        },
+    )
+    dm = MatSciMLDataModule.from_devset(
+        "LiPSDataset",
+        dset_kwargs={
+            "transforms": [
+                PeriodicPropertiesTransform(6.0),
+                PointCloudToGraphTransform("pyg"),
+            ]
+        },
+    )
+    trainer = pl.Trainer(fast_dev_run=10)
+    trainer.fit(task, datamodule=dm)

--- a/matsciml/models/tests/test_losses.py
+++ b/matsciml/models/tests/test_losses.py
@@ -29,3 +29,21 @@ def test_weighted_mse(atom_weighted_mse, shape):
     target = torch.rand_like(pred)
     ptr = torch.randint(1, 100, (shape[0],))
     atom_weighted_mse(pred, target, ptr)
+
+
+@pytest.mark.parametrize("shape", [(10,), (50, 3)])
+@pytest.mark.parametrize(
+    "quantiles",
+    [
+        {0.25: 0.5, 0.5: 1.0, 0.75: 3.21},
+        {0.02: 0.2, 0.32: 0.67, 0.5: 1.0, 0.83: 2.0, 0.95: 10.0},
+    ],
+)
+@pytest.mark.parametrize("use_norm", [True, False])
+@pytest.mark.parametrize("loss_func", ["mse", "huber"])
+def test_quantile_loss(shape, quantiles, use_norm, loss_func):
+    # ensure we test against back prop as well
+    x, y = torch.rand(2, *shape, requires_grad=True)
+    l_func = losses.BatchQuantileLoss(quantiles, loss_func, use_norm, huber_delta=0.01)
+    loss = l_func(x, y)
+    loss.mean().backward()


### PR DESCRIPTION
This PR implements a dynamic quantile-based loss, which computes and rescales specified loss functions depending on quantiles bins within a batch. An accompanying suite of tests will test argument capabilities as well as the end-to-end training with a nominal `EGNN` and `ForceRegressionTask`.

How the loss function works is detailed in the docstring. At a high level, we take the targets and compute their respective quantiles, and use these values to bin the targets as to allow the user to define which ranges to (de)emphasize. 