### PR TITLE
Adding `BatchQuantileLoss` to `__all__`

### DIFF
--- a/matsciml/models/losses.py
+++ b/matsciml/models/losses.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 
 
-__all__ = ["AtomWeightedL1", "AtomWeightedMSE"]
+__all__ = ["AtomWeightedL1", "AtomWeightedMSE", "BatchQuantileLoss"]
 
 
 class AtomWeightedL1(nn.Module):


### PR DESCRIPTION
This PR fixes the inability to import `BatchQuantileLoss` from the `losses` submodule, even if importing it directly with `from matsciml.models.losses import BatchQuantileLoss`, as it was accidentally omitted from the module's `__all__` definition.