### PR TITLE
ASE Backend For PBC Computation

### DIFF
--- a/matsciml/datasets/tests/test_transforms.py
+++ b/matsciml/datasets/tests/test_transforms.py
@@ -177,5 +177,23 @@ def test_graph_sorting():
     )
     dm.setup()
     loader = dm.train_dataloader()
-    graph = next(iter(loader))["graph"]
+    _ = next(iter(loader))["graph"]
     # not really anything to test, but just make sure it runs :D
+
+
+@pytest.mark.parametrize("backend", ["ase", "pymatgen"])
+def test_ase_periodic(backend):
+    trans = [
+        transforms.PeriodicPropertiesTransform(
+            cutoff_radius=6.0, adaptive_cutoff=True, backend=backend
+        )
+    ]
+    dm = MatSciMLDataModule.from_devset(
+        "S2EFDataset",
+        dset_kwargs={"transforms": trans},
+    )
+    dm.setup()
+    loader = dm.train_dataloader()
+    batch = next(iter(loader))
+    # check if periodic properties transform was applied
+    assert "unit_offsets" in batch

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 import torch
 from pymatgen.core import Lattice, Structure
@@ -35,7 +37,7 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
         self,
         cutoff_radius: float,
         adaptive_cutoff: bool = False,
-        backend: str = "pymatgen",
+        backend: Literal["pymatgen", "ase"] = "pymatgen",
     ) -> None:
         super().__init__()
         self.cutoff_radius = cutoff_radius

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import torch
 import numpy as np
+import torch
 from pymatgen.core import Lattice, Structure
 
 from matsciml.common.types import DataDict
 from matsciml.datasets.transforms.base import AbstractDataTransform
 from matsciml.datasets.utils import (
     calculate_periodic_shifts,
+    calculate_ase_periodic_shifts,
     make_pymatgen_periodic_structure,
 )
 
@@ -30,10 +31,16 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
     a large cut off for the entire dataset.
     """
 
-    def __init__(self, cutoff_radius: float, adaptive_cutoff: bool = False) -> None:
+    def __init__(
+        self,
+        cutoff_radius: float,
+        adaptive_cutoff: bool = False,
+        backend: str = "pymatgen",
+    ) -> None:
         super().__init__()
         self.cutoff_radius = cutoff_radius
         self.adaptive_cutoff = adaptive_cutoff
+        self.backend = backend
 
     def __call__(self, data: DataDict) -> DataDict:
         """
@@ -107,13 +114,23 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                 tuple(angle * (180.0 / torch.pi) for angle in angles),
             )
             lattice = Lattice.from_parameters(*abc, *angles, vesta=True)
+            # We need cell in data for ase backend.
+            data["cell"] = torch.tensor(lattice.matrix).unsqueeze(0).float()
+
         structure = make_pymatgen_periodic_structure(
             data["atomic_numbers"],
             data["pos"],
             lattice=lattice,
         )
-        graph_props = calculate_periodic_shifts(
-            structure, self.cutoff_radius, self.adaptive_cutoff
-        )
+        if self.backend == "pymatgen":
+            graph_props = calculate_periodic_shifts(
+                structure, self.cutoff_radius, self.adaptive_cutoff
+            )
+        elif self.backend == "ase":
+            graph_props = calculate_ase_periodic_shifts(
+                data, self.cutoff_radius, self.adaptive_cutoff
+            )
+        else:
+            raise RuntimeError(f"Requested backend f{self.backend} not available.")
         data.update(graph_props)
         return data

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -763,6 +763,7 @@ def calculate_ase_periodic_shifts(data, cutoff_radius, adaptive_cutoff):
         positions=data["pos"],
         numbers=data["atomic_numbers"],
         cell=cell.squeeze(0),
+        # Hard coding in the PBC direction for x, y, z.
         pbc=(True, True, True),
     )
     cutoff = [cutoff_radius] * atoms.positions.shape[0]


### PR DESCRIPTION
This PR adds a flag to the `PeriodicBoundaryCondition` transform to use either `pymatgen` or `ase` as a backend. The ASE backend is implemented and makes use of the [NeighborList](https://wiki.fysik.dtu.dk/ase/_modules/ase/neighborlist.html#NeighborList) utility in ASE. This requires creating an atoms object, and specifying a cutoff distance per node. The two functions `calculate_ase_periodic_shifts` and `calculate_periodic_shifts` are quite similar, however hard to combine due to the dependency on the different backends, so they are kept separate for now. 

Some parameters that may have an impact on results:
`NeighborList`: `self_interaction`, `bothways`
`Atoms`: `pbc`

For example, blindly applying PBC in x, y, and z for a structure which is not meant to be periodic in these directions may impact results. 