### PR TITLE
Revising optional package imports

### DIFF
--- a/matsciml/__init__.py
+++ b/matsciml/__init__.py
@@ -3,22 +3,8 @@ from __future__ import annotations
 from logging import getLogger
 
 # determine if intel libraries are available
-from matsciml.common.packages import package_registry
+from matsciml.common.packages import package_registry  # noqa: F401
 
 __version__ = "1.1.0"
 
 logger = getLogger(__file__)
-
-
-if package_registry["ipex"]:
-    try:
-        import intel_extension_for_pytorch  # noqa: F401
-    except ImportError as e:
-        logger.warning(f"Unable to load IPEX because of {e} - XPU may not function.")
-if package_registry["ccl"]:
-    try:
-        import oneccl_bindings_for_pytorch  # noqa: F401
-    except ImportError as e:
-        logger.warning(
-            f"Unable to load CCL bindings because of {e} - DDP XPU may not function."
-        )

--- a/matsciml/common/packages.py
+++ b/matsciml/common/packages.py
@@ -27,9 +27,7 @@ for package in [
         import_module(package)
         success = True
     except Exception:
-        logger.opt(exception=True).warning(
-            f"Could not import {package}, which may impact functionality."
-        )
+        logger.warning(f"Could not import {package}, which may impact functionality.")
     package_registry[package] = success
 # for backwards compatibility and looks better anyway
 package_registry["pyg"] = package_registry["torch_geometric"]

--- a/matsciml/common/packages.py
+++ b/matsciml/common/packages.py
@@ -13,14 +13,15 @@ The `package_registry` object is a convenient way to determine which packages ha
 been installed.
 """
 package_registry = {}
-package_registry["ipex"] = (
-    True if util.find_spec("intel_extension_for_pytorch") else False
-)
-package_registry["ccl"] = (
-    True if util.find_spec("oneccl_bindings_for_pytorch") else False
-)
 # graph specific packages; slightly more involved because we should try import
-for package in ["torch_geometric", "torch_scatter", "torch_sparse", "dgl"]:
+for package in [
+    "torch_geometric",
+    "torch_scatter",
+    "torch_sparse",
+    "dgl",
+    "intel_extension_for_pytorch",
+    "oneccl_bindings_for_pytorch",
+]:
     success = False
     try:
         import_module(package)
@@ -32,6 +33,8 @@ for package in ["torch_geometric", "torch_scatter", "torch_sparse", "dgl"]:
     package_registry[package] = success
 # for backwards compatibility and looks better anyway
 package_registry["pyg"] = package_registry["torch_geometric"]
+package_registry["ipex"] = package_registry["intel_extension_for_pytorch"]
+package_registry["ccl"] = package_registry["oneccl_bindings_for_pytorch"]
 package_registry["codecarbon"] = True if util.find_spec("codecarbon") else False
 
 

--- a/matsciml/lightning/__init__.py
+++ b/matsciml/lightning/__init__.py
@@ -2,11 +2,9 @@
 # SPDX-License-Identifier: MIT License
 from __future__ import annotations
 
-from matsciml.common.packages import package_registry
+from matsciml.common.packages import package_registry  # noqa: F401
 from matsciml.lightning.ddp import *
 from matsciml.lightning.data_utils import *
-
-if package_registry["ipex"]:
-    from matsciml.lightning.xpu import *
+from matsciml.lightning.xpu import *
 
 __all__ = ["MatSciMLDataModule", "MultiDataModule"]

--- a/matsciml/lightning/xpu.py
+++ b/matsciml/lightning/xpu.py
@@ -16,12 +16,8 @@ default_pg_timeout = timedelta(seconds=1800)
 
 logger = getLogger(__file__)
 
-if package_registry["ipex"]:
-    try:
-        import intel_extension_for_pytorch as ipex  # noqa: F401
-    except ImportError as e:
-        logger.warning(f"Unable to import IPEX due to {e} - XPU may not function.")
-
+# IPEX is not absolutely required for XPU usage for torch>=2.5.0
+if package_registry["ipex"] or torch.xpu.is_available():
     __all__ = ["XPUAccelerator", "SingleXPUStrategy"]
 
     class XPUAccelerator(Accelerator):

--- a/matsciml/lightning/xpu.py
+++ b/matsciml/lightning/xpu.py
@@ -159,3 +159,7 @@ if package_registry["ipex"] or torch.xpu.is_available():
         SingleXPUStrategy,
         description="Strategy utilizing a single Intel GPU device or tile.",
     )
+else:
+    logger.warning(
+        "IPEX was not installed or XPU is not available. `matsciml.lightning.xpu` will be empty."
+    )

--- a/matsciml/models/pyg/__init__.py
+++ b/matsciml/models/pyg/__init__.py
@@ -7,6 +7,8 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
+from loguru import logger
+
 from matsciml.common.packages import package_registry
 
 if "pyg" in package_registry:
@@ -18,7 +20,6 @@ else:
 if _has_pyg:
     from matsciml.models.pyg.cgcnn import CGCNN
     from matsciml.models.pyg.egnn import EGNN
-    from matsciml.models.pyg.faenet import FAENet
     from matsciml.models.pyg.mace import MACE, ScaleShiftMACE
 
     __all__ = ["CGCNN", "EGNN", "FAENet", "MACE", "ScaleShiftMACE"]
@@ -29,8 +30,17 @@ if _has_pyg:
         from matsciml.models.pyg.dimenet_plus_plus import DimeNetPlusPlusWrap
 
         __all__.extend(["DimeNetWrap", "DimeNetPlusPlusWrap"])
+    else:
+        logger.warning(
+            "Missing torch_sparse and torch_scatter; DimeNet models will not be available."
+        )
     if package_registry["torch_scatter"]:
         from matsciml.models.pyg.forcenet import ForceNet
         from matsciml.models.pyg.schnet import SchNetWrap
+        from matsciml.models.pyg.faenet import FAENet
 
-        __all__.extend(["ForceNet", "SchNetWrap"])
+        __all__.extend(["ForceNet", "SchNetWrap", "FAENet"])
+    else:
+        logger.warning(
+            "Missing torch_scatter; ForceNet, SchNet, and FAENet models will not be available."
+        )

--- a/matsciml/models/pyg/__init__.py
+++ b/matsciml/models/pyg/__init__.py
@@ -4,6 +4,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
+
 from __future__ import annotations
 
 from matsciml.common.packages import package_registry
@@ -16,10 +17,20 @@ else:
 # load models if we have PyG installed
 if _has_pyg:
     from matsciml.models.pyg.cgcnn import CGCNN
-    from matsciml.models.pyg.dimenet import DimeNetWrap
-    from matsciml.models.pyg.dimenet_plus_plus import DimeNetPlusPlusWrap
     from matsciml.models.pyg.egnn import EGNN
     from matsciml.models.pyg.faenet import FAENet
-    from matsciml.models.pyg.forcenet import ForceNet
     from matsciml.models.pyg.mace import MACE, ScaleShiftMACE
-    from matsciml.models.pyg.schnet import SchNetWrap
+
+    __all__ = ["CGCNN", "EGNN", "FAENet", "MACE", "ScaleShiftMACE"]
+
+    # these packages need additional pyg dependencies
+    if package_registry["torch_sparse"] and package_registry["torch_scatter"]:
+        from matsciml.models.pyg.dimenet import DimeNetWrap
+        from matsciml.models.pyg.dimenet_plus_plus import DimeNetPlusPlusWrap
+
+        __all__.extend(["DimeNetWrap", "DimeNetPlusPlusWrap"])
+    if package_registry["torch_scatter"]:
+        from matsciml.models.pyg.forcenet import ForceNet
+        from matsciml.models.pyg.schnet import SchNetWrap
+
+        __all__.extend(["ForceNet", "SchNetWrap"])


### PR DESCRIPTION
This PR uses the package registry a little bit more uniformly in determining which optional dependencies have been installed and are available.

- To support Intel XPUs being available in upstream PyTorch now, IPEX is no longer a required dependency and the accelerator and DDP strategies are imported if `torch.xpu.is_available()` or if IPEX was successfully imported. A warning will be posted if this module is loaded directly and if neither condition is fulfilled.
- On a similar vein, `torch_scatter` and `torch_sparse` being unavailable  or unimportable would mean _every_ PyG model would not work even if they are not required. This PR adds checks to gracefully try and include those models with explicit `torch_scatter` and/or `torch_sparse` dependencies, and warns the user that they will not be available.