### PR TITLE
Structured model output type

### DIFF
--- a/matsciml/common/tests/test_types.py
+++ b/matsciml/common/tests/test_types.py
@@ -22,3 +22,20 @@ def test_incorrect_force_shape():
     """This passes a force tensor with too many dimensions"""
     with pytest.raises(ValidationError):
         types.ModelOutput(batch_size=8, forces=torch.rand(32, 4, 3))
+
+
+def test_consistency_check_pass():
+    types.ModelOutput(
+        batch_size=8, forces=torch.rand(32, 3), node_energies=torch.rand(32, 1)
+    )
+
+
+def test_consistency_check_fail():
+    with pytest.raises(ValidationError):
+        # check mismatching node energies and forces
+        types.ModelOutput(
+            batch_size=8, forces=torch.rand(32, 3), node_energies=torch.rand(64, 1)
+        )
+    with pytest.raises(ValidationError):
+        # check mismatch in
+        types.ModelOutput(batch_size=4, total_energy=torch.rand(16, 1))

--- a/matsciml/common/tests/test_types.py
+++ b/matsciml/common/tests/test_types.py
@@ -18,6 +18,13 @@ def test_invalid_embeddings():
         types.ModelOutput(batch_size=8, embeddings="aggaga")
 
 
+def test_valid_embeddings():
+    embeddings = types.Embeddings(
+        system_embedding=torch.rand(64, 32), point_embedding=torch.rand(162, 32)
+    )
+    types.ModelOutput(batch_size=64, embeddings=embeddings)
+
+
 def test_incorrect_force_shape():
     """This passes a force tensor with too many dimensions"""
     with pytest.raises(ValidationError):

--- a/matsciml/common/tests/test_types.py
+++ b/matsciml/common/tests/test_types.py
@@ -1,8 +1,24 @@
 from __future__ import annotations
 
+import torch
+import pytest
+from pydantic import ValidationError
+
 from matsciml.common import types
 
 
 def test_output_validation():
     """Simple unit test to make sure a minimal configuration works."""
     types.ModelOutput(batch_size=16, embeddings=None, node_energies=None)
+
+
+def test_invalid_embeddings():
+    """Type invalid embeddings"""
+    with pytest.raises(ValidationError):
+        types.ModelOutput(batch_size=8, embeddings="aggaga")
+
+
+def test_incorrect_force_shape():
+    """This passes a force tensor with too many dimensions"""
+    with pytest.raises(ValidationError):
+        types.ModelOutput(batch_size=8, forces=torch.rand(32, 4, 3))

--- a/matsciml/common/tests/test_types.py
+++ b/matsciml/common/tests/test_types.py
@@ -44,5 +44,5 @@ def test_consistency_check_fail():
             batch_size=8, forces=torch.rand(32, 3), node_energies=torch.rand(64, 1)
         )
     with pytest.raises(RuntimeError):
-        # check mismatch in
+        # check mismatch in number of energies and batch size
         types.ModelOutput(batch_size=4, total_energy=torch.rand(16, 1))

--- a/matsciml/common/tests/test_types.py
+++ b/matsciml/common/tests/test_types.py
@@ -31,11 +31,11 @@ def test_consistency_check_pass():
 
 
 def test_consistency_check_fail():
-    with pytest.raises(ValidationError):
+    with pytest.raises(RuntimeError):
         # check mismatching node energies and forces
         types.ModelOutput(
             batch_size=8, forces=torch.rand(32, 3), node_energies=torch.rand(64, 1)
         )
-    with pytest.raises(ValidationError):
+    with pytest.raises(RuntimeError):
         # check mismatch in
         types.ModelOutput(batch_size=4, total_energy=torch.rand(16, 1))

--- a/matsciml/common/tests/test_types.py
+++ b/matsciml/common/tests/test_types.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from matsciml.common import types
+
+
+def test_output_validation():
+    """Simple unit test to make sure a minimal configuration works."""
+    types.ModelOutput(batch_size=16, embeddings=None, node_energies=None)

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable, Union
 
 import torch
-from pydantic import ConfigDict, Field, ValidationError, field_validator, BaseModel
+from pydantic import ConfigDict, Field, field_validator, BaseModel
 
 from matsciml.common import package_registry
 
@@ -133,16 +133,16 @@ class ModelOutput(BaseModel):
 
         Raises
         ------
-        ValidationError:
+        ValueError:
             If after running ``squeeze`` on the input tensor, the
             dimensions are still greater than one we raise a
-            ``ValidationError``.
+            ``ValueError``.
         """
         # drop all redundant dimensions
         values = values.squeeze()
         # last step is an assertion check for QA
         if values.ndim != 1:
-            raise ValidationError(
+            raise ValueError(
                 f"Expected graph/system energies to be scalar; got shape {values.shape}"
             )
         return values
@@ -166,16 +166,14 @@ class ModelOutput(BaseModel):
 
         Raises
         ------
-        ValidationError:
+        ValueError:
             If the dimensionality of the tensor is not 2D, and/or
             if the last dimensionality of the tensor is not 3-long.
         """
         if forces.ndim != 2:
-            raise ValidationError(
-                f"Expected force tensor to be 2D; got {forces.shape}."
-            )
+            raise ValueError(f"Expected force tensor to be 2D; got {forces.shape}.")
         if forces.size(-1) != 3:
-            raise ValidationError(
+            raise ValueError(
                 f"Expected last dimension of forces to be length 3; got {forces.shape}."
             )
         return forces

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -91,3 +91,22 @@ class Embeddings:
         system_embeddings = reduction(self.point_embedding, **self.reduction_kwargs)
         self.system_embedding = system_embeddings
         return system_embeddings
+
+
+@dataclass
+class ModelOutput:
+    """
+    Standardized output data structure out of models.
+
+    The advantage of doing is to standardize keys, as well
+    as to standardize shapes the are produced by models;
+    i.e. remove unused dimensions using ``pydantic``
+    validation mechanisms.
+    """
+
+    batch_size: int
+    embeddings: Embeddings | None = None
+    node_energies: torch.Tensor | None = None
+    total_energy: torch.Tensor | None = None
+    forces: torch.Tensor | None = None
+    stresses: torch.Tensor | None = None

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -145,3 +145,36 @@ class ModelOutput:
                 f"Expected graph/system energies to be scalar; got shape {values.shape}"
             )
         return values
+
+    @field_validator("forces", mode="after")
+    @classmethod
+    def check_force_shape(cls, forces: torch.Tensor) -> torch.Tensor:
+        """
+        Check to ensure that the force tensor has the expected
+        shape. Runs after the type checking by ``pydantic``.
+
+        Parameters
+        ----------
+        forces : torch.Tensor
+            Force tensor to check.
+
+        Returns
+        -------
+        torch.Tensor
+            Validated force tensor without modifications.
+
+        Raises
+        ------
+        ValidationError:
+            If the dimensionality of the tensor is not 2D, and/or
+            if the last dimensionality of the tensor is not 3-long.
+        """
+        if forces.ndim != 2:
+            raise ValidationError(
+                f"Expected force tensor to be 2D; got {forces.shape}."
+            )
+        if forces.size(-1) != 3:
+            raise ValidationError(
+                f"Expected last dimension of forces to be length 3; got {forces.shape}."
+            )
+        return forces

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Callable, Union
 
 import torch
@@ -35,7 +36,8 @@ DataDict = dict[str, Union[float, DataType]]
 BatchDict = dict[str, Union[float, DataType, DataDict]]
 
 
-class Embeddings(BaseModel):
+@dataclass
+class Embeddings:
     """
     Data structure that packs together embeddings from a model.
     """
@@ -44,8 +46,6 @@ class Embeddings(BaseModel):
     point_embedding: torch.Tensor | None = None
     reduction: str | Callable | None = None
     reduction_kwargs: dict[str, str | float] = Field(default_factory=dict)
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
     def num_points(self) -> int:

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Callable, Union
 
 import torch
+from pydantic import Field
+from pydantic.dataclasses import dataclass
 
 from matsciml.common import package_registry
 
@@ -44,7 +45,7 @@ class Embeddings:
     system_embedding: torch.Tensor | None = None
     point_embedding: torch.Tensor | None = None
     reduction: str | Callable | None = None
-    reduction_kwargs: dict[str, str | float] = field(default_factory=dict)
+    reduction_kwargs: dict[str, str | float] = Field(default_factory=dict)
 
     @property
     def num_points(self) -> int:

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -114,7 +114,9 @@ class ModelOutput(BaseModel):
 
     @field_validator("total_energy", mode="before")
     @classmethod
-    def standardize_total_energy(cls, values: torch.Tensor) -> torch.Tensor:
+    def standardize_total_energy(
+        cls, values: torch.Tensor | None
+    ) -> torch.Tensor | None:
         """
         Check to ensure the total energy tensor being passed
         is ultimately scalar.
@@ -138,13 +140,14 @@ class ModelOutput(BaseModel):
             dimensions are still greater than one we raise a
             ``ValueError``.
         """
-        # drop all redundant dimensions
-        values = values.squeeze()
-        # last step is an assertion check for QA
-        if values.ndim != 1:
-            raise ValueError(
-                f"Expected graph/system energies to be scalar; got shape {values.shape}"
-            )
+        if isinstance(values, torch.Tensor):
+            # drop all redundant dimensions
+            values = values.squeeze()
+            # last step is an assertion check for QA
+            if values.ndim != 1:
+                raise ValueError(
+                    f"Expected graph/system energies to be scalar; got shape {values.shape}"
+                )
         return values
 
     @field_validator("forces", mode="after")

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -202,4 +202,10 @@ class ModelOutput(BaseModel):
                 raise RuntimeError(
                     f"Batch size ({self.batch_size}) and energy mismatch ({len(self.total_energy)})."
                 )
+        if isinstance(self.embeddings, Embeddings):
+            if not self.embeddings.system_embedding.size(0) == self.batch_size:
+                raise RuntimeError(
+                    f"Expected {self.batch_size} system embeddings; got {self.embeddings.system_embedding.size(0)}."
+                )
+
         return self

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import Callable, Union
 
 import torch
-from pydantic import Field, ValidationError, field_validator
-from pydantic.dataclasses import dataclass
+from pydantic import ConfigDict, Field, ValidationError, field_validator, BaseModel
 
 from matsciml.common import package_registry
 
@@ -36,8 +35,7 @@ DataDict = dict[str, Union[float, DataType]]
 BatchDict = dict[str, Union[float, DataType, DataDict]]
 
 
-@dataclass
-class Embeddings:
+class Embeddings(BaseModel):
     """
     Data structure that packs together embeddings from a model.
     """
@@ -46,6 +44,8 @@ class Embeddings:
     point_embedding: torch.Tensor | None = None
     reduction: str | Callable | None = None
     reduction_kwargs: dict[str, str | float] = Field(default_factory=dict)
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
     def num_points(self) -> int:
@@ -93,8 +93,7 @@ class Embeddings:
         return system_embeddings
 
 
-@dataclass
-class ModelOutput:
+class ModelOutput(BaseModel):
     """
     Standardized output data structure out of models.
 
@@ -110,6 +109,8 @@ class ModelOutput:
     total_energy: torch.Tensor | None = None
     forces: torch.Tensor | None = None
     stresses: torch.Tensor | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @field_validator("total_energy", mode="before")
     @classmethod

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -149,7 +149,7 @@ class ModelOutput(BaseModel):
 
     @field_validator("forces", mode="after")
     @classmethod
-    def check_force_shape(cls, forces: torch.Tensor) -> torch.Tensor:
+    def check_force_shape(cls, forces: torch.Tensor | None) -> torch.Tensor | None:
         """
         Check to ensure that the force tensor has the expected
         shape. Runs after the type checking by ``pydantic``.
@@ -170,12 +170,13 @@ class ModelOutput(BaseModel):
             If the dimensionality of the tensor is not 2D, and/or
             if the last dimensionality of the tensor is not 3-long.
         """
-        if forces.ndim != 2:
-            raise ValueError(f"Expected force tensor to be 2D; got {forces.shape}.")
-        if forces.size(-1) != 3:
-            raise ValueError(
-                f"Expected last dimension of forces to be length 3; got {forces.shape}."
-            )
+        if isinstance(forces, torch.Tensor):
+            if forces.ndim != 2:
+                raise ValueError(f"Expected force tensor to be 2D; got {forces.shape}.")
+            if forces.size(-1) != 3:
+                raise ValueError(
+                    f"Expected last dimension of forces to be length 3; got {forces.shape}."
+                )
         return forces
 
     @model_validator(mode="after")


### PR DESCRIPTION
This PR introduces `pydantic` based data structures for homogenizing model outputs.

1. I've refactored the `Embeddings` class to use `pydantic`, away from the native `dataclass`. There wasn't much modification otherwise, as there aren't as many validation checks to be done with it.
2. The new `ModelOutput` data structure should be the way forward for all models; refactoring that can come later. The main advantage of this class is to homogenize and validate model outputs, and provide meaningful/helpful ways to debug when issues arise (e.g. shape mismatches, batch size with energy predictions, etc.).

At a high level, `pydantic` will run type checking on the inputs (casting when possible), and run user-defined `before` and `after` checks at the `Field` (specific attributes) and `Model` levels - we use the whole gambit for checking. The included unit tests should demonstrate how the class is expected to behave: most keyword arguments are optional (an upcoming PR will explain why), and we will perform checks if and when the relevant data is available.

Keep in mind `pydantic` models _only_ accept kwargs for creation - i.e. we have to be a bit more verbose/explicit, unfortunately.