### PR TITLE
Introducing structured model outputs

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -48,6 +48,13 @@ Open MatSciML Toolkit workflow of leveraging one or more output heads.
    :members:
 
 
+.. important::
+   Training tasks and workflows should branch based on the prescence of either
+   objects, taking ``ModelOutput`` as the priority. For specific tasks, we can
+   check if properties are set (e.g. ``total_energy`` and ``forces``), and if
+   they aren't there, we should pass the ``embeddings`` to output heads.
+
+
 PyG models
 ----------
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -19,6 +19,35 @@ The model interfaces we have depend on their original implementation:
 currently, we support models from DGL, PyG, and point clouds (specifically
 GALA).
 
+Implementing interfaces
+-----------------------
+
+.. note::
+   This section is primarily a detail for developers. If you are a user
+   and aren't interested in implementation details, feel free to skip ahead.
+
+As mentioned earlier, models in Open MatSciML Toolkit come in two flavors:
+wrappers of upstream implementations, or self-contained implementations.
+Ultimately, the output of models should be standardized in one of two ways:
+every model `_forward` call should return either an ``Embeddings`` (at the minimum)
+or a ``ModelOutput`` object. The latter is implemented with ``pydantic`` and
+therefore takes advantage of data validation workflows, including standardizing
+and checking tensor shapes, which is currently the **recommended** way for model
+outputs. It also allows flexibility in wrapper models to produce their own
+outputs with their own algorithm, but still be used seamlessly through the pipeline.
+An example of this can be found in the ``MACEWrapper``. The ``ModelOutput`` class also
+includes an ``embeddings`` field, which makes it  compatible with the traditional
+Open MatSciML Toolkit workflow of leveraging one or more output heads.
+
+
+.. autoclass:: matsciml.common.types.Embeddings
+   :members:
+
+
+.. autoclass:: matsciml.common.types.ModelOutput
+   :members:
+
+
 PyG models
 ----------
 

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -904,19 +904,24 @@ class BaseTaskModule(pl.LightningModule):
         batch: dict[str, torch.Tensor | dgl.DGLGraph | dict[str, torch.Tensor]],
     ) -> dict[str, torch.Tensor]:
         encoder_outputs = self.encoder(batch)
-        if not isinstance(encoder_outputs, (Embeddings, dict)):
-            raise RuntimeError(
-                f"Encoder model must emit a dict or `Embeddings` object. Got {encoder_outputs} instead."
-            )
-        if isinstance(encoder_outputs, Embeddings):
-            batch["embeddings"] = encoder_outputs
-            outputs = self.process_embedding(encoder_outputs)
+        # in the case that the model does not produce its own outputs,
+        # we will pass them through the output heads.
+        if not self.model.__skip_output_heads__:
+            if not isinstance(encoder_outputs, (Embeddings, dict)):
+                raise RuntimeError(
+                    f"Encoder model must emit a dict or `Embeddings` object. Got {encoder_outputs} instead."
+                )
+            if isinstance(encoder_outputs, Embeddings):
+                batch["embeddings"] = encoder_outputs
+                outputs = self.process_embedding(encoder_outputs)
+            else:
+                # here we assume that encoder model is predicting directly
+                outputs = encoder_outputs
+                # optionally if we still have embeddings, keep em
+                if "embeddings" in encoder_outputs:
+                    batch["embeddings"] = encoder_outputs["embeddings"]
         else:
-            # here we assume that encoder model is predicting directly
             outputs = encoder_outputs
-            # optionally if we still have embeddings, keep em
-            if "embeddings" in encoder_outputs:
-                batch["embeddings"] = encoder_outputs["embeddings"]
         return outputs
 
     def process_embedding(self, embeddings: Embeddings) -> dict[str, torch.Tensor]:

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -205,7 +205,8 @@ class BaseModel(nn.Module):
 
 
 class AbstractTask(ABC, pl.LightningModule):
-    # TODO the intention is for this class to supersede AbstractEnergyModel for DGL
+    __skip_output_heads__ = False  # allows wrapper models to bypass output heads
+
     def __init__(
         self,
         atom_embedding_dim: int,

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -700,7 +700,6 @@ class BaseTaskModule(pl.LightningModule):
         scheduler_kwargs: dict[str, dict[str, Any]] | None = None,
         log_embeddings: bool = False,
         log_embeddings_every_n_steps: int = 50,
-        use_encoder_predictions: bool = False,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -749,7 +748,6 @@ class BaseTaskModule(pl.LightningModule):
         if len(self.task_keys) > 0:
             self.task_loss_scaling = self._task_loss_scaling
         self.embedding_reduction_type = embedding_reduction_type
-        self.use_encoder_predictions = use_encoder_predictions
         self.save_hyperparameters(ignore=["encoder", "loss_func"])
 
     @property
@@ -776,7 +774,7 @@ class BaseTaskModule(pl.LightningModule):
         # if we're setting task keys we have enough to initialize
         # the output heads
         if not self.has_initialized:
-            if not self.use_encoder_predictions:
+            if not self.encoder.__skip_output_heads__:
                 self.output_heads = self._make_output_heads()
             else:
                 # keeping the keys to allow functionality that doesn't need

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -899,6 +899,9 @@ class BaseTaskModule(pl.LightningModule):
         else:
             # here we assume that encoder model is predicting directly
             outputs = encoder_outputs
+            # optionally if we still have embeddings, keep em
+            if "embeddings" in encoder_outputs:
+                batch["embeddings"] = encoder_outputs["embeddings"]
         return outputs
 
     def process_embedding(self, embeddings: Embeddings) -> dict[str, torch.Tensor]:

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -892,9 +892,13 @@ class BaseTaskModule(pl.LightningModule):
         self,
         batch: dict[str, torch.Tensor | dgl.DGLGraph | dict[str, torch.Tensor]],
     ) -> dict[str, torch.Tensor]:
-        embeddings = self.encoder(batch)
-        batch["embeddings"] = embeddings
-        outputs = self.process_embedding(embeddings)
+        encoder_outputs = self.encoder(batch)
+        if isinstance(encoder_outputs, Embeddings):
+            batch["embeddings"] = encoder_outputs
+            outputs = self.process_embedding(encoder_outputs)
+        else:
+            # here we assume that encoder model is predicting directly
+            outputs = encoder_outputs
         return outputs
 
     def process_embedding(self, embeddings: Embeddings) -> dict[str, torch.Tensor]:

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -893,6 +893,10 @@ class BaseTaskModule(pl.LightningModule):
         batch: dict[str, torch.Tensor | dgl.DGLGraph | dict[str, torch.Tensor]],
     ) -> dict[str, torch.Tensor]:
         encoder_outputs = self.encoder(batch)
+        if not isinstance(encoder_outputs, (Embeddings, dict)):
+            raise RuntimeError(
+                f"Encoder model must emit a dict or `Embeddings` object. Got {encoder_outputs} instead."
+            )
         if isinstance(encoder_outputs, Embeddings):
             batch["embeddings"] = encoder_outputs
             outputs = self.process_embedding(encoder_outputs)

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -907,13 +907,16 @@ class BaseTaskModule(pl.LightningModule):
         # in the case that the model does not produce its own outputs,
         # we will pass them through the output heads.
         if not self.model.__skip_output_heads__:
-            if not isinstance(encoder_outputs, (Embeddings, dict)):
+            if not isinstance(encoder_outputs, (Embeddings, dict, ModelOutput)):
                 raise RuntimeError(
-                    f"Encoder model must emit a dict or `Embeddings` object. Got {encoder_outputs} instead."
+                    f"Encoder model must emit a dict, `ModelOutput`, or `Embeddings` object. Got {encoder_outputs} instead."
                 )
             if isinstance(encoder_outputs, Embeddings):
                 batch["embeddings"] = encoder_outputs
                 outputs = self.process_embedding(encoder_outputs)
+            elif isinstance(encoder_outputs, ModelOutput):
+                batch["embeddings"] = encoder_outputs.embeddings
+                outputs = self.process_embedding(encoder_outputs.embeddings)
             else:
                 # here we assume that encoder model is predicting directly
                 outputs = encoder_outputs

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1093,7 +1093,9 @@ class BaseTaskModule(pl.LightningModule):
             loss_func = self.loss_func[key]
             # determine if we need additional arguments
             loss_func_signature = signature(loss_func.forward).parameters
-            kwargs = {"input": predictions[key], "target": target_val}
+            kwargs = {"input": getattr(predictions, key), "target": target_val}
+            if not isinstance(kwargs["input"], torch.Tensor):
+                raise KeyError(f"Expected model to produce output with key {key}.")
             # pack atoms per graph information too
             if "atoms_per_graph" in loss_func_signature:
                 if graph := batch.get("graph", None):

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -770,7 +770,9 @@ class BaseTaskModule(pl.LightningModule):
             else:
                 # keeping the keys to allow functionality that doesn't need
                 # the actual weights
-                self.output_heads = {key: None for key in self._task_keys}
+                self.output_heads = nn.ModuleDict(
+                    {key: None for key in self._task_keys}
+                )
             self.normalizers = self._make_normalizers()
         # homogenize it into a dictionary mapping
         if isinstance(self.loss_func, nn.Module) and not isinstance(

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -900,7 +900,7 @@ class BaseTaskModule(pl.LightningModule):
     def forward(
         self,
         batch: dict[str, torch.Tensor | dgl.DGLGraph | dict[str, torch.Tensor]],
-    ) -> dict[str, torch.Tensor]:
+    ) -> dict[str, torch.Tensor] | ModelOutput:
         encoder_outputs = self.encoder(batch)
         # in the case that the model does not produce its own outputs,
         # we will pass them through the output heads.

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1928,6 +1928,12 @@ class ForceRegressionTask(BaseTaskModule):
                     embeddings = encoder_outputs
                 # for BYO output head cases
                 elif isinstance(encoder_outputs, ModelOutput):
+                    # this checks to make sure we have the expected attributes
+                    for key in ["total_energy", "forces"]:
+                        if getattr(encoder_outputs, key, None) is None:
+                            raise RuntimeError(
+                                f"Model {self.encoder.__class__.__name__} is not emitting {key} in model outputs."
+                            )
                     # map the outputs as expected by the task
                     return {
                         "energy": encoder_outputs.total_energy,

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1093,7 +1093,11 @@ class BaseTaskModule(pl.LightningModule):
             loss_func = self.loss_func[key]
             # determine if we need additional arguments
             loss_func_signature = signature(loss_func.forward).parameters
-            kwargs = {"input": getattr(predictions, key), "target": target_val}
+            # TODO refactor this once outputs are homogenized
+            if isinstance(predictions, dict):
+                kwargs = {"input": predictions[key], "target": target_val}
+            else:
+                kwargs = {"input": getattr(predictions, key), "target": target_val}
             if not isinstance(kwargs["input"], torch.Tensor):
                 raise KeyError(f"Expected model to produce output with key {key}.")
             # pack atoms per graph information too

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -21,7 +21,13 @@ from torch.optim import AdamW, Optimizer, lr_scheduler
 
 from matsciml.common import package_registry
 from matsciml.common.registry import registry
-from matsciml.common.types import AbstractGraph, BatchDict, DataDict, Embeddings
+from matsciml.common.types import (
+    AbstractGraph,
+    BatchDict,
+    DataDict,
+    Embeddings,
+    ModelOutput,
+)
 from matsciml.models.common import OutputHead
 from matsciml.modules.normalizer import Normalizer
 from matsciml.models import losses as matsciml_losses
@@ -259,7 +265,7 @@ class AbstractTask(ABC, pl.LightningModule):
     def read_batch_size(self, batch: BatchDict) -> int | None: ...
 
     @abstractmethod
-    def _forward(self, *args, **kwargs) -> Embeddings:
+    def _forward(self, *args, **kwargs) -> Embeddings | ModelOutput:
         """
         Implements the actual logic of the architecture. Given a set
         of input features, produce outputs/predictions from the model.
@@ -271,7 +277,7 @@ class AbstractTask(ABC, pl.LightningModule):
         """
         ...
 
-    def forward(self, batch: BatchDict) -> Embeddings | Any:
+    def forward(self, batch: BatchDict) -> Embeddings | ModelOutput:
         """
         Given a batch structure, extract out data and pass it into the
         neural network architecture. This implements the 'forward' method
@@ -286,11 +292,11 @@ class AbstractTask(ABC, pl.LightningModule):
 
         Returns
         -------
-        Embeddings | Any
+        Embeddings | ModelOutput
             For models that do not have their own output mechanism, this
             emits a data structure containing system/graph and point/node
-            level embeddings. If they provide their own outputs, it may
-            be in whate
+            level embeddings. If they provide their own outputs, it should
+            be packaged in the ``ModelOutput`` data structure.
         """
         input_data = self.read_batch(batch)
         outputs = self._forward(**input_data)

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -384,7 +384,7 @@ class AbstractPointCloudModel(AbstractTask):
         mask: torch.Tensor | None = None,
         sizes: list[int] | None = None,
         **kwargs,
-    ) -> Embeddings:
+    ) -> Embeddings | ModelOutput:
         """
         Sets expected patterns for args for point cloud based modeling, whereby
         the bare minimum expected data are 'pos' and 'pc_features' akin to graph
@@ -527,7 +527,7 @@ class AbstractGraphModel(AbstractTask):
         edge_feats: torch.Tensor | None = None,
         graph_feats: torch.Tensor | None = None,
         **kwargs,
-    ) -> Embeddings:
+    ) -> Embeddings | ModelOutput:
         """
         Sets args/kwargs for the expected components of a graph-based
         model. At the bare minimum, we expect some kind of abstract

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -912,7 +912,7 @@ class BaseTaskModule(pl.LightningModule):
         encoder_outputs = self.encoder(batch)
         # in the case that the model does not produce its own outputs,
         # we will pass them through the output heads.
-        if not self.model.__skip_output_heads__:
+        if not self.encoder.__skip_output_heads__:
             if not isinstance(encoder_outputs, (Embeddings, dict, ModelOutput)):
                 raise RuntimeError(
                     f"Encoder model must emit a dict, `ModelOutput`, or `Embeddings` object. Got {encoder_outputs} instead."

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -271,7 +271,7 @@ class AbstractTask(ABC, pl.LightningModule):
         """
         ...
 
-    def forward(self, batch: BatchDict) -> Embeddings:
+    def forward(self, batch: BatchDict) -> Embeddings | Any:
         """
         Given a batch structure, extract out data and pass it into the
         neural network architecture. This implements the 'forward' method
@@ -286,16 +286,20 @@ class AbstractTask(ABC, pl.LightningModule):
 
         Returns
         -------
-        Embeddings
-            Data structure containing system/graph and point/node level embeddings.
+        Embeddings | Any
+            For models that do not have their own output mechanism, this
+            emits a data structure containing system/graph and point/node
+            level embeddings. If they provide their own outputs, it may
+            be in whate
         """
         input_data = self.read_batch(batch)
         outputs = self._forward(**input_data)
-        # raise an error to help spot models that have not yet been refactored
-        if not isinstance(outputs, Embeddings):
-            raise ValueError(
-                "Encoder did not return `Embeddings` data structure: please refactor your model!",
-            )
+        if not self.__skip_output_heads__:
+            # raise an error to help spot models that have not yet been refactored
+            if not isinstance(outputs, Embeddings):
+                raise ValueError(
+                    "Encoder did not return `Embeddings` data structure: please refactor your model!",
+                )
         return outputs
 
 

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -739,9 +739,17 @@ class BaseTaskModule(pl.LightningModule):
             # convert to a module dict for consistent API usage
             loss_func = nn.ModuleDict({key: value for key, value in loss_func.items()})
         self.loss_func = loss_func
-        default_heads = {"act_last": None, "hidden_dim": 128}
-        default_heads.update(output_kwargs)
-        self.output_kwargs = default_heads
+        # only add output kwargs if we are going to use them
+        if not encoder.__skip_output_heads__:
+            default_heads = {"act_last": None, "hidden_dim": 128}
+            default_heads.update(output_kwargs)
+            self.output_kwargs = default_heads
+        else:
+            # emit warning to user if the kwargs aren't being used
+            if output_kwargs:
+                logger.warning(
+                    f"Specified encoder {encoder.__class__.__name__} skips output heads; ignoring output kwargs."
+                )
         self.normalize_kwargs = normalize_kwargs
         self.task_keys = task_keys
         self._task_loss_scaling = kwargs.get("task_loss_scaling", {})

--- a/matsciml/models/pyg/__init__.py
+++ b/matsciml/models/pyg/__init__.py
@@ -20,9 +20,9 @@ else:
 if _has_pyg:
     from matsciml.models.pyg.cgcnn import CGCNN
     from matsciml.models.pyg.egnn import EGNN
-    from matsciml.models.pyg.mace import MACE, ScaleShiftMACE
+    from matsciml.models.pyg.mace import MACE, ScaleShiftMACE, MACEWrapper
 
-    __all__ = ["CGCNN", "EGNN", "FAENet", "MACE", "ScaleShiftMACE"]
+    __all__ = ["CGCNN", "EGNN", "FAENet", "MACE", "ScaleShiftMACE", "MACEWrapper"]
 
     # these packages need additional pyg dependencies
     if package_registry["torch_sparse"] and package_registry["torch_scatter"]:

--- a/matsciml/models/pyg/__init__.py
+++ b/matsciml/models/pyg/__init__.py
@@ -20,6 +20,7 @@ else:
 if _has_pyg:
     from matsciml.models.pyg.egnn import EGNN
     from matsciml.models.pyg.mace import MACE, ScaleShiftMACE, MACEWrapper
+    from matsciml.models.pyg.faenet import FAENet
 
     __all__ = ["CGCNN", "EGNN", "FAENet", "MACE", "ScaleShiftMACE", "MACEWrapper"]
 
@@ -38,7 +39,7 @@ if _has_pyg:
         from matsciml.models.pyg.schnet import SchNetWrap  # noqa: F401
         from matsciml.models.pyg.cgcnn import CGCNN  # noqa: F401
 
-        __all__.extend(["ForceNet", "SchNetWrap", "FAENet", "CGCNN"])
+        __all__.extend(["ForceNet", "SchNetWrap", "CGCNN"])
     else:
         logger.warning(
             "Missing torch_scatter; ForceNet, SchNet, and FAENet models will not be available."

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -63,7 +63,7 @@ class MACEWrapper(AbstractPyGModel):
         embedding_kwargs: Any = None,
         encoder_only: bool = True,
         readout_method: str | Callable = "add",
-        disable_forces: bool = False,
+        disable_forces: bool = True,
         **mace_kwargs,
     ) -> None:
         if embedding_kwargs is not None:

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -11,7 +11,13 @@ from torch_geometric.nn import pool
 from mendeleev import element
 
 from matsciml.models.base import AbstractPyGModel
-from matsciml.common.types import BatchDict, DataDict, AbstractGraph, Embeddings
+from matsciml.common.types import (
+    BatchDict,
+    DataDict,
+    AbstractGraph,
+    ModelOutput,
+    Embeddings,
+)
 from matsciml.common.registry import registry
 from matsciml.common.inspection import get_model_required_args, get_model_all_args
 
@@ -47,6 +53,8 @@ def free_ion_energy_table(num_elements: int = 100) -> torch.Tensor:
 
 @registry.register_model("MACEWrapper")
 class MACEWrapper(AbstractPyGModel):
+    __skip_output_heads__ = True  # MACE is BYO output head due to expansion
+
     def __init__(
         self,
         atom_embedding_dim: int,
@@ -55,6 +63,7 @@ class MACEWrapper(AbstractPyGModel):
         embedding_kwargs: Any = None,
         encoder_only: bool = True,
         readout_method: str | Callable = "add",
+        disable_forces: bool = False,
         **mace_kwargs,
     ) -> None:
         if embedding_kwargs is not None:
@@ -174,7 +183,7 @@ class MACEWrapper(AbstractPyGModel):
         node_feats: torch.Tensor,
         pos: torch.Tensor,
         **kwargs,
-    ) -> Embeddings:
+    ) -> ModelOutput:
         """
         Takes arguments in the standardized format, and passes them into MACE
         with some redundant mapping.
@@ -192,8 +201,8 @@ class MACEWrapper(AbstractPyGModel):
 
         Returns
         -------
-        Embeddings
-            MatSciML ``Embeddings`` structure
+        ModelOutput
+            MatSciML ``ModelOutput`` data structure.
         """
         # repack data into MACE format
         mace_data = {
@@ -208,11 +217,19 @@ class MACEWrapper(AbstractPyGModel):
         outputs = self.encoder(
             mace_data,
             training=self.training,
-            compute_force=False,
+            compute_force=not self.hparams["disable_forces"],
             compute_virials=False,
             compute_stress=False,
-            compute_displacement=False,
+            compute_displacement=not self.hparams["disable_forces"],
         )
         node_embeddings = outputs["node_feats"]
         graph_embeddings = self.readout(node_embeddings, graph.batch)
-        return Embeddings(graph_embeddings, node_embeddings)
+        embeddings = Embeddings(graph_embeddings, node_embeddings)
+        output = ModelOutput(
+            batch_size=graph.batch_size,
+            forces=outputs["forces"],
+            total_energy=outputs["energy"],
+            node_energies=outputs["node_energy"],
+            embeddings=embeddings,
+        )
+        return output

--- a/matsciml/models/pyg/mace/wrapper/model.py
+++ b/matsciml/models/pyg/mace/wrapper/model.py
@@ -173,6 +173,7 @@ class MACEWrapper(AbstractPyGModel):
                 "node_feats": one_hot_atoms,
                 "cell": batch["cell"],
                 "shifts": batch["offsets"],
+                "unit_shifts": batch["unit_offsets"],
             }
         )
         return data
@@ -211,6 +212,7 @@ class MACEWrapper(AbstractPyGModel):
             "ptr": graph.ptr,
             "cell": kwargs["cell"],
             "shifts": kwargs["shifts"],
+            "unit_shifts": kwargs["unit_shifts"],
             "batch": graph.batch,
             "edge_index": graph.edge_index,
         }

--- a/matsciml/models/pyg/mace/wrapper/tests/test_mace_wrapper.py
+++ b/matsciml/models/pyg/mace/wrapper/tests/test_mace_wrapper.py
@@ -97,10 +97,18 @@ def test_model_forward_nograd(dset_class_name: str, mace_architecture: MACEWrapp
     batch = next(iter(loader))
     # run the model without gradient tracking
     with torch.no_grad():
-        embeddings = mace_architecture(batch)
+        model_output = mace_architecture(batch)
+    embeddings = model_output.embeddings
     # returns embeddings, and runs numerical checks
     for z in [embeddings.system_embedding, embeddings.point_embedding]:
         assert torch.isreal(z).all()
         assert ~torch.isnan(z).all()  # check there are no NaNs
         assert torch.isfinite(z).all()
         assert torch.all(torch.abs(z) <= 1000)  # ensure reasonable values
+    # check energies as finite
+    graph_energies = model_output.total_energy
+    assert torch.isreal(graph_energies).all()
+    assert torch.isfinite(graph_energies).all()
+    node_energies = model_output.node_energies
+    assert torch.isreal(node_energies).all()
+    assert torch.isfinite(node_energies).all()


### PR DESCRIPTION
This PR is semi-related to #104, allowing flexibility for wrappers and full implementations to potentially have a common output format that is also "backwards" compatible. It depends on `ModelOutput` from #315, so please review and merge that before this PR.

- Added a private attribute of the base `AbstractTask` class (which graph models inherit) called `__skip_output_heads__`, which `BaseTaskLitModules` will check this to determine if output heads are needed or not. If we do not use them, we do not initialize the `OutputHeads` to save on parameters/ensure we don't have unused parameters.
- I have refactored the `MACEWrapper` as an example of how to do this, and we should do so for other wrappers as well (e.g. `CHGNet`). I've also updated the `sphinx` documentation to detail how this can be used.
- I've ensured that the regular workflow (with PyG EGNN) isn't broken, and included unit tests for `MACEWrapper` to run the forward pass and an end-to-end with `ForceRegressionTask`.