### PR TITLE
Self loop mask fix

### DIFF
--- a/matsciml/datasets/transforms/tests/test_pbc.py
+++ b/matsciml/datasets/transforms/tests/test_pbc.py
@@ -85,3 +85,28 @@ def test_periodic_generation(
     for index, count in counts.items():
         if not self_loops:
             assert count < 10, print(f"Node {index} has too many counts. {src_nodes}")
+
+
+def test_self_loop_condition():
+    """Tests for whether the self-loops exclusion is behaving as intended"""
+    coords = torch.FloatTensor(alumina.cart_coords)
+    cell = torch.FloatTensor(alumina.lattice.matrix)
+    num_atoms = coords.size(0)
+    atomic_numbers = torch.ones(num_atoms)
+    packed_data = {"pos": coords, "cell": cell, "atomic_numbers": atomic_numbers}
+    no_loop_transform = PeriodicPropertiesTransform(
+        cutoff_radius=6.0, backend="ase", allow_self_loops=False
+    )
+    no_loop_result = no_loop_transform(packed_data)
+    # since it's no self loops this sum should be zero
+    same_node = no_loop_result["src_nodes"] == no_loop_result["dst_nodes"]
+    same_image = no_loop_result["images"].sum(dim=-1) == 0
+    assert torch.sum(torch.logical_and(same_node, same_image)) == 0
+    allow_loop_transform = PeriodicPropertiesTransform(
+        cutoff_radius=6.0, backend="ase", allow_self_loops=True
+    )
+    loop_result = allow_loop_transform(packed_data)
+    # there should be some self-loops in this graph
+    same_node = loop_result["src_nodes"] == loop_result["dst_nodes"]
+    same_image = loop_result["images"].sum(dim=-1) == 0
+    assert torch.sum(torch.logical_and(same_node, same_image)) > 0

--- a/matsciml/datasets/transforms/tests/test_pbc.py
+++ b/matsciml/datasets/transforms/tests/test_pbc.py
@@ -56,9 +56,7 @@ nac = Structure(
 )
 @pytest.mark.parametrize("self_loops", [True, False])
 @pytest.mark.parametrize("backend", ["pymatgen", "ase"])
-@pytest.mark.parametrize(
-    "cutoff_radius", [6.0, 9.0, 15.0]
-)  # TODO figure out why pmg fails on 3
+@pytest.mark.parametrize("cutoff_radius", [6.0, 9.0, 15.0])
 def test_periodic_generation(
     coords: np.ndarray,
     cell: np.ndarray,
@@ -84,6 +82,8 @@ def test_periodic_generation(
     counts = Counter(src_nodes)
     for index, count in counts.items():
         if not self_loops:
+            # TODO pymatgen backend fails this check at cutoff radius = 15
+            # and I don't know why
             assert count <= 10, f"Node {index} has too many counts. {src_nodes}"
 
 

--- a/matsciml/datasets/transforms/tests/test_pbc.py
+++ b/matsciml/datasets/transforms/tests/test_pbc.py
@@ -84,7 +84,7 @@ def test_periodic_generation(
     counts = Counter(src_nodes)
     for index, count in counts.items():
         if not self_loops:
-            assert count <= 10, print(f"Node {index} has too many counts. {src_nodes}")
+            assert count <= 10, f"Node {index} has too many counts. {src_nodes}"
 
 
 def test_self_loop_condition():

--- a/matsciml/datasets/transforms/tests/test_pbc.py
+++ b/matsciml/datasets/transforms/tests/test_pbc.py
@@ -84,7 +84,7 @@ def test_periodic_generation(
     counts = Counter(src_nodes)
     for index, count in counts.items():
         if not self_loops:
-            assert count < 10, print(f"Node {index} has too many counts. {src_nodes}")
+            assert count <= 10, print(f"Node {index} has too many counts. {src_nodes}")
 
 
 def test_self_loop_condition():


### PR DESCRIPTION
This PR fixes the logic for removing self-loops in the `allow_self_loops` flag for `PeriodicPropertiesTransform`.

I've rewritten the mask calculation to make it more readable for humans, as well as added a dedicated unit test that explicitly checks for the presence of self-loops to make sure the logic is implemented correctly.