### PR TITLE
Data schema and HDF5 data support

### DIFF
--- a/Dockerfile.xpu
+++ b/Dockerfile.xpu
@@ -1,0 +1,29 @@
+FROM amr-registry.caas.intel.com/aipg/kinlongk-pytorch:nightly-xpu
+# for setup run with root
+USER 0
+# needed to make sure mamba environment is activated
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+# install packages, particularly xpu torch from nightly wheels
+RUN pip install torch-geometric
+# DGl is currently unsupported, and uses libtorch so we need to build it
+WORKDIR /opt/matsciml
+COPY . .
+RUN pip install -e .
+RUN git clone --recurse-submodules https://github.com/dmlc/dgl.git /opt/dgl
+ENV DGL_HOME=/opt/dgl
+WORKDIR /opt/dgl/build
+RUN cmake -DUSE_CUDA=OFF -DPython3_EXECUTABLE=/opt/conda/bin/python .. && make
+WORKDIR /opt/dgl/python
+RUN pip install .
+RUN micromamba clean --all --yes && rm -rf /opt/xpu-backend /var/lib/apt/lists/*
+# make conda read-writable for user
+RUN chown -R $MAMBA_USER:$MAMBA_USER /opt/matsciml && chown -R $MAMBA_USER:$MAMBA_USER /opt/conda
+# change back to non-root user
+USER $MAMBA_USER
+LABEL org.opencontainers.image.authors="Kin Long Kelvin Lee"
+LABEL org.opencontainers.image.vendor="Intel Labs"
+LABEL org.opencontainers.image.base.name="amr-registry.caas.intel.com/aipg/kinlongk-pytorch:nightly"
+LABEL org.opencontainers.image.title="kinlongk-pytorch"
+LABEL org.opencontainers.image.description="XPU enabled PyTorch+Triton from Github artifact wheel builds."
+HEALTHCHECK NONE
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -1,0 +1,61 @@
+FROM mambaorg/micromamba:noble AS oneapi_xpu
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+# for setup run with root
+USER 0
+# needed to make sure mamba environment is activated
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+# VGID as an environment variable specifying the group ID for render on host
+# this needs to match, otherwise non-root users will not pick up cards
+ARG VGID=993
+# install firmware, oneAPI, etc.
+RUN apt-get update -y && apt-get install -y software-properties-common wget git make g++ gcc gpg-agent
+RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+    | gpg --dearmor > /usr/share/keyrings/intel-for-pytorch-gpu-dev-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/intel-for-pytorch-gpu-dev-keyring.gpg] https://apt.repos.intel.com/intel-for-pytorch-gpu-dev all main" > /etc/apt/sources.list.d/intel-for-pytorch-gpu-dev.list
+RUN wget -qO - https://repositories.intel.com/gpu/intel-graphics.key \
+    | gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu noble unified" > /etc/apt/sources.list.d/intel-gpu-noble.list
+RUN apt-get update -y && \
+	apt-get upgrade -y && \
+	apt-get install -y git make g++ gcc gpg-agent wget \
+        intel-for-pytorch-gpu-dev-0.5 \
+        intel-pti-dev \
+        cmake \
+        tzdata \
+        zlib1g zlib1g-dev \
+        xpu-smi \
+        intel-opencl-icd intel-level-zero-gpu libze1 intel-oneapi-mpi \ 
+        intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 \
+        libegl-mesa0 libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \
+        libglapi-mesa libgles2-mesa-dev libglx-mesa0 libigdgmm12 libxatracker2 mesa-va-drivers \
+        mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo hwinfo clinfo
+# make sure oneAPI components are in environment variables
+RUN source /opt/intel/oneapi/setvars.sh
+# make it so you don't have to source oneAPI every time
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+FROM oneapi_xpu
+# set aliases so python and pip are met
+RUN ln -s /opt/conda/bin/python /usr/local/bin/python && ln -s /opt/conda/bin/pip /usr/local/bin/pip
+# clone matsciml into container and install
+RUN git clone https://github.com/IntelLabs/matsciml /opt/matsciml
+WORKDIR /opt/matsciml
+# install packages, particularly xpu torch from nightly wheels
+RUN micromamba install -y -n base -f conda.yml && \
+    pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/xpu && \
+    pip install -e './[all]'
+RUN micromamba clean --all --yes && rm -rf /opt/xpu-backend /var/lib/apt/lists/*
+# let non-root mamba user have access to GPUS
+RUN groupadd -g $VGID render && usermod -a -G video,render $MAMBA_USER
+# make conda read-writable for user
+RUN chown -R $MAMBA_USER:$MAMBA_USER /opt/matsciml && chown -R $MAMBA_USER:$MAMBA_USER /opt/conda
+# change back to non-root user
+USER $MAMBA_USER
+LABEL org.opencontainers.image.authors="Kin Long Kelvin Lee"
+LABEL org.opencontainers.image.vendor="Intel Labs"
+LABEL org.opencontainers.image.base.name="amr-registry.caas.intel.com/aipg/kinlongk-pytorch:nightly"
+LABEL org.opencontainers.image.title="kinlongk-pytorch"
+LABEL org.opencontainers.image.description="XPU enabled PyTorch+Triton from Github artifact wheel builds."
+HEALTHCHECK NONE

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -26,7 +26,7 @@ RUN apt-get update -y && \
         tzdata \
         zlib1g zlib1g-dev \
         xpu-smi \
-        intel-opencl-icd intel-level-zero-gpu libze1 intel-oneapi-mpi \ 
+        intel-opencl-icd intel-level-zero-gpu libze1 intel-oneapi-mpi \
         intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 \
         libegl-mesa0 libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \
         libglapi-mesa libgles2-mesa-dev libglx-mesa0 libigdgmm12 libxatracker2 mesa-va-drivers \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# this sources oneAPI components and silences the output so we don't
+# have to see the wall of text every time we enter the container
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
+exec "$@"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ The Open MatSciML Toolkit
 
    Getting started <self>
    datasets
+   schema
    transforms
    models
    training

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -50,3 +50,132 @@ property name/values.
 
 .. autoclass:: matsciml.datasets.schema.DataSampleSchema
    :members:
+
+
+Creating datasets with schema
+#############################
+
+.. NOTE::
+   This section is primarily for people interested in developing new datasets.
+
+The premise behind defining these schema rigorously is to encourage reproducible workflows
+with (hopefully) less technical debt: we can safely rely on data to validate itself,
+catch mistakes when serializing/dumping data for others to use, and set reasonable expectations
+on what data will be available at what parts of training and evaluation. For those interested
+in creating their own datasets, this section lays out some preliminary notes on how to wrangle
+your data to adhere to schema, and make the data ready to be used by the pipeline.
+
+Matching your data to the schema
+================================
+
+First step in dataset creation is taking whatever primary data format you have, and mapping
+them to the ``DataSampleSchema`` laid out above. The required keys include ``index``, ``cart_coords``,
+and so on, and by definition need to be provided. The code below shows an example loop
+over a list of data, which we convert into a dictionary with the same keys as expected in ``DataSampleSchema``:
+
+.. ::
+ :caption: Example abstract code for mapping your data to the schema
+   all_data = ...  # should be a list of samples
+   samples = []
+   for index, data in enumerate(all_data):
+       temp_dict = {}
+       temp_dict["cart_coords"] = data.positions
+       temp_dict['index'] = index
+       temp_dict['datatype'] = "OptimizationCycle"   # must be one of the enums
+       temp_dict['num_atoms'] = len(data.positions)
+       schema = DataSampleSchema(**temp_dict)
+       samples.append(schema)
+
+You end up with a list of ``DataSampleSchema`` which undergo all of the validation
+and consistency checks.
+
+Data splits
+======================
+
+At this point you could call it a day, but if we want to create uniform random
+training and validation splits, this is a good point to do so. The code below
+shows one way of generating the splits: keep in mind that this mechanism for
+splitting might not be appropriate for your data - to mitigate data leakage,
+you may need to consider using more sophisticated algorithms that consider chemical
+elements, de-correlate dynamics, etc. Treat the code below as boilerplate, and
+modify it as needed.
+
+.. ::
+   :caption: Example code showing how to generate training and validation splits
+   import numpy as np
+   import h5py
+   from matsciml.datasets.generic import write_data_to_hdf5_group
+
+   SEED = 73926   # this will be reused when generating the metadata
+   rng =  np.random.default_rng(SEED)
+
+   all_indices = np.arange(len(samples))
+   val_split = int(len(samples) * 0.2)
+   rng.shuffle(all_indices)
+   train_indices = all_indices[val_split:]
+   val_indices = all_indices[:val_split]
+
+   # instantiate HDF5 files
+   train_h5 = h5py.File("./train.h5", mode="w")
+
+   for index in train_indices:
+        sample = samples[index]
+        # store each data sample as a group comprising array data
+        group = train_h5.create_group(str(index))
+        # takes advantage of pydantic serialization
+        for key, value in sample.model_dump(round_trip=True).items():
+            if value is not None:
+                write_data_to_hdf5_group(key, value, group)
+
+
+Repeat the loop above for your validation set.
+
+Dataset metadata
+==================
+
+Once we have created these splits, there's a bunch of metadata associated
+with **how** we created the splits that we should record so that at runtime,
+there's no ambiguity which data and splits are being used and where they
+came from.
+
+.. ::
+   from datetime import datetime
+   from matsciml.datasets.generic import MatSciMLDataset
+   from matsciml.datasets.schema import DatasetSchema
+
+   # use the datasets we created above; `strict_checksum` needs to be
+   # set the False here because we're going to be generating the checksum
+   train_dset = MatSciMLDataset("./train.h5", strict_checksum=False)
+   train_checksum = train_dset.blake2s_checksum
+
+   # fill in the dataset metadata schema
+   dset_schema = DatasetSchema(
+       name="My new dataset",
+       creation=datetime.now(),
+       split_blake2s={
+           "train": train_checksum,
+           "validation": ...,
+           "test": ...,  # these should be made the same way as the training set
+       },
+       targets=[...],   # see below
+       dataset_type="OptimizationCycle",   # choose one of the `DataTypeEnum`
+       seed=SEED,    # from the first code snippet
+   )
+   # writes the schema where it's expected
+   dset.to_json_file("metadata.json")
+
+
+Hopefully you can appreciate that the metadata is meant to lessen the burden
+of future users of the dataset (including yourself!). The last thing to cover
+here is that ``targets`` was omitted in the snippet above: this field is meant
+for you to record every property that may or may not be part of the standard
+``DataSampleSchema`` which is intended to be used throughout training. This is
+the ``TargetSchema``: you must detail the name, expected shape, and a short
+description of every property (including the standard ones). The main motivation
+for this is that ``total_energy`` for one dataset may mean something very different
+between one dataset to the next (electronic energy? thermodynamic corrections?),
+and specifying this for the end user will remove any ambiguities.
+
+
+.. autoclass:: matsciml.datasets.schema.TargetSchema
+   :members:

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -1,0 +1,52 @@
+Schema
+==========
+
+The Open MatSciML Toolkit tries to place emphasis on reproducibility, and the general
+rule of "explicit is better than implicit" by defining schema for data and other development
+concepts.
+
+The intention is to move away from hardcoded ``Dataset`` classes that are rigid in
+that they require writing code, as well as not always reliably reproducible as the
+underlying data and frameworks change and evolve over time. Instead, the schema
+provided in ``matsciml`` tries to shift technical debt from maintaining code to
+**documenting** data, which assuming a thorough and complete description, should
+in principle be usable regardless of breaking API changes in frameworks that we rely
+on like ``pymatgen``, ``torch_geometric``, and so on. As a dataset is being packaged
+for distribution/defined, the schema should also make intentions of the developer clear
+to the end-user, e.g. what target label is available, how it was calculated, and so on,
+to help subsequent reproduction efforts. As an effect, this also makes development of
+``matsciml`` a lot more streamlined, as it then homogenizes field names (i.e. we can
+reliably expect ``cart_coords`` to be available and are cartesian coordinates).
+
+.. TIP::
+   You do not have to construct objects contained in schema if they are ``pydantic``
+   models themselves: for example, the ``PeriodicBoundarySchema`` is required in
+   ``DataSampleSchema``, but you can alternatively just pass a dictionary with the
+   expected key/value mappings (i.e. ``{'x': True, 'y': True, 'z': False}``) for
+   the relevant schema.
+
+
+Dataset schema reference
+########################
+
+This schema lays out what can be described as metadata for a dataset. We define all of
+the expected fields in ``targets``, and record checksums for each dataset split such
+that we can record what model was trained on what specific split. Currently, it is the
+responsibility of the dataset distributor to record this metadata for their dataset,
+and package it as a ``metadata.json`` file in the same folder as the HDF5 files.
+
+.. autoclass:: matsciml.datasets.schema.DatasetSchema
+   :members:
+
+Data sample schema reference
+############################
+
+This schema comprises a **single** data sample, providing standardized field names for
+a host of commonly used properties. Most properties are optional for the class construction,
+but we highly recommend perusing the fields shown below to find the attribute closest to
+the property being recorded: ``pydantic`` does not allow arbitrary attributes to be stored
+in schema, but non-standard properties can be stashed away in ``extras`` as a dictionary of
+property name/values.
+
+.. autoclass:: matsciml.datasets.schema.DataSampleSchema
+   :members:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# this sources oneAPI components and silences the output so we don't
+# have to see the wall of text every time we enter the container
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
+exec "$@"

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -37,8 +37,9 @@ def write_data_to_hdf5(
 
     Raises
     ------
-    RuntimeError:
-        [TODO:description]
+    IndexError:
+        If a sample of data already exists at the specified index while
+        overwrite is set to False.
     """
     assert h5_file.mode != "r"
     if overwrite:
@@ -237,9 +238,9 @@ class MatSciMLDataModule(pl.LightningDataModule):
     ):
         """
         Initialize a ``MatSciMLDataModule`` that uses the HDF5
-        binary data format.
-
-        [TODO:description]
+        binary data format. Provides a ``Lightning`` wrapper around
+        the dataset class, which individually handles splits whereas
+        this class handles a collection of HDF5 files.
 
         Parameters
         ----------

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -181,6 +181,8 @@ class MatSciMLDataset(Dataset):
             a ``RuntimeError`` will be raised.
         """
         with h5py.File(str(self.filepath).absolute(), "w") as h5_file:
+            if overwrite and str(index) in h5_file:
+                del h5_file[str(index)]
             group = h5_file.create_group(str(index))
             sample_data = sample.model_dump(round_trip=True)
             for key, value in sample_data.items():

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -20,6 +20,8 @@ from matsciml.datasets.schema import (
 
 logger = getLogger("matsciml.datasets.MatSciMLDataset")
 
+__all__ = ["MatSciMLDataset", "MatSciMLDataModule"]
+
 
 def write_data_to_hdf5_group(key: str, data: Any, h5_group: h5py.Group) -> None:
     """

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -41,7 +41,9 @@ def write_data_to_hdf5(
         If a sample of data already exists at the specified index while
         overwrite is set to False.
     """
-    assert h5_file.mode != "r"
+    assert any(
+        [letter in h5_file.mode for letter in ["w", "x", "a"]]
+    ), f"HDF5 file must be open for writing; mode set to {h5_file.mode}."
     if overwrite:
         # if allowed to overwrite, we delete the existing
         # data and group

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -290,7 +290,13 @@ class MatSciMLDataset(Dataset):
             sample_data = read_hdf5_data(sample_group)
             # validate expected data
             for target in self.metadata.targets:
-                if target.name not in sample_data:
+                is_missing = True
+                if target.name in sample_data:
+                    is_missing = False
+                if "extras" in sample_data:
+                    if target.name in sample_data["extras"]:
+                        is_missing = False
+                if is_missing:
                     raise KeyError(
                         f"Expected {target.name} in data sample but not found."
                     )

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Literal
 from logging import getLogger
 
 import h5py
-from torch.utils.data import Dataset
+from torch.utils.data import DataLoader, Dataset
 from lightning import pytorch as pl
 
 from matsciml.datasets.schema import DatasetSchema, DataSampleSchema
@@ -425,3 +425,29 @@ class MatSciMLDataModule(pl.LightningDataModule):
             assert "train" in self.datasets, "No training split available!"
         if stage == "predict":
             assert "predict" in self.datasets, "No predict split available!"
+
+    def train_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.datasets["train"], shuffle=True, **self.hparams.loader_kwargs
+        )
+
+    def val_dataloader(self) -> DataLoader | None:
+        if "validation" not in self.datasets:
+            return None
+        return DataLoader(
+            self.datasets["validation"], shuffle=False, **self.hparams.loader_kwargs
+        )
+
+    def test_dataloader(self) -> DataLoader | None:
+        if "test" not in self.datasets:
+            return None
+        return DataLoader(
+            self.datasets["test"], shuffle=False, **self.hparams.loader_kwargs
+        )
+
+    def predict_dataloader(self) -> DataLoader | None:
+        if "predict" not in self.datasets:
+            return None
+        return DataLoader(
+            self.datasets["predict"], shuffle=False, **self.hparams.loader_kwargs
+        )

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -249,9 +249,7 @@ class MatSciMLDataset(Dataset):
                 sample_group = h5_data[data_index]
             except KeyError as e:
                 raise KeyError(f"Data sample {data_index} missing from dataset.") from e
-            sample_data = {}
-            for key, value in sample_group.items():
-                sample_data[key] = value
+            sample_data = read_hdf5_data(sample_group)
             # validate expected data
             for target in self.metadata.targets:
                 if target.name not in sample_data:

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -338,6 +338,9 @@ class MatSciMLDataModule(pl.LightningDataModule):
             If the provided filepath is not a directory, this method
             will raise a ``RuntimeError``.
         """
+        loader_kwargs.setdefault("num_workers", 0)
+        loader_kwargs.setdefault("persistent_workers", False)
+        loader_kwargs.setdefault("batch_size", 8)
         super().__init__()
         if not isinstance(filepath, Path):
             filepath = Path(filepath)

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -409,7 +409,7 @@ class MatSciMLDataModule(pl.LightningDataModule):
             raise RuntimeError("No .h5 files found in target directory.")
         self._h5_files = h5_files
 
-    def setup(self, stage: str):
+    def setup(self, stage: str | None = None) -> None:
         # check and set the available HDF5 data files
         self.h5_files = self.hparams.filepath
         self.datasets = {

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -118,11 +118,34 @@ class MatSciMLDataset(Dataset):
 
     @property
     def metadata(self) -> DatasetSchema:
-        meta_target = self.filepath.parent.joinpath("metadata.json")
-        if not meta_target.exists():
-            raise RuntimeError("No metadata for dataset.")
-        with open(meta_target) as read_file:
-            return DatasetSchema.model_validate_json(read_file.read(), strict=True)
+        """
+        Underlying ``DatasetSchema`` that should accompany all ``matsciml`` datasets.
+
+        This schema should contain information about splits, target properties,
+        and if relevant, graph wiring and so on.
+
+        Returns
+        -------
+        DatasetSchema
+            Validated ``DatasetSchema`` object
+
+        Raises
+        ------
+        RuntimeError:
+            If there is no metadata
+        """
+        if not hasattr(self, "_metadata"):
+            meta_target = self.filepath.parent.joinpath("metadata.json")
+            if not meta_target.exists():
+                raise FileNotFoundError(
+                    "No `metadata.json` specifying DatasetSchema found in dataset directory.."
+                )
+            with open(meta_target) as read_file:
+                metadata = DatasetSchema.model_validate_json(
+                    read_file.read(), strict=True
+                )
+            self._metadata = metadata
+        return self._metadata
 
     @property
     @cache

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -11,7 +11,11 @@ import h5py
 from torch.utils.data import DataLoader, Dataset
 from lightning import pytorch as pl
 
-from matsciml.datasets.schema import DatasetSchema, DataSampleSchema
+from matsciml.datasets.schema import (
+    DatasetSchema,
+    DataSampleSchema,
+    collate_samples_into_batch_schema,
+)
 
 
 logger = getLogger("matsciml.datasets.MatSciMLDataset")
@@ -434,26 +438,38 @@ class MatSciMLDataModule(pl.LightningDataModule):
 
     def train_dataloader(self) -> DataLoader:
         return DataLoader(
-            self.datasets["train"], shuffle=True, **self.hparams.loader_kwargs
+            self.datasets["train"],
+            shuffle=True,
+            **self.hparams.loader_kwargs,
+            collate_fn=collate_samples_into_batch_schema,
         )
 
     def val_dataloader(self) -> DataLoader | None:
         if "validation" not in self.datasets:
             return None
         return DataLoader(
-            self.datasets["validation"], shuffle=False, **self.hparams.loader_kwargs
+            self.datasets["validation"],
+            shuffle=False,
+            **self.hparams.loader_kwargs,
+            collate_fn=collate_samples_into_batch_schema,
         )
 
     def test_dataloader(self) -> DataLoader | None:
         if "test" not in self.datasets:
             return None
         return DataLoader(
-            self.datasets["test"], shuffle=False, **self.hparams.loader_kwargs
+            self.datasets["test"],
+            shuffle=False,
+            **self.hparams.loader_kwargs,
+            collate_fn=collate_samples_into_batch_schema,
         )
 
     def predict_dataloader(self) -> DataLoader | None:
         if "predict" not in self.datasets:
             return None
         return DataLoader(
-            self.datasets["predict"], shuffle=False, **self.hparams.loader_kwargs
+            self.datasets["predict"],
+            shuffle=False,
+            **self.hparams.loader_kwargs,
+            collate_fn=collate_samples_into_batch_schema,
         )

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -61,8 +61,42 @@ class MatSciMLDataset(Dataset):
         self,
         filepath: PathLike,
         transforms: list[Callable] | None = None,
-        strict_checksum: bool = False,
+        strict_checksum: bool = True,
     ):
+        """
+        Dataset class for generic ``MatSciMLDataset``s that use
+        the data schema specifications.
+
+        The main output of this class is mainly data loading from
+        HDF5 files, parsing ``DatasetSchema`` metadata that are
+        adjacent to HDF5 files, and returning data samples in the
+        form of ``DataSampleSchema`` objects, which in principle
+        should replace conventional ``DataDict`` (i.e. just plain
+        dictionaries with arbitrary key/value pairs) that were used
+        in earlier ``matsciml`` versions.
+
+        Parameters
+        ----------
+        filepath : PathLike
+            Filepath to a specific HDF5 file, containing a data split
+            of either ``train``, ``test``, ``validation``, or ``predict``.
+        transforms : list[Callable], optional
+            If provided, should be a list of Python callable objects
+            that will operate on the data.
+        strict_checksum : bool, default True
+            If ``True``, the dataset will refuse to run if it does not
+            match any of the checksums contained in the metadata. This
+            implementation does not **need** to know which split the data
+            is, but has to match at least one of the specified splits.
+            This can be disabled manually by setting to ``False``, but
+            means the dataset can be modified.
+
+        Raises
+        ------
+        RuntimeError:
+            If no checksums in the metadata match the current data
+            while ``strict_checksum`` is set to ``True``.
+        """
         super().__init__()
         if not isinstance(filepath, Path):
             filepath = Path(filepath)

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -242,7 +242,45 @@ class MatSciMLDataset(Dataset):
         with self.read_data() as h5_data:
             return list(h5_data.keys())
 
-    def __getitem__(self, index: int):
+    def __getitem__(self, index: int) -> DataSampleSchema:
+        """
+        Retrieves a sample from the present dataset.
+
+        Data samples are organized into top-level ``h5py.Group``s,
+        and the passed ``index`` value maps onto the underlying
+        ``data_index`` which corresponds to the index the data sample
+        originally had before splits.
+
+        We recursively read in data contained within a group, and
+        use the key/values to reconstruct and validate with a ``DataSampleSchema``.
+        Finally, we apply transforms if they are provided to this object,
+        and return it.
+
+        Parameters
+        ----------
+        index : int
+            Integer corresponding to a value within the range of
+            the dataset length. This may or may not coincide with
+            the actual ``h5py.Group`` keys, but refers to the ``keys``
+            property of ``MatSciMLDataset`` to retrieve the 'real'
+            key to read with.
+
+        Returns
+        -------
+        DataSampleSchema
+            Data sample from disk after validation, and transforms
+            applied if relevant.
+
+        Raises
+        ------
+        KeyError:
+            If the data sample index is missing from the dataset.
+        KeyError:
+            If a target key is defined in the metadata, but missing
+            from the dictionary before passing into ``DataSampleSchema``.
+        RuntimeError:
+            If a transform was unable to be applied to the ``DataSampleSchema``.
+        """
         data_index = self.keys[index]
         with self.read_data() as h5_data:
             try:

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -201,6 +201,12 @@ class MatSciMLDataset(Dataset):
         with self.read_data() as h5_data:
             return len(h5_data.keys())
 
+    @property
+    @cache
+    def keys(self) -> list[str]:
+        with self.read_data() as h5_data:
+            return list(h5_data.keys())
+
     def __getitem__(self, index: int):
         index = str(index)
         with self.read_data() as h5_data:

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -138,7 +138,7 @@ class MatSciMLDataset(Dataset):
 
     @cache
     def __len__(self) -> int:
-        with self.data as h5_data:
+        with self.read_data() as h5_data:
             return len(h5_data.keys())
 
     def __getitem__(self, index: int):

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -207,7 +207,15 @@ class MatSciMLDataModule(pl.LightningDataModule):
         if not filepath.is_dir():
             raise RuntimeError(f"Expected filepath to be a directory; got {filepath}")
         self.metadata = filepath.joinpath("metadata.json")
-        self.save_hyperparameters()
+        # add to things to save
+        hparams_to_save = {
+            "filepath": filepath,
+            "transforms": transforms,
+            "strict_checksum": strict_checksum,
+            "metadata": self.metadata.model_dump(),
+            "loader_kwargs": loader_kwargs,
+        }
+        self.save_hyperparameters(hparams_to_save)
 
     @property
     def metadata(self) -> DatasetSchema:

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -208,12 +208,12 @@ class MatSciMLDataset(Dataset):
             return list(h5_data.keys())
 
     def __getitem__(self, index: int):
-        index = str(index)
+        data_index = self.keys[index]
         with self.read_data() as h5_data:
             try:
-                sample_group = h5_data[index]
+                sample_group = h5_data[data_index]
             except KeyError as e:
-                raise KeyError(f"Data sample {index} missing from dataset.") from e
+                raise KeyError(f"Data sample {data_index} missing from dataset.") from e
             sample_data = {}
             for key, value in sample_group.items():
                 sample_data[key] = value

--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -151,9 +151,12 @@ class MatSciMLDataset(Dataset):
             sample_data = {}
             for key, value in sample_group.items():
                 sample_data[key] = value
-            for key in self.metadata.target_keys:
-                if key not in sample_data:
-                    raise KeyError(f"Expected {key} in data sample but not found.")
+            # validate expected data
+            for target in self.metadata.targets:
+                if target.name not in sample_data:
+                    raise KeyError(
+                        f"Expected {target.name} in data sample but not found."
+                    )
             sample = DataSampleSchema(**sample_data)
             # now try to apply transforms
             if self.transforms:

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -94,7 +94,7 @@ class MatsciMLSchema(BaseModel):
         """
         if not isinstance(json_path, Path):
             json_path = Path(json_path)
-        with open(json_path.with_suffix(".json"), "r") as write_file:
+        with open(json_path.with_suffix(".json"), "w+") as write_file:
             json.dump(self.model_dump(), write_file, indent=2)
 
 

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -43,6 +43,18 @@ experience for both developers and users by defining a consistent set of
 attribute names that should be
 """
 
+__all__ = [
+    "DataSampleSchema",
+    "DataSampleEnum",
+    "DatasetSchema",
+    "SplitHashSchema",
+    "PeriodicBoundarySchema",
+    "NormalizationSchema",
+    "GraphWiringSchema",
+    "TargetSchema",
+    "collate_samples_into_batch_schema",
+]
+
 # ruff: noqa: F722
 
 

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -803,7 +803,7 @@ class DataSampleSchema(MatsciMLSchema):
                         "Fractional coordinate dimensions do not match cartesians."
                     )
                 )
-            if min(self.frac_coords) < 0.0 or max(self.frac_coords) > 1.0:
+            if self.frac_coords.min() < 0.0 or self.frac_coords.max() > 1.0:
                 self._exception_wrapper(
                     ValueError("Fractional coordinates are outside of [0, 1].")
                 )

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -836,10 +836,10 @@ class DataSampleSchema(MatsciMLSchema):
                     "Fractional coordinate dimensions do not match cartesians."
                 )
             # round coordinate values so that -1e-6 is just zero and doesn't fail the test
-            round_coords = np.round(self.frac_coords, decimals=3)
-            if np.any(np.logical_or(round_coords > 1.0, round_coords < 0.0)):
-                raise ValueError(
-                    f"Fractional coordinates are outside of [0, 1]: {self.frac_coords}"
+            round_coords = np.round(self.frac_coords, decimals=2)
+            if np.any(np.logical_or(round_coords > 1.01, round_coords < 0.0)):
+                logger.warning(
+                    f"Fractional coordinates are outside of [0, 1]: {round_coords}"
                 )
         return self
 

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -27,6 +27,7 @@ import torch
 
 from matsciml.common.packages import package_registry
 from matsciml.common.inspection import get_all_args
+from matsciml.common.types import Embeddings, ModelOutput
 from matsciml.modules.normalizer import Normalizer
 from matsciml.datasets.transforms import PeriodicPropertiesTransform
 from matsciml.datasets.utils import cart_frac_conversion
@@ -1066,6 +1067,8 @@ def collate_samples_into_batch_schema(samples: list[DataSampleSchema]) -> object
         "batch_size": (int, ...),
         "graph": (Any | None, None),
         "num_edges": (NDArray[Shape["*"], int] | torch.LongTensor | None, None),
+        "embeddings": (Embeddings | None, None),
+        "outputs": (ModelOutput | None, None),
     }
     collected_data = {}  # holds all the data to unpack into the generated schema
     # check to see if graphs are present

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -405,9 +405,19 @@ class TargetSchema(MatsciMLSchema):
     """
 
     name: str
-    shape: int | list[int]
+    shape: str
     description: str
     units: str | None = None
+
+    @model_validator(mode="after")
+    def check_shape_str(self) -> Self:
+        """This checks to make sure that the shape specification is valid for ``Shape``."""
+        invalid_regex = re.compile(r"[^\d\,\*]+")
+        if invalid_regex.search(self.shape):
+            raise ValueError(
+                f"Target shape should be specified with digits, commas, and wildcard only. Got {self.shape}"
+            )
+        return self
 
 
 class DatasetSchema(MatsciMLSchema):

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -327,6 +327,36 @@ class GraphWiringSchema(BaseModel):
             )
 
 
+class TargetSchema(BaseModel):
+    """
+    Schema that specifies a target label or property.
+
+    The intention is to provide sufficient fields to make targets
+    in a dataset fully documented to leave zero ambiguities.
+
+    Attributes
+    ----------
+    name : str
+        String name of the target. This will be used to look up
+        targets throughout the pipeline.
+    shape : int | list[int]
+        Designated shape of the target. For scalar targets, pass
+        a value of zero to this field.
+    description : str
+        Long text description of what this target is and how it
+        was calculated.
+    units : str, optional
+        Expected units of this property. This is more for documentation
+        for now, but in the future it may be helpful to do unit
+        conversions with this field.
+    """
+
+    name: str
+    shape: int | list[int]
+    description: str
+    units: str | None = None
+
+
 class DatasetSchema(BaseModel):
     """
     A schema for defining a collection of data samples.

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -15,6 +15,7 @@ from pydantic import (
     ConfigDict,
     Field,
     ValidationError,
+    create_model,
     field_validator,
     model_validator,
     ValidationInfo,
@@ -993,3 +994,131 @@ class DataSampleSchema(MatsciMLSchema):
                 self._exception_wrapper(
                     TypeError(f"Unexpected graph type: {type(self.graph)}")
                 )
+
+
+def _concatenate_data_list(all_data: list[Any]) -> list[Any] | torch.Tensor:
+    """
+    Concatenates an arbitrary list of data where possible.
+
+    For array-types (NumPy, PyTorch), we first convert all
+    of the sample data into tensors, followed by concatenation
+    along the first dimension (nodes or edges).
+
+    For scalar-types, we return a 1D tensor.
+
+    For all other types, we return the inputs unmodified.
+
+    Parameters
+    ----------
+    all_data : list[Any]
+        List of data to try and concatenate.
+
+    Returns
+    -------
+    list[Any] | torch.Tensor
+        If the concatenation was successful, returns a tensor.
+        Otherwise, returns the unmodified input.
+    """
+    sample = all_data[0]
+    if isinstance(sample, (np.ndarray, torch.Tensor)):
+        # homogenize all samples into tensors
+        all_data = [torch.Tensor(s) for s in all_data]
+        return torch.concat(all_data)
+    if isinstance(sample, (float, int)):
+        output = torch.Tensor(all_data)
+        if isinstance(sample, int):
+            output = output.long()
+        return output
+    else:
+        # leave the data as a list
+        return all_data
+
+
+def collate_samples_into_batch_schema(samples: list[DataSampleSchema]) -> object:
+    """
+    Function to collate a list of ``DataSampleSchema`` into a dynamically
+    generated ``BatchSchema``.
+
+    The additional logic in this function is to handle graphs, copying
+    references to their respective data, and calling the respective framework
+    batching functions.
+
+    The purpose of on-the-fly schema generation is to do some degree of
+    validation, but primarily provide regular structure for use in the
+    task pipeline side of things. Given that the schema should be serializable,
+    it may also make debugging more streamlined.
+
+    Parameters
+    ----------
+    samples : list[DataSampleSchema]
+        List of data samples that have been pre-validated.
+
+    Returns
+    -------
+    object
+        Instance of a ``BatchSchema`` object. This is not explicitly annotated
+        since the model/class is defined dynamically based off incoming data.
+    """
+    ref_schema = samples[0].schema()
+    # initial keys are going to hold the main structure of the schema
+    schema_to_generate = {
+        "num_atoms": (NDArray[Shape["*"], int] | torch.LongTensor, ...),
+        "batch_size": (int, ...),
+        "graph": (Any | None, None),
+        "num_edges": (NDArray[Shape["*"], int] | torch.LongTensor | None, None),
+    }
+    collected_data = {}  # holds all the data to unpack into the generated schema
+    # check to see if graphs are present
+    if samples[0].graph is not None:
+        graph_sample = samples[0].graph
+        if "pyg" in package_registry:
+            from torch_geometric.data import Batch, Data
+
+            if isinstance(graph_sample, Data):
+                batched_graph = Batch.from_data_list(
+                    [sample.graph for sample in samples]
+                )
+                graph_type = Batch
+                for key in batched_graph.keys():
+                    data = getattr(batched_graph, key)
+                    schema_to_generate[key] = (type(data), ...)
+                    collected_data[key] = data
+                collected_data["num_edges"] = _concatenate_data_list(
+                    [sample.graph.batch_num_edges() for sample in samples]
+                ).long()
+        else:
+            from dgl import DGLGraph, batch
+
+            if isinstance(graph_sample, DGLGraph):
+                batched_graph = batch([sample.graph for sample in samples])
+                graph_type = DGLGraph
+                for key, data in batched_graph.ndata.items():
+                    schema_to_generate[key] = (type(data), ...)
+                    collected_data[key] = data
+                for key, data in batched_graph.edata.items():
+                    schema_to_generate[key] = (type(data), ...)
+                    collected_data[key] = data
+                collected_data["num_edges"] = _concatenate_data_list(
+                    [sample.graph.batch_num_edges() for sample in samples]
+                ).long()
+        collected_data["num_atoms"] = _concatenate_data_list(
+            [sample.num_atoms for sample in samples]
+        ).long()
+        collected_data["graph"] = batched_graph
+        schema_to_generate["graph"] = (graph_type, ...)
+    # for everything else that wasn't packed into the graph
+    for key in ref_schema["required"]:
+        if key not in schema_to_generate:
+            schema_to_generate[key] = (Any, ...)
+        if key not in collected_data:
+            collected_data[key] = _concatenate_data_list(
+                [getattr(sample, key) for sample in samples]
+            )
+    collected_data["batch_size"] = len(samples)
+    # generate the schema, then create the model
+    BatchSchema = create_model(
+        "BatchSchema",
+        **schema_to_generate,
+        __config__=ConfigDict(arbitrary_types_allowed=True, use_enum_values=True),
+    )
+    return BatchSchema(**collected_data)

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -414,7 +414,7 @@ class DatasetSchema(BaseModel):
     edge_stats: NormalizationSchema | None = None
 
     @classmethod
-    def from_json(cls, json_path: PathLike) -> Self:
+    def from_json_file(cls, json_path: PathLike) -> Self:
         """
         Deserialize a JSON file, validating against the expected dataset
         schema.

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -392,9 +392,12 @@ class TargetSchema(MatsciMLSchema):
     name : str
         String name of the target. This will be used to look up
         targets throughout the pipeline.
-    shape : int | list[int]
-        Designated shape of the target. For scalar targets, pass
-        a value of zero to this field.
+    shape : str
+        Designated shape of the target. Use '*' to specify variable
+        dimensions, and integers for fixed dimensions separated
+        by commas. As an example, '*' could designate a number of
+        node features (since the number of nodes is variable), and
+        '*, 3' could represent a vector property also over nodes.
     description : str
         Long text description of what this target is and how it
         was calculated.

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -468,7 +468,8 @@ class DataSampleSchema(BaseModel):
     atomic_numbers: NDArray[Shape["*"], int]
     pbc: PeriodicBoundarySchema
     datatype: DataSampleEnum
-    electron_spins: NDArray[Shape["*"], float] | None = None  # electronic spin at atom
+    alpha_electron_spins: NDArray[Shape["*"], float] | None = None
+    beta_electron_spins: NDArray[Shape["*"], float] | None = None
     nuclear_spins: NDArray[Shape["*"], float] | None = (
         None  # optional nuclear spin at atom
     )

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -23,7 +23,6 @@ from numpydantic import NDArray, Shape
 from loguru import logger
 import numpy as np
 import torch
-import h5py
 
 from matsciml.common.packages import package_registry
 from matsciml.common.inspection import get_all_args
@@ -994,22 +993,3 @@ class DataSampleSchema(MatsciMLSchema):
                 self._exception_wrapper(
                     TypeError(f"Unexpected graph type: {type(self.graph)}")
                 )
-
-    def write_to_hdf5(self, h5_file: h5py.File) -> None:
-        """
-        Write the current data schema to an open HDF5 file.
-
-        This uses the index value of the sample to create an
-        HDF5 group, and for every property that is not ``None``
-        will write to the group.
-
-        Parameters
-        ----------
-        h5_file : h5py.File
-            Open HDF5 file for writing.
-        """
-        assert h5_file.mode != "r", "HDF5 file must be open for writing."
-        group = h5_file.create_group(self.index)
-        for key, value in self.model_dump().items():
-            if value is not None:
-                group[key] = value

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -836,7 +836,7 @@ class DataSampleSchema(MatsciMLSchema):
                     "Fractional coordinate dimensions do not match cartesians."
                 )
             # round coordinate values so that -1e-6 is just zero and doesn't fail the test
-            round_coords = np.round(self.frac_coords, decimals=5)
+            round_coords = np.round(self.frac_coords, decimals=3)
             if np.any(np.logical_or(round_coords > 1.0, round_coords < 0.0)):
                 raise ValueError(
                     f"Fractional coordinates are outside of [0, 1]: {self.frac_coords}"

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -23,6 +23,7 @@ from numpydantic import NDArray, Shape
 from loguru import logger
 import numpy as np
 import torch
+import h5py
 
 from matsciml.common.packages import package_registry
 from matsciml.common.inspection import get_all_args
@@ -890,3 +891,22 @@ class DataSampleSchema(MatsciMLSchema):
                 self._exception_wrapper(
                     TypeError(f"Unexpected graph type: {type(self.graph)}")
                 )
+
+    def write_to_hdf5(self, h5_file: h5py.File) -> None:
+        """
+        Write the current data schema to an open HDF5 file.
+
+        This uses the index value of the sample to create an
+        HDF5 group, and for every property that is not ``None``
+        will write to the group.
+
+        Parameters
+        ----------
+        h5_file : h5py.File
+            Open HDF5 file for writing.
+        """
+        assert h5_file.mode != "r", "HDF5 file must be open for writing."
+        group = h5_file.create_group(self.index)
+        for key, value in self.model_dump().items():
+            if value is not None:
+                group[key] = value

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -634,6 +634,31 @@ class DataSampleSchema(BaseModel):
             return self.extras[name]
         return None
 
+    def _exception_wrapper(self, exception: Exception):
+        """
+        Re-raises an exception that uses this class, and chains the sample index.
+
+        This is to make debugging more informative, as it allows
+        arbitrary exceptions to be raised while also informing us
+        which sample specifically is causing issues.
+
+        Parameters
+        ----------
+        exception : Exception
+            Any possible ``Exception``. The type of exception is
+            used to re-raise the exception including the sample index.
+
+        Raises
+        ------
+        exception_cls
+            Raises the same exception as the input one, with
+            an additional message.
+        """
+        exception_cls = exception.__class__
+        raise exception_cls(
+            f"Data schema validation failed at sample {self.index}."
+        ) from exception
+
     @model_validator(mode="after")
     def atom_count_consistency(self) -> Self:
         for key in [

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -42,17 +42,6 @@ attribute names that should be
 # ruff: noqa: F722
 
 
-class DatasetEnum(str, Enum):
-    s2ef = "S2EFDataset"
-    is2re = "IS2REDataset"
-    mp20 = "MaterialsProjectDataset"
-    mptraj = "MaterialsTrajectoryDataset"
-    alexandria = "AlexandriaDataset"
-    nomad = "NomadDataset"
-    oqmd = "OQMDDataset"
-    generic = "GenericDataset"
-
-
 class DataSampleEnum(str, Enum):
     """
     An Enum for categorizing data samples, which implicitly

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -372,10 +372,10 @@ class DatasetSchema(BaseModel):
     creation : datetime
         An immutable ``datetime`` for when the dataset was
         created.
-    target_keys : list[str]
-        List of keys that are expected to be treated as target
-        labels. This is used by the data pipeline to specifically
-        load and designate as targets.
+    targets : list[TargetSchema]
+        A list of ``TargetSchema`` objects or dictionaries that satisfy
+        the schema. This is used simultaneously for documentation as
+        well as for data loading to look specifically for these keys.
     split_blake2s : SplitHashSchema
         Schema representing blake2s checksums for each dataset split.
     modified : datetime, optional
@@ -403,7 +403,7 @@ class DatasetSchema(BaseModel):
 
     name: str
     creation: datetime
-    target_keys: list[str]
+    targets: list[TargetSchema]
     split_blake2s: SplitHashSchema
     dataset_type: DataSampleEnum | list[DataSampleEnum]
     modified: datetime | None = None

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -915,6 +915,7 @@ class DataSampleSchema(MatsciMLSchema):
             Instance of an ``Atoms`` object constructed with
             the current data sample.
         """
+        pbc = [value for value in self.pbc.model_dump().values()]
         return Atoms(
             positions=self.cart_coords,
             cell=self.lattice_matrix,
@@ -922,6 +923,7 @@ class DataSampleSchema(MatsciMLSchema):
             tags=self.atomic_labels,
             charges=self.atomic_charges,
             masses=self.isotopic_masses,
+            pbc=pbc,
         )
 
     @property

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -741,7 +741,7 @@ class DataSampleSchema(MatsciMLSchema):
     graph: Any = None
     extras: dict[str, Any] | None = None
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, use_enum_values=True)
 
     def __getattr__(self, name: str) -> Any | None:
         """Overrides the behavior of `getattr` to also look in `extras` if available"""

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -127,7 +127,9 @@ class DataSampleEnum(str, Enum):
 
     scf = "SCFCycle"
     opt_trajectory = "OptimizationCycle"
-    property = "Property"
+    e_property = "ElectronicPropertyCalculation"
+    n_property = "NuclearPropertyCalculation"
+    states = "ExcitedStateCalculation"
 
 
 class SplitHashSchema(MatsciMLSchema):

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -488,6 +488,7 @@ class DataSampleSchema(BaseModel):
     )
     charge: float | None = None  # overall system charge
     multiplicity: float | None = None  # overall system multiplicity
+    electronic_state_index: int = 0
     images: NDArray[Shape["*, 3"], int] | None = None
     offsets: NDArray[Shape["*, 3"], float] | None = None
     unit_offsets: NDArray[Shape["*, 3"], float] | None = None

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -10,7 +10,7 @@ import json
 import re
 
 from ase import Atoms
-from ase.geometry import cell_to_cellpar, cellpar_to_cell
+from ase.geometry import cell_to_cellpar, cellpar_to_cell, complete_cell
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -775,6 +775,18 @@ class DataSampleSchema(MatsciMLSchema):
         raise exception_cls(
             f"Data schema validation failed at sample {self.index}."
         ) from exception
+
+    @field_validator("lattice_matrix")
+    @classmethod
+    def orthogonal_lattice_matrix(cls, values: NDArray[Shape["3, 3"], float] | None):
+        """
+        Ensures that the lattice matrix comprises a complete
+        basis of orthogonal vectors.
+        """
+
+        if values is not None:
+            values = complete_cell(values)
+        return values
 
     @model_validator(mode="before")
     @classmethod

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -673,23 +673,29 @@ class DataSampleSchema(BaseModel):
             value = getattr(self, key, None)
             if value is not None:
                 if len(value) != self.num_atoms:
-                    raise ValueError(
-                        f"Inconsistent number of elements for {key}; expected {self.num_atoms}, got {len(value)}."
+                    self._exception_wrapper(
+                        ValueError(
+                            f"Inconsistent number of elements for {key}; expected {self.num_atoms}, got {len(value)}."
+                        )
                     )
         for key in ["forces", "stresses"]:
             value = getattr(self, key, None)
             if value is not None:
                 if value.shape[0] != self.num_atoms:
-                    raise ValueError(
-                        f"Inconsistent number of elements for node property {key}; expected {self.num_atoms}, got {value.shape[0]}."
+                    self._exception_wrapper(
+                        ValueError(
+                            f"Inconsistent number of elements for node property {key}; expected {self.num_atoms}, got {value.shape[0]}."
+                        )
                     )
         if self.edge_index is not None:
             for key in ["images", "offsets", "unit_offsets"]:
                 value = getattr(self, key, None)
                 if value is not None:
                     if value.shape[0] != self.edge_index:
-                        raise ValueError(
-                            f"Inconsistent number of elements for edge property {key}."
+                        self._exception_wrapper(
+                            ValueError(
+                                f"Inconsistent number of elements for edge property {key}."
+                            )
                         )
         return self
 
@@ -737,9 +743,11 @@ class DataSampleSchema(BaseModel):
                 value = getattr(self, key)
                 if value is not None:
                     if value.shape[0] != num_edges:
-                        raise ValueError(
-                            f"Mismatch in edge property {key}. "
-                            "Expected the first dimension to match the number of edges."
+                        self._exception_wrapper(
+                            ValueError(
+                                f"Mismatch in edge property {key}. "
+                                "Expected the first dimension to match the number of edges."
+                            )
                         )
         return self
 
@@ -769,4 +777,6 @@ class DataSampleSchema(BaseModel):
                 if isinstance(self.graph, DGLGraph):
                     return "dgl"
             else:
-                raise TypeError(f"Unexpected graph type: {type(self.graph)}")
+                self._exception_wrapper(
+                    TypeError(f"Unexpected graph type: {type(self.graph)}")
+                )

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -527,9 +527,10 @@ class DatasetSchema(MatsciMLSchema):
 
     @model_validator(mode="after")
     def check_target_normalization(self) -> Self:
+        """Cross-check target normalization specification with defined targets."""
         if self.normalization is not None:
             # first check every key is available as targets
-            target_keys = set(self.target_keys)
+            target_keys = set([target.name for target in self.targets])
             norm_keys = set(self.normalization.keys())
             # check to see if we have unexpected norm keys
             diff = norm_keys - target_keys
@@ -596,7 +597,7 @@ class DataSampleSchema(MatsciMLSchema):
     isotopic_masses : NDArray[Shape['*'], float], optional
         Specifies isotopic masses for each atom as a variable
         length array of floating point values.
-    atomic_charges: NDArray[Shape['*'], float], optional
+    atomic_charges : NDArray[Shape['*'], float], optional
         Specifies some characterization of charge for each atom
         as a variable length array of floating point values.
     atomic_energies : NDArray[Shape['*'], float], optional
@@ -611,7 +612,7 @@ class DataSampleSchema(MatsciMLSchema):
         are multiple types of total energy values, we recommend writing
         the most primitive type (e.g. total electronic energy) available,
         and add others (e.g. corrections, etc.) to ``extra``.
-    forces: NDArray[Shape['*, 3'], float], optional
+    forces : NDArray[Shape['*, 3'], float], optional
         Specifies atomic forces on each atom as a variable length
         array of 3D vectors with floating point values.
     stresses : NDArray[Shape['*, 3, 3'], float], optional
@@ -835,6 +836,19 @@ class DataSampleSchema(MatsciMLSchema):
         return self
 
     def to_ase_atoms(self) -> Atoms:
+        """
+        Provides a simple conversion to an ``ase.Atoms`` object.
+
+        This method does not strictly check that outputs are mapped
+        correctly, but at least maps the fields in the schema to
+        intended attributes in the ``Atoms`` class.
+
+        Returns
+        -------
+        Atoms
+            Instance of an ``Atoms`` object constructed with
+            the current data sample.
+        """
         return Atoms(
             positions=self.cart_coords,
             cell=self.lattice_matrix,

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Literal, Any, Self
 from os import PathLike
 from pathlib import Path
-import json
 import re
 
 from ase import Atoms
@@ -95,7 +94,7 @@ class MatsciMLSchema(BaseModel):
         if not isinstance(json_path, Path):
             json_path = Path(json_path)
         with open(json_path.with_suffix(".json"), "w+") as write_file:
-            json.dump(self.model_dump(), write_file, indent=2)
+            write_file.write(self.model_dump_json(round_trip=True, indent=2))
 
 
 class DataSampleEnum(str, Enum):

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -104,11 +104,14 @@ class DataSampleEnum(str, Enum):
     samples may relate to one another. An example would be
     ``OptimizationCycle``, which implies the dataset should
     contain multiple samples per structure of atomic forces.
-    ``SCFCycle`` on the other hand may be more fine grained,
-    as it may contain a wide array
 
     These tend to map more directly to computational chemistry
-    workflows, and
+    workflows, although naturally some types of calculations
+    will have overlap between them (e.g. an excited state geometry
+    optimization). In those cases, the recommendation would be
+    to select the intended use case - i.e. ``OptimizationCycle``
+    is the preferred enum for this example as it infers the
+    presence of atomic forces.
 
     Attributes
     ----------
@@ -120,9 +123,18 @@ class DataSampleEnum(str, Enum):
         Describes data comprising a single optimization or relaxation
         step, which includes atomic forces, (partial) Hessians,
         and geometry convergence metrics.
-    property : str
-        Describes a specific property calculation. This can range
-        from multipole moments, to polarization, etc.
+    e_property : str
+        Describes a specific electronic property calculation. This can range
+        from multipole moments, to polarization, etc. Choose this
+        category if your intention is to provide properties, even if
+        certain electronic properties come for 'free' with SCF calculations.
+    n_property : str
+        Describes a specific nuclear property calculation, such as nuclear
+        multipole moments (e.g. nitrogen quadrupole), magnetic moments, etc.
+    states : str
+        Describes an excited state calculation that does not involve geometry
+        optimizations. This may refer to oscillator strengths/transition
+        moments.
     """
 
     scf = "SCFCycle"

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -484,6 +484,9 @@ class DatasetSchema(MatsciMLSchema):
         Mean/std values for the nodes per data sample.
     edge_stats : NormalizationSchema, optional
         Mean/std values for the number of edges per data sample.
+    seed : int, optional
+        Random seed used to generate the splits. This is kept optional
+        in the case where splits are not randomly generated.
     """
 
     name: str
@@ -497,6 +500,7 @@ class DatasetSchema(MatsciMLSchema):
     normalization: dict[str, NormalizationSchema] | None = None
     node_stats: NormalizationSchema | None = None
     edge_stats: NormalizationSchema | None = None
+    seed: int | None = None
 
     @classmethod
     def from_json_file(cls, json_path: PathLike) -> Self:

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -708,6 +708,9 @@ class DataSampleSchema(MatsciMLSchema):
         does not fit under any of the currently defined fields, but
         is not recommended as it bypasses any of the type and shape
         validations that ``pydantic``/``numpydantic`` provides.
+    transform_store : dict[str, Any], optional
+        Dictionary storage for transform results. This is a way to organize
+        products of transforms, e.g. instead of overwriting properties.
     """
 
     index: int
@@ -744,6 +747,7 @@ class DataSampleSchema(MatsciMLSchema):
     unit_offsets: NDArray[Shape["*, 3"], float] | None = None
     graph: Any = None
     extras: dict[str, Any] | None = None
+    transform_store: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(arbitrary_types_allowed=True, use_enum_values=True)
 

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -801,6 +801,7 @@ class DataSampleSchema(MatsciMLSchema):
                 self._exception_wrapper(
                     ValueError("Fractional coordinates are outside of [0, 1].")
                 )
+        return self
 
     @model_validator(mode="after")
     def atom_count_consistency(self) -> Self:

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -832,14 +832,14 @@ class DataSampleSchema(MatsciMLSchema):
             )
         if isinstance(self.frac_coords, NDArray):
             if self.frac_coords.shape != self.cart_coords.shape:
-                self._exception_wrapper(
-                    ValueError(
-                        "Fractional coordinate dimensions do not match cartesians."
-                    )
+                raise ValueError(
+                    "Fractional coordinate dimensions do not match cartesians."
                 )
-            if self.frac_coords.min() < 0.0 or self.frac_coords.max() > 1.0:
-                self._exception_wrapper(
-                    ValueError("Fractional coordinates are outside of [0, 1].")
+            # round coordinate values so that -1e-6 is just zero and doesn't fail the test
+            round_coords = np.round(self.frac_coords, decimals=5)
+            if np.any(np.logical_or(round_coords > 1.0, round_coords < 0.0)):
+                raise ValueError(
+                    f"Fractional coordinates are outside of [0, 1]: {self.frac_coords}"
                 )
         return self
 

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -263,7 +263,9 @@ class GraphWiringSchema(MatsciMLSchema):
     function.
 
     The validation of this schema includes checking to ensure
-    that the
+    that a specific package used for performing neighborhood
+    calculations matches the recorded version, to ensure that
+    there are no unexpected changes to the algorithm used.
 
     Attributes
     ----------

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -434,7 +434,7 @@ class TargetSchema(MatsciMLSchema):
     @model_validator(mode="after")
     def check_shape_str(self) -> Self:
         """This checks to make sure that the shape specification is valid for ``Shape``."""
-        invalid_regex = re.compile(r"[^\d\,\*]+")
+        invalid_regex = re.compile(r"[^\d\,\*\s]+")
         if invalid_regex.search(self.shape):
             raise ValueError(
                 f"Target shape should be specified with digits, commas, and wildcard only. Got {self.shape}"

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -703,6 +703,21 @@ class DataSampleSchema(BaseModel):
                 return False
         return True
 
+    @model_validator(mode="after")
+    def check_edge_data(self) -> Self:
+        """Ensure that if edge properties are consistent with number of edges."""
+        if self.edge_index is not None:
+            num_edges = self.edge_index.shape[1]
+            for key in ["images", "offsets", "unit_offsets"]:
+                value = getattr(self, key)
+                if value is not None:
+                    if value.shape[0] != num_edges:
+                        raise ValueError(
+                            f"Mismatch in edge property {key}. "
+                            "Expected the first dimension to match the number of edges."
+                        )
+        return self
+
     def to_ase_atoms(self) -> Atoms:
         return Atoms(
             positions=self.cart_coords,

--- a/matsciml/datasets/tests/test_schema.py
+++ b/matsciml/datasets/tests/test_schema.py
@@ -197,3 +197,24 @@ def test_lattice_param_to_matrix_consistency():
     assert np.allclose(reconverted, data.lattice_parameters)
     exact = np.array([[5.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 5.0]])
     assert np.allclose(exact, data.lattice_matrix)
+
+
+def test_lattice_matrix_to_param_consistency():
+    """Make sure that lattice parameters map to matrix correctly during validation"""
+    coords = np.random.rand(5, 3)
+    numbers = np.random.randint(1, 100, (5))
+    data = schema.DataSampleSchema(
+        index=0,
+        num_atoms=5,
+        cart_coords=coords,
+        atomic_numbers=numbers,
+        pbc={"x": True, "y": True, "z": True},
+        datatype="OptimizationCycle",
+        lattice_matrix=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+    )
+    assert data.frac_coords is not None
+    assert data.lattice_matrix is not None
+    converted = cell_to_cellpar(data.lattice_matrix)
+    assert np.allclose(converted, data.lattice_parameters)
+    exact = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    assert np.allclose(exact, data.lattice_matrix)

--- a/matsciml/datasets/tests/test_schema.py
+++ b/matsciml/datasets/tests/test_schema.py
@@ -48,10 +48,14 @@ def test_dataset_minimal_schema_pass():
         targets=[
             {
                 "name": "total_energy",
-                "shape": 0,
+                "shape": "0",
                 "description": "Total energy of the system.",
             },
-            {"name": "forces", "shape": 3, "description": "Atomic forces per node."},
+            {
+                "name": "forces",
+                "shape": "*,3",
+                "description": "Atomic forces per node.",
+            },
         ],
         split_blake2s=splits,
     )
@@ -70,10 +74,14 @@ def test_dataset_minimal_schema_roundtrip():
         targets=[
             {
                 "name": "total_energy",
-                "shape": 0,
+                "shape": "0",
                 "description": "Total energy of the system.",
             },
-            {"name": "forces", "shape": 3, "description": "Atomic forces per node."},
+            {
+                "name": "forces",
+                "shape": "*,3",
+                "description": "Atomic forces per node.",
+            },
         ],
         split_blake2s=splits,
     )

--- a/matsciml/datasets/tests/test_schema.py
+++ b/matsciml/datasets/tests/test_schema.py
@@ -67,7 +67,14 @@ def test_dataset_minimal_schema_roundtrip():
         name="GenericDataset",
         creation=datetime.now(),
         dataset_type="SCFCycle",
-        target_keys=["energy", "forces"],
+        targets=[
+            {
+                "name": "total_energy",
+                "shape": 0,
+                "description": "Total energy of the system.",
+            },
+            {"name": "forces", "shape": 3, "description": "Atomic forces per node."},
+        ],
         split_blake2s=splits,
     )
     json_rep = dset.model_dump_json()

--- a/matsciml/datasets/tests/test_schema.py
+++ b/matsciml/datasets/tests/test_schema.py
@@ -45,7 +45,14 @@ def test_dataset_minimal_schema_pass():
         name="GenericDataset",
         creation=datetime.now(),
         dataset_type="SCFCycle",
-        target_keys=["energy", "forces"],
+        targets=[
+            {
+                "name": "total_energy",
+                "shape": 0,
+                "description": "Total energy of the system.",
+            },
+            {"name": "forces", "shape": 3, "description": "Atomic forces per node."},
+        ],
         split_blake2s=splits,
     )
     assert dset

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -1046,7 +1046,7 @@ def cart_frac_conversion(
 
     # This matrix is normally for fractional to cart. Implements the matrix found in
     # https://en.wikipedia.org/wiki/Fractional_coordinates#General_transformations_between_fractional_and_Cartesian_coordinates
-    rotation = torch.tensor(
+    rotation = np.array(
         [
             [
                 a
@@ -1069,11 +1069,13 @@ def cart_frac_conversion(
             ],
             [a * np.cos(beta), b * np.cos(alpha), c],
         ],
-        dtype=coords.dtype,
     )
     if to_fractional:
         # invert elements for the opposite conversion
-        rotation = torch.linalg.inv(rotation)
+        rotation = np.linalg.inv(rotation)
+    # if coords are already torch, cast as a tensor so we can matmul
+    if isinstance(coords, torch.Tensor):
+        rotation = torch.from_numpy(rotation).to(coords.type)
     output = coords @ rotation
     return output
 

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -4,8 +4,6 @@ import pickle
 from dataclasses import dataclass
 from collections.abc import Generator
 from functools import lru_cache, partial
-from ase.geometry import Cell, cellpar_to_cell, complete_cell
-from ase.neighborlist import NeighborList
 from os import makedirs
 from pathlib import Path
 from typing import Any, Callable
@@ -20,6 +18,7 @@ from joblib import Parallel, delayed
 from pymatgen.core import Lattice, Structure
 from tqdm import tqdm
 import ase
+from ase.geometry import Cell, cellpar_to_cell, complete_cell
 from ase.neighborlist import neighbor_list
 
 from matsciml.common import package_registry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ dependencies = [
   "e3nn",
   "mace-torch==0.3.6",
   "monty==2024.2.2",
-  "loguru"
+  "loguru",
+  "numpydantic>=1.6.4",
+  "pydantic>=2.9.2",
 ]
 description = "PyTorch Lightning and Deep Graph Library enabled materials science deep learning pipeline"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This PR introduces classes in preparation for a big refactor, emphasizing on reproducibility and generally "explicit is better than implicit". The eventual goal would be to replace currently defined LMDB datasets with the HDF5 + fully specified schema: the former being a better known and less problematic binary data format, and the latter meaning all datasets can share the same Python implementation, but be fully documented *and* validated at runtime.

- Leans on `pydantic` schema definition and validation quite heavily, up to and including array shape validation in `DataSampleSchema`, and fully documented datasets with `DatasetSchema`.
- Schema provides consistent field names, which should phase out `DataDict` and any ambiguity in the pipelines of what key maps to what.
- As seen in `__getitem__` of the new dataset class, the code is significantly simpler for the data loading logic.