### PR TITLE
Edge count fix

### DIFF
--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -661,7 +661,7 @@ class Edge:
 
     def __str__(self) -> str:
         """Represents the edge without phase or parity information. Mainly for hashing."""
-        return f"Sorted src/dst: {self.sorted_index}, |image|: {self.image}"
+        return f"Sorted src/dst: {self.sorted_index}, |image|: {self.unsigned_image}"
 
     def __hash__(self) -> int:
         return hash(str(self))

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -644,7 +644,8 @@ class Edge:
         return all([index_eq, image_eq])
 
     def __str__(self) -> str:
-        return f"Sorted src/dst: {self.sorted_index}, image: {self.image}"
+        """Represents the edge without phase or parity information. Mainly for hashing."""
+        return f"Sorted src/dst: {self.sorted_index}, |image|: {self.image}"
 
     def __hash__(self) -> int:
         return hash(str(self))

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -656,7 +656,7 @@ class Edge:
 
     def __eq__(self, other: Edge) -> bool:
         index_eq = self.sorted_index == other.sorted_index
-        image_eq = np.all(self.image == other.image)
+        image_eq = np.all(self.unsigned_image == other.unsigned_image)
         return all([index_eq, image_eq])
 
     def __str__(self) -> str:

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -638,6 +638,22 @@ class Edge:
     def sorted_index(self) -> tuple[int, int]:
         return (min(self.src, self.dst), max(self.src, self.dst))
 
+    @property
+    def unsigned_image(self) -> np.ndarray:
+        """
+        Returns the absolute image indices.
+
+        This is used when considering parity-inversion,
+        i.e. two edges are equivalent if they are in
+        in mirroring cell images.
+
+        Returns
+        -------
+        np.ndarray
+            Indices without parity
+        """
+        return np.abs(self.image)
+
     def __eq__(self, other: Edge) -> bool:
         index_eq = self.sorted_index == other.sorted_index
         image_eq = np.all(self.image == other.image)

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -664,6 +664,32 @@ class Edge:
         return f"Sorted src/dst: {self.sorted_index}, |image|: {self.unsigned_image}"
 
     def __hash__(self) -> int:
+        """
+        This hash method is primarily intended for use in
+        ``set`` comparisons to check for uniqueness.
+
+        The general idea for edge-uniqueness is assuming
+        the undirected case where ``src`` and ``dst``
+        is exchangable, and when not considering phase
+        for image indices.
+
+        As an example, the following two edges are
+        equivalent as they have interchangable ``src``
+        and ``dst`` indices, **and** the displacement
+        owing to image offsets is the same - just in
+        opposite directions,
+
+        ```
+        Edge(src=1, dst=7, image=[-1, 0, 0])
+        Edge(src=7, dst=1, image[1, 0, 0])
+        ```
+
+        Returns
+        -------
+        int
+            Permutation invariant hash of this edge.
+        """
+
         return hash(str(self))
 
 


### PR DESCRIPTION
This PR is related to #321, and makes the edges being returned exactly equivalent to those counted by `ovito`.

The changes made affect the `Edge` dataclass that was being used with either `pymatgen` and `ase` backends for periodic boundary calculations; the `__eq__` and `__hash__` methods now compare `image` indices without considering phase. The result is that edges are kept in `set`s as __undirected__ and equivalent by mirror symmetry.