### PR TITLE
Model output validation fix

### DIFF
--- a/matsciml/common/tests/test_types.py
+++ b/matsciml/common/tests/test_types.py
@@ -32,9 +32,17 @@ def test_incorrect_force_shape():
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
-def test_consistency_check_pass(batch_size):
+@pytest.mark.parametrize("is_unsqueeze", [True, False])
+def test_consistency_check_pass(batch_size, is_unsqueeze):
+    energies = torch.rand(batch_size)
+    # this imitates models that might keep redundant dimensions
+    if is_unsqueeze:
+        energies.unsqueeze_(-1)
     types.ModelOutput(
-        batch_size=batch_size, forces=torch.rand(32, 3), node_energies=torch.rand(32, 1)
+        batch_size=batch_size,
+        forces=torch.rand(32, 3),
+        node_energies=torch.rand(32, 1),
+        total_energy=energies,
     )
 
 

--- a/matsciml/common/tests/test_types.py
+++ b/matsciml/common/tests/test_types.py
@@ -31,9 +31,10 @@ def test_incorrect_force_shape():
         types.ModelOutput(batch_size=8, forces=torch.rand(32, 4, 3))
 
 
-def test_consistency_check_pass():
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
+def test_consistency_check_pass(batch_size):
     types.ModelOutput(
-        batch_size=8, forces=torch.rand(32, 3), node_energies=torch.rand(32, 1)
+        batch_size=batch_size, forces=torch.rand(32, 3), node_energies=torch.rand(32, 1)
     )
 
 

--- a/matsciml/common/types.py
+++ b/matsciml/common/types.py
@@ -148,7 +148,7 @@ class ModelOutput(BaseModel):
             if values.ndim == 0:
                 values = values.unsqueeze(0)
             # last step is an assertion check for QA
-            if values.ndim != 1:
+            if values.numel() != 1 and values.ndim != 1:
                 raise ValueError(
                     f"Expected graph/system energies to be scalar; got shape {values.shape}"
                 )


### PR DESCRIPTION
This PR fixes the issue where a batch size of 1 will cause the `ModelOutput` model validation to fail for `standardize_total_energy`, where a single scalar wrapped in a `torch.Tensor` returns an `ndim != 1` with an empty `torch.Size([])` for the shape.

The fix makes it so that the check that particular check is skipped if there is a single element in `total_energies` after all of the homogenizing work is done. I've also parameterized the corresponding unit test to include a number of different batch sizes, including one.