### PR TITLE
Final edge creation

### DIFF
--- a/matsciml/datasets/tests/test_edge_logic.py
+++ b/matsciml/datasets/tests/test_edge_logic.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+import numpy as np
+
+from matsciml.datasets.utils import Edge
+
+
+def test_non_self_interaction():
+    """
+    These two nodes edges should not be equivalent, since they
+    are not self-interactions and the images are different
+    """
+    a = Edge(src=0, dst=10, image=np.array([-1, 0, 0]))
+    b = Edge(src=0, dst=10, image=np.array([1, 0, 0]))
+    assert a != b
+
+
+def test_self_interaction_image():
+    """
+    These two edges are mirror images of one another since
+    the src/dst are the same node.
+    """
+    a = Edge(src=0, dst=0, image=np.array([-1, 0, 0]))
+    b = Edge(src=0, dst=0, image=np.array([1, 0, 0]))
+    assert a == b
+
+
+@pytest.mark.parametrize("is_undirected", [True, False])
+def test_directed_edges(is_undirected):
+    """
+    These two are the same edge in the undirected case,
+    but are different if treating directed graphs
+    """
+    a = Edge(src=5, dst=10, image=np.array([0, 0, 0]), is_undirected=is_undirected)
+    b = Edge(src=10, dst=5, image=np.array([0, 0, 0]), is_undirected=is_undirected)
+    if is_undirected:
+        assert a == b
+    else:
+        assert a != b

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -29,6 +29,8 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
         allow_self_loops: bool = False,
         convert_to_unit_cell: bool = False,
         is_cartesian: bool | None = None,
+        is_directed: bool = False,
+        exclude_mirror: bool = True,
     ) -> None:
         """
         Rewires an already present graph to include periodic boundary conditions.
@@ -90,6 +92,8 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
             )
         self.is_cartesian = is_cartesian
         self.convert_to_unit_cell = convert_to_unit_cell
+        self.is_directed = is_directed
+        self.exclude_mirror = exclude_mirror
 
     def __call__(self, data: DataDict) -> DataDict:
         """
@@ -135,6 +139,8 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                     self.cutoff_radius,
                     self.adaptive_cutoff,
                     max_neighbors=self.max_neighbors,
+                    is_directed=self.is_directed,
+                    exclude_mirror=self.exclude_mirror,
                 )
                 data.update(graph_props)
                 return data
@@ -179,11 +185,21 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                 is_cartesian=self.is_cartesian,
             )
             graph_props = calculate_periodic_shifts(
-                structure, self.cutoff_radius, self.adaptive_cutoff, self.max_neighbors
+                structure,
+                self.cutoff_radius,
+                self.adaptive_cutoff,
+                self.max_neighbors,
+                self.is_directed,
+                self.exclude_mirror,
             )
         elif self.backend == "ase":
             graph_props = calculate_ase_periodic_shifts(
-                data, self.cutoff_radius, self.adaptive_cutoff, self.max_neighbors
+                data,
+                self.cutoff_radius,
+                self.adaptive_cutoff,
+                self.max_neighbors,
+                self.is_directed,
+                self.exclude_mirror,
             )
         else:
             raise RuntimeError(f"Requested backend f{self.backend} not available.")

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -30,7 +30,6 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
         convert_to_unit_cell: bool = False,
         is_cartesian: bool | None = None,
         is_directed: bool = False,
-        exclude_mirror: bool = True,
     ) -> None:
         """
         Rewires an already present graph to include periodic boundary conditions.
@@ -93,7 +92,6 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
         self.is_cartesian = is_cartesian
         self.convert_to_unit_cell = convert_to_unit_cell
         self.is_directed = is_directed
-        self.exclude_mirror = exclude_mirror
 
     def __call__(self, data: DataDict) -> DataDict:
         """
@@ -140,7 +138,6 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                     self.adaptive_cutoff,
                     max_neighbors=self.max_neighbors,
                     is_directed=self.is_directed,
-                    exclude_mirror=self.exclude_mirror,
                 )
                 data.update(graph_props)
                 return data
@@ -190,7 +187,6 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                 self.adaptive_cutoff,
                 self.max_neighbors,
                 self.is_directed,
-                self.exclude_mirror,
             )
         elif self.backend == "ase":
             graph_props = calculate_ase_periodic_shifts(
@@ -199,7 +195,6 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                 self.adaptive_cutoff,
                 self.max_neighbors,
                 self.is_directed,
-                self.exclude_mirror,
             )
         else:
             raise RuntimeError(f"Requested backend f{self.backend} not available.")

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -29,7 +29,7 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
         allow_self_loops: bool = False,
         convert_to_unit_cell: bool = False,
         is_cartesian: bool | None = None,
-        is_directed: bool = False,
+        is_undirected: bool = False,
     ) -> None:
         """
         Rewires an already present graph to include periodic boundary conditions.
@@ -91,7 +91,7 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
             )
         self.is_cartesian = is_cartesian
         self.convert_to_unit_cell = convert_to_unit_cell
-        self.is_directed = is_directed
+        self.is_undirected = is_undirected
 
     def __call__(self, data: DataDict) -> DataDict:
         """
@@ -137,7 +137,7 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                     self.cutoff_radius,
                     self.adaptive_cutoff,
                     max_neighbors=self.max_neighbors,
-                    is_directed=self.is_directed,
+                    is_directed=self.is_undirected,
                 )
                 data.update(graph_props)
                 return data
@@ -186,7 +186,7 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                 self.cutoff_radius,
                 self.adaptive_cutoff,
                 self.max_neighbors,
-                self.is_directed,
+                self.is_undirected,
             )
         elif self.backend == "ase":
             graph_props = calculate_ase_periodic_shifts(
@@ -194,7 +194,7 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                 self.cutoff_radius,
                 self.adaptive_cutoff,
                 self.max_neighbors,
-                self.is_directed,
+                self.is_undirected,
             )
         else:
             raise RuntimeError(f"Requested backend f{self.backend} not available.")

--- a/matsciml/datasets/transforms/pbc.py
+++ b/matsciml/datasets/transforms/pbc.py
@@ -137,7 +137,7 @@ class PeriodicPropertiesTransform(AbstractDataTransform):
                     self.cutoff_radius,
                     self.adaptive_cutoff,
                     max_neighbors=self.max_neighbors,
-                    is_directed=self.is_undirected,
+                    is_undirected=self.is_undirected,
                 )
                 data.update(graph_props)
                 return data

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -661,7 +661,7 @@ class Edge:
             Returns True if either the exact, or mirror image of
             ``image_a`` is equivalent to ``image_b``.
         """
-        return np.any([np.all(image_a == image_b), np.all((-1 * image_a) == image_b)])
+        return any([np.all(image_a == image_b), np.all((-1 * image_a) == image_b)])
 
     def __eq__(self, other: Edge) -> bool:
         index_eq = self.sorted_index == other.sorted_index

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -666,11 +666,15 @@ class Edge:
         return any([np.all(image_a == image_b), np.all((-1 * image_a) == image_b)])
 
     def __eq__(self, other: Edge) -> bool:
-        index_eq = self.sorted_index == other.sorted_index
-        # for interactions with the same atom between neighboring images
-        if self.src != self.dst:
-            image_eq = True  # shortcut since this is more likely to occur
+        if self.is_directed:
+            # if we care about directionality, equality is based on exact match
+            index_eq = (self.src, self.dst) == (other.src, other.dst)
         else:
+            # otherwise, equality is based only on pair of nodes
+            index_eq = self.sorted_index == other.sorted_index
+        # for interactions with the same atom between neighboring images
+        image_eq = True
+        if self.src == self.dst and self.exclude_mirror:
             image_eq = self._compare_mirror_images(self.image, other.image)
         return all([index_eq, image_eq])
 

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -788,7 +788,6 @@ def calculate_periodic_shifts(
     adaptive_cutoff: bool = False,
     max_neighbors: int = 1000,
     is_undirected: bool = False,
-    exclude_mirror: bool = True,
 ) -> dict[str, torch.Tensor]:
     """
     Compute properties with respect to periodic boundary conditions.
@@ -915,7 +914,6 @@ def calculate_ase_periodic_shifts(
     adaptive_cutoff: bool,
     max_neighbors: int = 1000,
     is_undirected: bool = False,
-    exclude_mirror: bool = True,
 ) -> dict[str, torch.Tensor]:
     """
     Calculate edges for the system using ``ase`` routines.

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -865,7 +865,6 @@ def calculate_periodic_shifts(
                     site.index,
                     np.array(site.image),
                     is_directed,
-                    exclude_mirror,
                 )
             )
     # now only keep the edges after the first loop
@@ -969,7 +968,7 @@ def calculate_ase_periodic_shifts(
     keep = set()
     # only keeps undirected edges that are unique
     for src, dst, image in zip(all_src, all_dst, all_images):
-        keep.add(Edge(src=src, dst=dst, image=image))
+        keep.add(Edge(src=src, dst=dst, image=image, is_directed=is_directed))
     # keep.add(Edge(src, dst, image, is_directed, exclude_mirror))
 
     all_src, all_dst, all_images = [], [], []

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -634,6 +634,8 @@ class Edge:
     src: int
     dst: int
     image: np.ndarray
+    is_directed: bool
+    exclude_mirror: bool
 
     @property
     def sorted_index(self) -> tuple[int, int]:

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -787,7 +787,7 @@ def calculate_periodic_shifts(
     cutoff: float,
     adaptive_cutoff: bool = False,
     max_neighbors: int = 1000,
-    is_directed: bool = False,
+    is_undirected: bool = False,
     exclude_mirror: bool = True,
 ) -> dict[str, torch.Tensor]:
     """
@@ -864,7 +864,7 @@ def calculate_periodic_shifts(
                     src_idx,
                     site.index,
                     np.array(site.image),
-                    is_directed,
+                    is_undirected,
                 )
             )
     # now only keep the edges after the first loop
@@ -914,7 +914,7 @@ def calculate_ase_periodic_shifts(
     cutoff_radius: float,
     adaptive_cutoff: bool,
     max_neighbors: int = 1000,
-    is_directed: bool = False,
+    is_undirected: bool = False,
     exclude_mirror: bool = True,
 ) -> dict[str, torch.Tensor]:
     """
@@ -968,8 +968,7 @@ def calculate_ase_periodic_shifts(
     keep = set()
     # only keeps undirected edges that are unique
     for src, dst, image in zip(all_src, all_dst, all_images):
-        keep.add(Edge(src=src, dst=dst, image=image, is_undirected=is_directed))
-    # keep.add(Edge(src, dst, image, is_directed, exclude_mirror))
+        keep.add(Edge(src=src, dst=dst, image=image, is_undirected=is_undirected))
 
     all_src, all_dst, all_images = [], [], []
     num_atoms = len(atoms)

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -680,7 +680,7 @@ class Edge:
 
     def __str__(self) -> str:
         """Represents the edge without phase or parity information. Mainly for hashing."""
-        return f"Sorted src/dst: {self.sorted_index}, |image|: {self.unsigned_image}"
+        return f"src/dst: {self.sorted_index}, image: {self.image}"
 
     def __hash__(self) -> int:
         """
@@ -713,9 +713,11 @@ class Edge:
         else:
             idx = self.sorted_index
         if self.exclude_mirror:
-            img = (self.image, -1 * self.image)
+            img = np.vstack([self.image, -1 * self.image])
+            # this makes including the mirror image permutation invariant
+            img.sort(axis=0)
         else:
-            img = self.image.copy()
+            img = self.image
         rep = f"{idx}{img}"
 
         return hash(rep)

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -608,7 +608,7 @@ def element_types():
 
 class Edge:
     def __init__(
-        self, src: int, dst: int, image: np.ndarray, is_directed: bool = False
+        self, src: int, dst: int, image: np.ndarray, is_undirected: bool = False
     ):
         """
         Initializes the Edge object with the source, destination,
@@ -622,7 +622,7 @@ class Edge:
         image : np.ndarray
             1D vector of three elements as a ``np.ndarray``.
         """
-        if is_directed:
+        if is_undirected:
             if src > dst:
                 # Enforce directed order
                 src, dst, image = dst, src, -image
@@ -632,7 +632,7 @@ class Edge:
         self.src = src
         self.dst = dst
         self.image = image
-        self.is_directed = is_directed
+        self.is_undirected = is_undirected
 
     @staticmethod
     def _canonicalize_image(image: np.ndarray) -> np.ndarray:
@@ -686,7 +686,7 @@ class Edge:
         """
         if not isinstance(other, Edge):
             return False
-        if self.is_directed:
+        if self.is_undirected:
             node_eq = self.directed_index == other.directed_index
         else:
             node_eq = (self.src == other.src) and (self.dst == other.dst)
@@ -968,7 +968,7 @@ def calculate_ase_periodic_shifts(
     keep = set()
     # only keeps undirected edges that are unique
     for src, dst, image in zip(all_src, all_dst, all_images):
-        keep.add(Edge(src=src, dst=dst, image=image, is_directed=is_directed))
+        keep.add(Edge(src=src, dst=dst, image=image, is_undirected=is_directed))
     # keep.add(Edge(src, dst, image, is_directed, exclude_mirror))
 
     all_src, all_dst, all_images = [], [], []

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -708,8 +708,17 @@ class Edge:
         int
             Permutation invariant hash of this edge.
         """
+        if self.is_directed:
+            idx = (self.src, self.dst)
+        else:
+            idx = self.sorted_index
+        if self.exclude_mirror:
+            img = (self.image, -1 * self.image)
+        else:
+            img = self.image.copy()
+        rep = f"{idx}{img}"
 
-        return hash(str(self))
+        return hash(rep)
 
 
 def make_pymatgen_periodic_structure(


### PR DESCRIPTION
This PR modifies the `Edge` class to get exact parity in the number of edges with `ovito`, thanks to code contributed by Sajid Mannan from IIT Delhi.

We introduce an `is_undirected` flag to the `Edge` class that modifies the behavior of the `__eq__` for this class, which propagates to the behavior of how edges are treated in `set()` for determining uniqueness.

I've added a documented set of tests to explain what the expected behavior of the edge sets are.