### PR TITLE
Refactor `DataSampleSchema` to use tensors

### DIFF
--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -811,7 +811,7 @@ class DataSampleSchema(MatsciMLSchema):
             self.frac_coords = cart_frac_conversion(
                 self.cart_coords, *self.lattice_parameters, to_fractional=True
             )
-        if isinstance(self.frac_coords, NDArray):
+        if isinstance(self.frac_coords, torch.Tensor):
             if self.frac_coords.shape != self.cart_coords.shape:
                 raise ValueError(
                     "Fractional coordinate dimensions do not match cartesians."

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -740,11 +740,11 @@ class DataSampleSchema(MatsciMLSchema):
     atomic_energies: v.Float1DTensor | None = None
     atomic_labels: v.Long1DTensor | None = None
     total_energy: float | None = None
-    forces: v.CoordTensor
-    stresses: v.StressTensor
+    forces: v.CoordTensor | None = None
+    stresses: v.StressTensor | None = None
     lattice_parameters: v.LatticeParameters | None = None
-    lattice_matrix: v.LatticeTensor
-    edge_index: v.EdgeTensor
+    lattice_matrix: v.LatticeTensor | None = None
+    edge_index: v.EdgeTensor | None = None
     frac_coords: v.CoordTensor | None = None
     charge: float | None = None  # overall system charge
     multiplicity: float | None = None  # overall system multiplicity

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -32,6 +32,7 @@ from matsciml.common.types import Embeddings, ModelOutput
 from matsciml.modules.normalizer import Normalizer
 from matsciml.datasets.transforms import PeriodicPropertiesTransform
 from matsciml.datasets.utils import cart_frac_conversion
+from matsciml.datasets import validators as v
 
 """This module defines schemas pertaining to data, using ``pydantic`` models
 to help with validation and (de)serialization.
@@ -728,36 +729,30 @@ class DataSampleSchema(MatsciMLSchema):
 
     index: int
     num_atoms: int
-    cart_coords: NDArray[Shape["*, 3"], float] | Tensor
-    atomic_numbers: NDArray[Shape["*"], int] | Tensor
+    cart_coords: v.CoordTensor
+    atomic_numbers: v.Long1DTensor
     pbc: PeriodicBoundarySchema
     datatype: DataSampleEnum
-    alpha_electron_spins: NDArray[Shape["*"], float] | Tensor | None = None
-    beta_electron_spins: NDArray[Shape["*"], float] | Tensor | None = None
-    nuclear_spins: NDArray[Shape["*"], float] | Tensor | None = (
-        None  # optional nuclear spin at atom
-    )
-    isotopic_masses: NDArray[Shape["*"], float] | Tensor | None = None
-    atomic_charges: NDArray[Shape["*"], float] | Tensor | None = None
-    atomic_energies: NDArray[Shape["*"], float] | Tensor | None = None
-    atomic_labels: NDArray[Shape["*"], int] | Tensor | None = (
-        None  # allows atoms to be tagged with class labels
-    )
+    alpha_electron_spins: v.Float1DTensor | None = None
+    beta_electron_spins: v.Float1DTensor | None = None
+    nuclear_spins: v.Float1DTensor | None = None
+    isotopic_masses: v.Float1DTensor | None = None
+    atomic_charges: v.Float1DTensor | None = None
+    atomic_energies: v.Float1DTensor | None = None
+    atomic_labels: v.Long1DTensor | None = None
     total_energy: float | None = None
-    forces: NDArray[Shape["*, 3"], float] | Tensor | None = None
-    stresses: NDArray[Shape["*, 3, 3"], float] | Tensor | None = None
+    forces: v.CoordTensor
+    stresses: v.StressTensor
     lattice_parameters: NDArray[Shape["6"], float] | Tensor | None = None
-    lattice_matrix: NDArray[Shape["3, 3"], float] | Tensor | None = None
-    edge_index: NDArray[Shape["2, *"], int] | Tensor | None = (
-        None  # allows for precomputed edges
-    )
-    frac_coords: NDArray[Shape["*, 3"], float] | Tensor | None = None
+    lattice_matrix: v.LatticeTensor
+    edge_index: v.EdgeTensor
+    frac_coords: v.CoordTensor | None = None
     charge: float | None = None  # overall system charge
     multiplicity: float | None = None  # overall system multiplicity
     electronic_state_index: int = 0
-    images: NDArray[Shape["*, 3"], int] | Tensor | None = None
-    offsets: NDArray[Shape["*, 3"], float] | Tensor | None = None
-    unit_offsets: NDArray[Shape["*, 3"], float] | Tensor | None = None
+    images: v.CoordTensor | None = None
+    offsets: v.CoordTensor | None = None
+    unit_offsets: v.CoordTensor | None = None
     graph: Any = None
     extras: dict[str, Any] | None = None
     transform_store: dict[str, Any] = Field(default_factory=dict)

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -24,6 +24,7 @@ from numpydantic import NDArray, Shape
 from loguru import logger
 import numpy as np
 import torch
+from torch import Tensor
 
 from matsciml.common.packages import package_registry
 from matsciml.common.inspection import get_all_args
@@ -727,36 +728,36 @@ class DataSampleSchema(MatsciMLSchema):
 
     index: int
     num_atoms: int
-    cart_coords: NDArray[Shape["*, 3"], float]
-    atomic_numbers: NDArray[Shape["*"], int]
+    cart_coords: NDArray[Shape["*, 3"], float] | Tensor
+    atomic_numbers: NDArray[Shape["*"], int] | Tensor
     pbc: PeriodicBoundarySchema
     datatype: DataSampleEnum
-    alpha_electron_spins: NDArray[Shape["*"], float] | None = None
-    beta_electron_spins: NDArray[Shape["*"], float] | None = None
-    nuclear_spins: NDArray[Shape["*"], float] | None = (
+    alpha_electron_spins: NDArray[Shape["*"], float] | Tensor | None = None
+    beta_electron_spins: NDArray[Shape["*"], float] | Tensor | None = None
+    nuclear_spins: NDArray[Shape["*"], float] | Tensor | None = (
         None  # optional nuclear spin at atom
     )
-    isotopic_masses: NDArray[Shape["*"], float] | None = None
-    atomic_charges: NDArray[Shape["*"], float] | None = None
-    atomic_energies: NDArray[Shape["*"], float] | None = None
-    atomic_labels: NDArray[Shape["*"], int] | None = (
+    isotopic_masses: NDArray[Shape["*"], float] | Tensor | None = None
+    atomic_charges: NDArray[Shape["*"], float] | Tensor | None = None
+    atomic_energies: NDArray[Shape["*"], float] | Tensor | None = None
+    atomic_labels: NDArray[Shape["*"], int] | Tensor | None = (
         None  # allows atoms to be tagged with class labels
     )
     total_energy: float | None = None
-    forces: NDArray[Shape["*, 3"], float] | None = None
-    stresses: NDArray[Shape["*, 3, 3"], float] | None = None
-    lattice_parameters: NDArray[Shape["6"], float] | None = None
-    lattice_matrix: NDArray[Shape["3, 3"], float] | None = None
-    edge_index: NDArray[Shape["2, *"], int] | None = (
+    forces: NDArray[Shape["*, 3"], float] | Tensor | None = None
+    stresses: NDArray[Shape["*, 3, 3"], float] | Tensor | None = None
+    lattice_parameters: NDArray[Shape["6"], float] | Tensor | None = None
+    lattice_matrix: NDArray[Shape["3, 3"], float] | Tensor | None = None
+    edge_index: NDArray[Shape["2, *"], int] | Tensor | None = (
         None  # allows for precomputed edges
     )
-    frac_coords: NDArray[Shape["*, 3"], float] | None = None
+    frac_coords: NDArray[Shape["*, 3"], float] | Tensor | None = None
     charge: float | None = None  # overall system charge
     multiplicity: float | None = None  # overall system multiplicity
     electronic_state_index: int = 0
-    images: NDArray[Shape["*, 3"], int] | None = None
-    offsets: NDArray[Shape["*, 3"], float] | None = None
-    unit_offsets: NDArray[Shape["*, 3"], float] | None = None
+    images: NDArray[Shape["*, 3"], int] | Tensor | None = None
+    offsets: NDArray[Shape["*, 3"], float] | Tensor | None = None
+    unit_offsets: NDArray[Shape["*, 3"], float] | Tensor | None = None
     graph: Any = None
     extras: dict[str, Any] | None = None
     transform_store: dict[str, Any] = Field(default_factory=dict)

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -24,7 +24,6 @@ from numpydantic import NDArray, Shape
 from loguru import logger
 import numpy as np
 import torch
-from torch import Tensor
 
 from matsciml.common.packages import package_registry
 from matsciml.common.inspection import get_all_args
@@ -743,7 +742,7 @@ class DataSampleSchema(MatsciMLSchema):
     total_energy: float | None = None
     forces: v.CoordTensor
     stresses: v.StressTensor
-    lattice_parameters: NDArray[Shape["6"], float] | Tensor | None = None
+    lattice_parameters: v.LatticeParameters | None = None
     lattice_matrix: v.LatticeTensor
     edge_index: v.EdgeTensor
     frac_coords: v.CoordTensor | None = None

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import re
 
 from ase import Atoms
-from ase.geometry import cell_to_cellpar, cellpar_to_cell, complete_cell
+from ase.geometry import cell_to_cellpar, cellpar_to_cell
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -790,18 +790,6 @@ class DataSampleSchema(MatsciMLSchema):
         raise exception_cls(
             f"Data schema validation failed at sample {self.index}."
         ) from exception
-
-    @field_validator("lattice_matrix")
-    @classmethod
-    def orthogonal_lattice_matrix(cls, values: NDArray[Shape["3, 3"], float] | None):
-        """
-        Ensures that the lattice matrix comprises a complete
-        basis of orthogonal vectors.
-        """
-
-        if values is not None:
-            values = complete_cell(values)
-        return values
 
     @model_validator(mode="before")
     @classmethod

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -804,40 +804,6 @@ class DataSampleSchema(MatsciMLSchema):
             values["lattice_matrix"] = lattice_matrix
         return values
 
-    @field_validator("lattice_parameters")
-    @classmethod
-    def check_lattice_param_angles(
-        cls, values: NDArray[Shape["6"], np.floating] | None
-    ):
-        """
-        Check to make sure that if lattice parameters are set, then the
-        angles are in degrees, not radians.
-
-        The check is done by expecting a vector of six elements is passed,
-        with the latter three are the angles. We assume that angles are
-        in radians if none of the values exceed 2pi (i.e. 360 degrees).
-
-        This check is only performed if the lattice parameters are provided.
-
-        Parameters
-        ----------
-        values : NDArray[Shape['6'], float] | None
-            Vector of lattice parameters.
-
-        Raises
-        ------
-        ValueError:
-            If all lattice angles are smaller than or equal to
-            2pi, they are likely to be in radians.
-        """
-        if values is not None:
-            all_are_radians = np.all(values[3:] <= 2 * np.pi)
-            if all_are_radians:
-                raise ValueError(
-                    "Expected lattice angles to be in degrees. All input values are smaller than 2 * np.pi."
-                )
-        return values
-
     @model_validator(mode="after")
     def coordinate_consistency(self) -> Self:
         """Sets fractional coordinates if parameters are available, and checks them"""

--- a/matsciml/datasets/validators.py
+++ b/matsciml/datasets/validators.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import torch
+
+
+def array_like_serialization(data: np.ndarray | torch.Tensor) -> list:
+    """Map array-like data to list for JSON serialization"""
+    return data.tolist()
+
+
+def cast_to_torch(data: float | int | Iterable[float | int]) -> torch.Tensor:
+    """
+    Coerces data into PyTorch tensors when possible. Assumes only
+    numeric data is passed into this function (e.g. strings will fail)
+
+    Parameters
+    ----------
+    data : Any
+        Coerces iterable data into tensors. For NumPy arrays,
+        we use `torch.from_numpy`. Scalar values are also
+        packed into tensors.
+
+    Returns
+    -------
+    torch.Tensor
+        A tensor with matching data type and shape.
+    """
+    # wrap as a list to use the same pipeline
+    if isinstance(data, float | int):
+        data = [data]
+    if isinstance(data, np.ndarray):
+        return torch.from_numpy(data)
+    else:
+        return torch.tensor(data)
+
+
+def check_coord_dims(data: torch.Tensor) -> torch.Tensor:
+    """For coordinate tensors, check to make sure the last dimension is 3D"""
+    assert data.size(-1) == 3, "Last dimension of coordinate tensors should be size 3."
+    return data
+
+
+def check_lattice_matrix_like(data: torch.Tensor) -> torch.Tensor:
+    if data.ndim < 2:
+        raise ValueError("Lattice matrix should be at least 2D")
+    last_dims = data.shape[-2:]
+    if last_dims != (3, 3):
+        raise ValueError("Lattice matrix should be (3, 3) in last two dimensions.")
+    return data

--- a/matsciml/datasets/validators.py
+++ b/matsciml/datasets/validators.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Iterable
 
+from ase.geometry import complete_cell
 import numpy as np
 import torch
 
@@ -50,3 +51,9 @@ def check_lattice_matrix_like(data: torch.Tensor) -> torch.Tensor:
     if last_dims != (3, 3):
         raise ValueError("Lattice matrix should be (3, 3) in last two dimensions.")
     return data
+
+
+def check_lattice_ortho(data: torch.Tensor) -> torch.Tensor:
+    """Check if the lattice matrix comprises orthogonal basis vectors"""
+    # recasts after check
+    return torch.from_numpy(complete_cell(data))

--- a/matsciml/datasets/validators.py
+++ b/matsciml/datasets/validators.py
@@ -87,6 +87,13 @@ def check_edge_like(data: torch.Tensor) -> torch.Tensor:
     return data
 
 
+def check_lattice_param_like(data: torch.Tensor) -> torch.Tensor:
+    """Checks that the last dimension has six values"""
+    if data.size(-1) != 6:
+        raise ValueError("Expects 6 parameters for lattice parameters.")
+    return data
+
+
 # type for coordinate-like tensors
 CoordTensor = Annotated[
     torch.Tensor,
@@ -132,5 +139,13 @@ EdgeTensor = Annotated[
     BeforeValidator(cast_to_torch),
     AfterValidator(coerce_long_like),
     AfterValidator(check_edge_like),
+    PlainSerializer(array_like_serialization),
+]
+
+LatticeParameters = Annotated[
+    torch.Tensor,
+    BeforeValidator(cast_to_torch),
+    AfterValidator(check_lattice_param_like),
+    AfterValidator(coerce_float_like),
     PlainSerializer(array_like_serialization),
 ]

--- a/matsciml/datasets/validators.py
+++ b/matsciml/datasets/validators.py
@@ -7,6 +7,20 @@ import numpy as np
 import torch
 
 
+def coerce_long_like(data: torch.Tensor) -> torch.Tensor:
+    """If the input tensor is not integer type, cast to int64"""
+    if torch.is_floating_point(data):
+        return data.long()
+    return data
+
+
+def coerce_float_like(data: torch.Tensor) -> torch.Tensor:
+    """If the input tensor is not floating point, cast to fp32"""
+    if not torch.is_floating_point(data):
+        return data.float()
+    return data
+
+
 def array_like_serialization(data: np.ndarray | torch.Tensor) -> list:
     """Map array-like data to list for JSON serialization"""
     return data.tolist()

--- a/matsciml/datasets/validators.py
+++ b/matsciml/datasets/validators.py
@@ -18,10 +18,8 @@ def coerce_long_like(data: torch.Tensor) -> torch.Tensor:
 
 
 def coerce_float_like(data: torch.Tensor) -> torch.Tensor:
-    """If the input tensor is not floating point, cast to fp32"""
-    if not torch.is_floating_point(data):
-        return data.float()
-    return data
+    """Currently, force all floating point data to be FP32"""
+    return data.float()
 
 
 def array_like_serialization(data: np.ndarray | torch.Tensor) -> list:


### PR DESCRIPTION
This PR refactors the `DataSampleSchema` to use `Annotated` abstraction instead of a `field` and `model` validators, and replacing the shape checking with methods in the new `matsciml.datasets.validators` module.

The intention behind these changes are:

1. Ensure that tensors are used first and foremost, which otherwise introduces barriers to usage in the full pipeline because tensors need to be moved to devices, expected dtypes, etc.
2. The tensor annotations in the model schema are now more semantically meaningful; e.g. `CoordTensor` has more implications to it than `NDArray['*, 3']`. For the user/developer, these effectively "named" tensors in the annotations are likely better to work with.
3. Reusable validator workflows: nominally they can be used with batched data as well.