### PR TITLE
Static batch schema

### DIFF
--- a/matsciml/datasets/generic.py
+++ b/matsciml/datasets/generic.py
@@ -11,11 +11,7 @@ import h5py
 from torch.utils.data import DataLoader, Dataset
 from lightning import pytorch as pl
 
-from matsciml.datasets.schema import (
-    DatasetSchema,
-    DataSampleSchema,
-    collate_samples_into_batch_schema,
-)
+from matsciml.datasets.schema import DatasetSchema, DataSampleSchema, BatchSchema
 
 
 logger = getLogger("matsciml.datasets.MatSciMLDataset")
@@ -443,7 +439,7 @@ class MatSciMLDataModule(pl.LightningDataModule):
             self.datasets["train"],
             shuffle=True,
             **self.hparams.loader_kwargs,
-            collate_fn=collate_samples_into_batch_schema,
+            collate_fn=BatchSchema.from_data_samples,
         )
 
     def val_dataloader(self) -> DataLoader | None:
@@ -453,7 +449,7 @@ class MatSciMLDataModule(pl.LightningDataModule):
             self.datasets["validation"],
             shuffle=False,
             **self.hparams.loader_kwargs,
-            collate_fn=collate_samples_into_batch_schema,
+            collate_fn=BatchSchema.from_data_samples,
         )
 
     def test_dataloader(self) -> DataLoader | None:
@@ -463,7 +459,7 @@ class MatSciMLDataModule(pl.LightningDataModule):
             self.datasets["test"],
             shuffle=False,
             **self.hparams.loader_kwargs,
-            collate_fn=collate_samples_into_batch_schema,
+            collate_fn=BatchSchema.from_data_samples,
         )
 
     def predict_dataloader(self) -> DataLoader | None:
@@ -473,5 +469,5 @@ class MatSciMLDataModule(pl.LightningDataModule):
             self.datasets["predict"],
             shuffle=False,
             **self.hparams.loader_kwargs,
-            collate_fn=collate_samples_into_batch_schema,
+            collate_fn=BatchSchema.from_data_samples,
         )

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -28,7 +28,7 @@ from matsciml.common.inspection import get_all_args
 from matsciml.common.types import Embeddings, ModelOutput
 from matsciml.modules.normalizer import Normalizer
 from matsciml.datasets.transforms import PeriodicPropertiesTransform
-from matsciml.datasets.utils import cart_frac_conversion
+from matsciml.datasets.utils import cart_frac_conversion, _recursive_move_tensors
 from matsciml.datasets import validators as v
 
 """This module defines schemas pertaining to data, using ``pydantic`` models
@@ -941,10 +941,9 @@ class DataSampleSchema(MatsciMLSchema):
 
     def to(self, device: str | torch.device) -> None:
         """In-place transfer of tensors to a target device"""
-        for key in self.model_fields.keys():
+        for key in self.model_fields_set:
             value = getattr(self, key)
-            if isinstance(value, torch.Tensor):
-                setattr(self, key, value.to(device))
+            setattr(self, key, _recursive_move_tensors(value, device))
 
     @property
     def graph_backend(self) -> Literal["dgl", "pyg"] | None:

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -973,6 +973,7 @@ class BatchSchema(DataSampleSchema):
     charge: v.Float1DTensor | None = None
     multiplicity: v.Float1DTensor | None = None
     electronic_state_index: v.Long1DTensor | None = None
+    lattice_matrix: v.BatchedLatticeTensor | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True, use_enum_values=True)
 

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -939,6 +939,13 @@ class DataSampleSchema(MatsciMLSchema):
             pbc=pbc,
         )
 
+    def to(self, device: str | torch.device) -> None:
+        """In-place transfer of tensors to a target device"""
+        for key in self.model_fields.keys():
+            value = getattr(self, key)
+            if isinstance(value, torch.Tensor):
+                setattr(self, key, value.to(device))
+
     @property
     def graph_backend(self) -> Literal["dgl", "pyg"] | None:
         if not self.graph:

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -1090,12 +1090,13 @@ def _concatenate_data_list(all_data: list[Any]) -> list[Any] | torch.Tensor:
         Otherwise, returns the unmodified input.
     """
     sample = all_data[0]
-    if isinstance(sample, (np.ndarray, torch.Tensor)):
-        # homogenize all samples into tensors
-        all_data = [torch.Tensor(s) for s in all_data]
-        return torch.concat(all_data)
-    if isinstance(sample, (float, int)):
-        output = torch.Tensor(all_data)
+    if isinstance(sample, torch.Tensor):
+        if sample.ndim == 1:
+            return torch.concat(all_data)
+        else:
+            return torch.vstack(all_data)
+    elif isinstance(sample, (float, int)):
+        output = torch.tensor(all_data)
         if isinstance(sample, int):
             output = output.long()
         return output

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -974,6 +974,8 @@ class BatchSchema(DataSampleSchema):
     multiplicity: v.Float1DTensor | None = None
     electronic_state_index: v.Long1DTensor | None = None
     lattice_matrix: v.BatchedLatticeTensor | None = None
+    embeddings: Embeddings | None = None
+    outputs: ModelOutput | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True, use_enum_values=True)
 

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -814,12 +814,6 @@ class DataSampleSchema(MatsciMLSchema):
                 raise ValueError(
                     "Fractional coordinate dimensions do not match cartesians."
                 )
-            # round coordinate values so that -1e-6 is just zero and doesn't fail the test
-            round_coords = np.round(self.frac_coords, decimals=2)
-            if torch.any(torch.logical_or(round_coords > 1.01, round_coords < 0.0)):
-                logger.warning(
-                    f"Fractional coordinates are outside of [0, 1]: {round_coords}"
-                )
         return self
 
     @model_validator(mode="after")

--- a/matsciml/datasets/schema.py
+++ b/matsciml/datasets/schema.py
@@ -933,11 +933,12 @@ class DataSampleSchema(MatsciMLSchema):
             pbc=pbc,
         )
 
-    def to(self, device: str | torch.device) -> None:
+    def to(self, device: str | torch.device) -> Self:
         """In-place transfer of tensors to a target device"""
         for key in self.model_fields_set:
             value = getattr(self, key)
             setattr(self, key, _recursive_move_tensors(value, device))
+        return self
 
     @property
     def graph_backend(self) -> Literal["dgl", "pyg"] | None:

--- a/matsciml/datasets/tests/test_schema.py
+++ b/matsciml/datasets/tests/test_schema.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 import torch
 from ase.geometry import cell_to_cellpar
+from torch_geometric.data import Data
 
 from matsciml.datasets import schema
 from matsciml.datasets.transforms import PeriodicPropertiesTransform
@@ -244,3 +245,30 @@ def test_basic_data_batching(num_atoms, array_lib, num_samples):
         samples.append(data)
     batch = schema.BatchSchema.from_data_samples(samples)
     assert batch
+
+
+@pytest.mark.parametrize("num_atoms", [5, 12, 16])
+@pytest.mark.parametrize("num_samples", [2, 4])
+def test_batching_with_graph(num_atoms, num_samples):
+    coords = torch.rand(num_atoms, 3)
+    numbers = torch.randint(1, 100, (num_atoms,))
+    edges = torch.randint(0, num_atoms - 1, (2, 25))
+    graph = Data(coords=coords, atomic_numbers=numbers, edge_index=edges)
+    pbc = {"x": True, "y": True, "z": True}
+    lattice = torch.rand(3, 3)
+    samples = []
+    for _ in range(num_samples):
+        data = schema.DataSampleSchema(
+            index=0,
+            num_atoms=num_atoms,
+            cart_coords=coords,
+            atomic_numbers=numbers,
+            pbc=pbc,
+            datatype="SCFCycle",
+            graph=graph,
+            lattice_matrix=lattice,
+        )
+        samples.append(data)
+    batch = schema.BatchSchema.from_data_samples(samples)
+    assert batch
+    assert batch.batch_size == num_samples

--- a/matsciml/datasets/tests/test_schema.py
+++ b/matsciml/datasets/tests/test_schema.py
@@ -218,3 +218,29 @@ def test_lattice_matrix_to_param_consistency():
     assert np.allclose(converted, data.lattice_parameters)
     exact = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     assert np.allclose(exact, data.lattice_matrix)
+
+
+@pytest.mark.parametrize("num_atoms", [5, 12, 16])
+@pytest.mark.parametrize("array_lib", ["numpy", "torch"])
+@pytest.mark.parametrize("num_samples", [2, 4])
+def test_basic_data_batching(num_atoms, array_lib, num_samples):
+    if array_lib == "numpy":
+        coords = np.random.rand(num_atoms, 3)
+        numbers = np.random.randint(1, 100, (num_atoms))
+    else:
+        coords = torch.rand(num_atoms, 3)
+        numbers = torch.randint(1, 100, (num_atoms,))
+    pbc = {"x": True, "y": True, "z": True}
+    samples = []
+    for _ in range(num_samples):
+        data = schema.DataSampleSchema(
+            index=0,
+            num_atoms=num_atoms,
+            cart_coords=coords,
+            atomic_numbers=numbers,
+            pbc=pbc,
+            datatype="SCFCycle",
+        )
+        samples.append(data)
+    batch = schema.BatchSchema.from_data_samples(samples)
+    assert batch

--- a/matsciml/datasets/tests/test_schema.py
+++ b/matsciml/datasets/tests/test_schema.py
@@ -272,3 +272,6 @@ def test_batching_with_graph(num_atoms, num_samples):
     batch = schema.BatchSchema.from_data_samples(samples)
     assert batch
     assert batch.batch_size == num_samples
+    # test to see if transfer method works
+    batch.to("cpu")
+    assert batch

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -1016,7 +1016,7 @@ def calculate_ase_periodic_shifts(
 
 
 def cart_frac_conversion(
-    coords: torch.Tensor,
+    coords: torch.Tensor | np.ndarray,
     a: float,
     b: float,
     c: float,
@@ -1071,10 +1071,13 @@ def cart_frac_conversion(
 
     lattice_matrix = complete_cell(cellpar_to_cell([a, b, c, alpha, beta, gamma]))
     cell = Cell(lattice_matrix)
+    if isinstance(coords, torch.Tensor):
+        coords = coords.numpy()
     if to_fractional:
-        return cell.scaled_positions(coords)
+        coords = cell.scaled_positions(coords)
     else:
-        return cell.cartesian_positions(coords)
+        coords = cell.cartesian_positions(coords)
+    return torch.from_numpy(coords)
 
 
 def build_nearest_images(max_image_number: int) -> torch.Tensor:

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -1133,7 +1133,11 @@ def _recursive_move_tensors(obj: Any, device: str | torch.device) -> Any:
     if isinstance(obj, dict):
         for key, value in obj.items():
             obj[key] = _recursive_move_tensors(value, device)
+    # TODO: movement will break references between graph and schema
+    # fields, causing redundancy
     if isinstance(obj, torch.Tensor):
+        return obj.to(device)
+    if "pyg" in package_registry and isinstance(obj, PyGGraph):
         return obj.to(device)
     # in the final case, return object without modification
     return obj

--- a/matsciml/datasets/utils.py
+++ b/matsciml/datasets/utils.py
@@ -1103,3 +1103,34 @@ def build_nearest_images(max_image_number: int) -> torch.Tensor:
     )
     images = torch.FloatTensor(list(indices))
     return images
+
+
+def _recursive_move_tensors(obj: Any, device: str | torch.device) -> Any:
+    """
+    Moves all tensors within a nested data structure to the specified device.
+
+    This function recursively traverses the input object, which can be a dictionary
+    or list containing tensors, and moves each tensor to the specified device. If
+    the object is not a tensor, it is returned unchanged.
+
+    Parameters
+    ----------
+    obj : Any
+        The input data structure (e.g., dictionary, list)
+        containing tensors.
+    device : str | torch.device
+        The device to which the tensors should be moved. Can be a
+        string ('cpu', 'cuda') or a torch.device object.
+
+    Returns
+    -------
+    Any
+        The modified data structure with tensors moved to the specified device.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            obj[key] = _recursive_move_tensors(value, device)
+    if isinstance(obj, torch.Tensor):
+        return obj.to(device)
+    # in the final case, return object without modification
+    return obj

--- a/matsciml/datasets/validators.py
+++ b/matsciml/datasets/validators.py
@@ -49,8 +49,11 @@ def cast_to_torch(data: float | int | Iterable[float | int]) -> torch.Tensor:
         data = [data]
     if isinstance(data, np.ndarray):
         return torch.from_numpy(data)
-    else:
+    if not isinstance(data, torch.Tensor):
         return torch.tensor(data)
+    # assume that the construct is already a torch tensor,
+    # or we wouldn't be able to convert it anyway
+    return data
 
 
 def check_coord_dims(data: torch.Tensor) -> torch.Tensor:

--- a/matsciml/datasets/validators.py
+++ b/matsciml/datasets/validators.py
@@ -127,6 +127,7 @@ StressTensor = Annotated[
 LatticeTensor = Annotated[
     torch.Tensor,
     BeforeValidator(cast_to_torch),
+    BeforeValidator(check_lattice_ortho),
     AfterValidator(check_lattice_matrix_like),
     AfterValidator(coerce_float_like),
     PlainSerializer(array_like_serialization),
@@ -145,5 +146,10 @@ LatticeParameters = Annotated[
     BeforeValidator(cast_to_torch),
     AfterValidator(check_lattice_param_like),
     AfterValidator(coerce_float_like),
+    PlainSerializer(array_like_serialization),
+]
+
+BatchedLatticeTensor = Annotated[
+    torch.Tensor,
     PlainSerializer(array_like_serialization),
 ]


### PR DESCRIPTION
This PR addresses an issue with the existing `BatchSchema` definition, which is done on-the-fly based on what information was actually packed into the individual data samples. The issue with this is that serialization is not possible, which prevents multiple data loader workers being used, which hinders training.

This is solved by creating a static definition of a `BatchSchema` that subclasses `DataSampleSchema`. The scope of testing is on a new HDF5 dataset with PyG graphs, and is functional for multi-GPU training.

Summary of changes:
- Defined `BatchSchema`, subclassing `DataSampleSchema`
- Added a `to` method for `DataSampleSchema` (which is inherited by `BatchSchema`) for data transfers to accelerators
- Added `transfer_batch_to_device` methods to `LightningModule` definitions, which facilitates the data transfer before model calls
- Unit tests for batching with the new `BatchSchema`